### PR TITLE
ntfsck: fix some ntfsck crashes

### DIFF
--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -1893,7 +1893,6 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 		goto out;
 	}
 
-	ntfs_index_ctx_reinit(icx);
 	icx_add_ie = ntfs_index_ctx_get(icx->ni, NTFS_INDEX_I30, 4);
 	if (!icx_add_ie)
 		goto out;
@@ -1903,7 +1902,10 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 	if (ret)
 		goto out;
 
-	ntfs_index_lookup(&ie_dup->key, le16_to_cpu(ie_dup->key_length), icx);
+	if (le16_to_cpu(ie_dup->key_length) > 0) {
+		ntfs_index_ctx_reinit(icx);
+		ntfs_index_lookup(&ie_dup->key, le16_to_cpu(ie_dup->key_length), icx);
+	}
 out:
 	free(ie_roam);
 	if (ie_dup)

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -934,6 +934,7 @@ static void ntfsck_delete_orphaned_inode(ntfs_inode **ni)
 	/* Do not delete system file */
 	if (utils_is_metadata(*ni) == 1) {
 		ntfs_inode_close(*ni);
+		*ni = NULL;
 		return;
 	}
 


### PR DESCRIPTION
Do not reinit 'icx' if entry key_length is zero in ntfs_index_rm() Fix use-after-free error