### PR TITLE
index header length check / index entry length check and repair

### DIFF
--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -3018,20 +3018,16 @@ static int ntfsck_check_index_bitmap(ntfs_inode *ni, ntfs_attr *bm_na)
 static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 					 ntfs_index_context *ictx)
 {
-	ntfs_attr *bmp_na;
+	ntfs_attr *bmp_na = NULL;
 	INDEX_ALLOCATION *ia;
-	FILE_NAME_ATTR *ie_fn;
 	INDEX_ENTRY *ie;
 	INDEX_ROOT *ir = ictx->ir;
-	ntfs_inode *ni = ictx->ni, *cni;
-	MFT_REF mref;
+	ntfs_inode *ni = ictx->ni;
 	VCN vcn;
 	u32 ir_size = le32_to_cpu(ir->index.index_length);
-	u32 ib_cnt = 0, i;
-	BOOL ib_corrupted = FALSE;
-	u8 *ir_buf, *ia_buf = NULL, *bmp_buf = NULL, *ibs, *index_end;
-	char *filename;
+	u8 *ir_buf = NULL, *ia_buf = NULL, *bmp_buf = NULL, *index_end;
 	u64 max_vcn_bits;
+	VCN max_vcn;
 
 	ictx->ia_na = ntfs_attr_open(ni, AT_INDEX_ALLOCATION,
 			ictx->name, ictx->name_len);
@@ -3041,36 +3037,12 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 	bmp_na = ntfs_attr_open(ictx->ni, AT_BITMAP, ictx->name, ictx->name_len);
 	if (!bmp_na) {
 		ntfs_log_error("Failed to open bitmap\n");
-		ntfs_attr_close(ictx->ia_na);
-		ictx->ia_na = NULL;
-		return;
+		goto out;
 	}
 
 	bmp_buf = malloc(bmp_na->data_size);
 	if (!bmp_buf) {
 		ntfs_log_error("Failed to allocate bitmap buffer\n");
-		ntfs_attr_close(ictx->ia_na);
-		ntfs_attr_close(bmp_na);
-		ictx->ia_na = NULL;
-		return;
-	}
-
-	ir_buf = malloc(le32_to_cpu(ir->index.index_length));
-	if (!ir_buf) {
-		ntfs_log_error("Failed to allocate ir buffer\n");
-		ntfs_free(bmp_buf);
-		ntfs_attr_close(ictx->ia_na);
-		ntfs_attr_close(bmp_na);
-		ictx->ia_na = NULL;
-		return;
-	}
-
-	memcpy(ir_buf, (u8 *)&ir->index + le32_to_cpu(ir->index.entries_offset),
-		       ir_size);
-
-	ia_buf = ntfs_malloc(ictx->ia_na->data_size);
-	if (!ia_buf) {
-		ntfs_log_error("Failed to allocate ia buffer\n");
 		goto out;
 	}
 
@@ -3079,52 +3051,26 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 		goto out;
 	}
 
-	max_vcn_bits = bmp_na->data_size * 8;
-
-	ibs = ia_buf;
-	for (i = ictx->ia_na->data_size, vcn = 0; i > 0; i -= ictx->block_size, vcn++) {
-		if (max_vcn_bits <= vcn)
-			break;
-
-		if (!ntfs_bit_get(bmp_buf, vcn))
-			continue;
-
-		if (ntfs_attr_mst_pread(ictx->ia_na,
-					ntfs_ib_vcn_to_pos(ictx, vcn), 1,
-					ictx->block_size, ibs) != 1) {
-			ntfs_log_perror("Failed to read index blocks of inode(%"PRIu64"), %d",
-					ictx->ni->mft_no, errno);
-			ib_corrupted = TRUE;
-			goto out;
-		}
-
-		if (ntfs_index_block_inconsistent(vol, ictx->ia_na, (INDEX_ALLOCATION *)ibs,
-					ictx->block_size, ni->mft_no,
-					vcn))
-			ib_corrupted = TRUE;
-		ibs += ictx->block_size;
-		ib_cnt++;
-	}
-
-	if (ib_corrupted == FALSE)
-		goto out;
-
-	if (ntfsck_initialize_index_attr(ni)) {
-		ntfs_log_perror("Failed to initialize index attributes of inode(%"PRIu64")\n",
-				ni->mft_no);
+	ir_buf = malloc(le32_to_cpu(ir->index.index_length));
+	if (!ir_buf) {
+		ntfs_log_error("Failed to allocate ir buffer\n");
 		goto out;
 	}
 
+	memcpy(ir_buf, (u8 *)&ir->index + le32_to_cpu(ir->index.entries_offset),
+		       ir_size);
+
+	/* check entries in INDEX_ROOT */
 	index_end = ir_buf + ir_size;
 	ie = (INDEX_ENTRY *)ir_buf;
-
-	for (;; ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
+	for (; (u8 *)ie < index_end;
+			ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
 		if ((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end ||
 		    (u8 *)ie + le16_to_cpu(ie->length) > index_end) {
 
 			ntfs_log_verbose("Index root entry out of bounds in"
 					" inode %"PRId64"\n", ni->mft_no);
-			break;
+			goto initialize_index;
 		}
 
 		/* The last entry cannot contain a name. */
@@ -3137,43 +3083,55 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 		/* The file name must not overflow from the entry */
 		if (ntfs_index_entry_inconsistent(vol, ie, COLLATION_FILE_NAME,
 				ni->mft_no, NULL) < 0)
-			continue;
-
-		ie_fn = &ie->key.file_name;
-		mref = le64_to_cpu(ie->indexed_file);
-		filename = ntfs_attr_name_get(ie_fn->file_name, ie_fn->file_name_length);
-		ntfs_log_info("Inserting entry to index root, mref : %"PRIu64", %s\n",
-			      MREF(le64_to_cpu(ie->indexed_file)), filename);
-		free(filename);
-
-		cni = ntfs_inode_open(vol, MREF(mref));
-		if (!cni)
-			continue;
-
-		if (ntfs_index_add_filename(ni, ie_fn,
-					    MK_MREF(cni->mft_no,
-					    le16_to_cpu(cni->mrec->sequence_number))))
-			ntfs_log_error("Failed to add index entry, errno : %d\n",
-					errno);
-		ntfs_inode_close(cni);
+			goto initialize_index;
 	}
 
-	ia = (INDEX_ALLOCATION *)ia_buf;
-	for (i = 0; i < ib_cnt; i++) {
+	ia_buf = ntfs_malloc(vol->cluster_size);
+	if (!ia_buf) {
+		ntfs_log_error("Failed to allocate ia buffer\n");
+		goto out;
+	}
+
+	max_vcn_bits = bmp_na->data_size * 8;
+	max_vcn = ictx->ia_na->data_size >> vol->cluster_size_bits;
+
+	/* check index block and entries in INDEX_ALLOCATION */
+	for (vcn = 0; vcn < max_vcn; vcn++) {
+		if (max_vcn_bits <= vcn)
+			break;
+
+		if (!ntfs_bit_get(bmp_buf, vcn))
+			continue;
+
+		if (ntfs_attr_mst_pread(ictx->ia_na,
+					ntfs_ib_vcn_to_pos(ictx, vcn), 1,
+					ictx->block_size, ia_buf) != 1) {
+			ntfs_log_perror("Failed to read index blocks of inode(%"PRIu64"), %d",
+					ictx->ni->mft_no, errno);
+			goto initialize_index;
+		}
+
+		if (ntfs_index_block_inconsistent(vol, ictx->ia_na,
+					(INDEX_ALLOCATION *)ia_buf,
+					ictx->block_size, ni->mft_no, vcn)) {
+			goto initialize_index;
+		}
+
+		/* check index entries in a INDEX_ALLOCATION block */
+		ia = (INDEX_ALLOCATION *)ia_buf;
 		index_end = (u8 *)ia + ictx->block_size;
 		ie = (INDEX_ENTRY *)((u8 *)&ia->index +
 				le32_to_cpu(ia->index.entries_offset));
 
 		for (;; ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
 			/* Bounds checks. */
-			if ((u8 *)ie < (u8 *)ia || (u8 *)ie +
-				sizeof(INDEX_ENTRY_HEADER) > index_end ||
-				(u8 *)ie + le16_to_cpu(ie->length) >
-				index_end) {
+			if (((u8 *)ie < (u8 *)ia) ||
+					((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end) ||
+					((u8 *)ie + le16_to_cpu(ie->length) > index_end)) {
 
 				ntfs_log_verbose("Index entry out of bounds in directory inode "
-						 "%"PRId64".\n", ni->mft_no);
-				break;
+						"%"PRId64".\n", ni->mft_no);
+				goto initialize_index;
 			}
 
 			/* The last entry cannot contain a name. */
@@ -3185,42 +3143,36 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 
 			/* The file name must not overflow from the entry */
 			if (ntfs_index_entry_inconsistent(vol, ie,
-							  COLLATION_FILE_NAME,
-							  ni->mft_no,
-							  NULL))
-				continue;
-
-			ie_fn = &ie->key.file_name;
-			mref = le64_to_cpu(ie->indexed_file);
-			filename = ntfs_attr_name_get(ie_fn->file_name,
-					ie_fn->file_name_length);
-			ntfs_log_info("Inserting entry to $IA, mref : %"PRIu64", %s\n",
-				      MREF(le64_to_cpu(ie->indexed_file)), filename);
-			free(filename);
-
-			cni = ntfs_inode_open(vol, MREF(mref));
-			if (!cni)
-				continue;
-
-			if (ntfs_index_add_filename(ni, ie_fn,
-					MK_MREF(cni->mft_no,
-						le16_to_cpu(cni->mrec->sequence_number))))
-				ntfs_log_error("Failed to add index entry, errno : %d\n",
-						errno);
-			ntfs_inode_close(cni);
+						COLLATION_FILE_NAME, ni->mft_no, NULL))
+				goto initialize_index;
 		}
-		ia = (INDEX_ALLOCATION *)((u8 *)ia + ictx->block_size);
 	}
 
 out:
-	ntfs_free(ir_buf);
+	if (ir_buf)
+		ntfs_free(ir_buf);
+
 	if (bmp_buf)
 		ntfs_free(bmp_buf);
+
 	if (ia_buf)
 		ntfs_free(ia_buf);
-	ntfs_attr_close(ictx->ia_na);
-	ntfs_attr_close(bmp_na);
-	ictx->ia_na = NULL;
+
+	if (bmp_na)
+		ntfs_attr_close(bmp_na);
+
+	if (ictx->ia_na) {
+		ntfs_attr_close(ictx->ia_na);
+		ictx->ia_na = NULL;
+	}
+
+	return;
+
+initialize_index:
+	if (ntfsck_initialize_index_attr(ni))
+		ntfs_log_perror("Failed to initialize index attributes of inode(%"PRIu64")\n",
+				ni->mft_no);
+	goto out;
 }
 
 static int _ntfsck_remove_index(ntfs_inode *parent_ni, ntfs_inode *ni)


### PR DESCRIPTION
adding index header / index entry length check
if error return checking routine, fsck initialize index of directory to fix it, and not checked index entries repaired within orphaned inode handling routine.