### PR TITLE
ntfsprogs-plus: v0.9.6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@
 
 # Autoconf
 AC_PREREQ(2.59)
-AC_INIT([ntfsprogs],[0.9.5],[ntfsprogs-devel@lists.sf.net])
+AC_INIT([ntfsprogs],[0.9.6],[ntfsprogs-devel@lists.sf.net])
 LIBNTFS_3G_VERSION="89"
 AC_CONFIG_SRCDIR([src/ntfsck.c])
 


### PR DESCRIPTION
CHANGE NOTE

Change $MFT/$MFTMirror check logic. If $MFT is normal, then use it. And if $MFT is corrupted and $MFTMirr is normal, then use $MFTMirr.