### PR TITLE
ntfsck: fix segfault, check ictx->actx is null or not

### DIFF
--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -2890,8 +2890,9 @@ remove_index:
 						MREF(mref), filename);
 				ret = STATUS_FIXED;
 				fsck_err_fixed();
+				if (ictx->actx)
+					ntfs_inode_mark_dirty(ictx->actx->ntfs_ino);
 			}
-			ntfs_inode_mark_dirty(ictx->actx->ntfs_ino);
 		}
 	}
 


### PR DESCRIPTION
ntfs_ih_takeout() does not check ntfs_index_lookup() return value. so function who calling ntfs_ih_takeout() can have null pointer of ictx->actx.