### PR TITLE
ntfsck: call ntfs_inode_mark_dirty() only when ntfs_index_rm() success

### DIFF
--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -2890,8 +2890,9 @@ remove_index:
 						MREF(mref), filename);
 				ret = STATUS_FIXED;
 				fsck_err_fixed();
+				if (ictx->actx)
+					ntfs_inode_mark_dirty(ictx->actx->ntfs_ino);
 			}
-			ntfs_inode_mark_dirty(ictx->actx->ntfs_ino);
 		}
 	}
 


### PR DESCRIPTION
ntfs_index_rm() can free resource of ictx->actx, when ntfs_index_rm() failure.
So. ntfs_inode_mark_dirty() call only whn ntfs_index_rm() return success.