### PR TITLE
For finding cluster dup

### DIFF
--- a/include/ntfs-3g/bitmap.h
+++ b/include/ntfs-3g/bitmap.h
@@ -42,6 +42,9 @@ extern char ntfs_bit_get_and_set(u8 *bitmap, const u64 bit, const u8 new_value);
 extern int  ntfs_bitmap_set_run(ntfs_attr *na, s64 start_bit, s64 count);
 extern int  ntfs_bitmap_clear_run(ntfs_attr *na, s64 start_bit, s64 count);
 
+#define BITS_PER_BYTE	8
+#define BITS_PER_LONG	(sizeof(unsigned long) * BITS_PER_BYTE)
+
 /**
  * ntfs_bitmap_set_bit - set a bit in a bitmap
  * @na:		attribute containing the bitmap

--- a/include/ntfs-3g/fsck.h
+++ b/include/ntfs-3g/fsck.h
@@ -29,8 +29,8 @@ char ntfs_fsck_mftbmp_get(ntfs_volume *vol, const u64 bit);
 int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no);
 int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no);
 void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit);
-u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos);
-int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit);
+u8 *ntfs_fsck_find_lcnbmp_block(ntfs_volume *vol, s64 pos);
+int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit, BOOL check);
 
 ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
 		ntfs_mount_flags flags __attribute__((unused)));

--- a/include/ntfs-3g/fsck.h
+++ b/include/ntfs-3g/fsck.h
@@ -30,7 +30,7 @@ int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no);
 int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no);
 void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit);
 u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos);
-int ntfsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit);
+int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit);
 
 ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
 		ntfs_mount_flags flags __attribute__((unused)));

--- a/include/ntfs-3g/fsck.h
+++ b/include/ntfs-3g/fsck.h
@@ -30,6 +30,7 @@ int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no);
 int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no);
 void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit);
 u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos);
+int ntfsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit);
 
 ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
 		ntfs_mount_flags flags __attribute__((unused)));

--- a/include/ntfs-3g/fsck.h
+++ b/include/ntfs-3g/fsck.h
@@ -30,6 +30,7 @@ int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no);
 int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no);
 void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit);
 u8 *ntfs_fsck_find_lcnbmp_block(ntfs_volume *vol, s64 pos);
+u8 *ntfs_fsck_find_mftbmp_block(ntfs_volume *vol, s64 pos);
 int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit, BOOL check);
 
 ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),

--- a/include/ntfs-3g/fsck.h
+++ b/include/ntfs-3g/fsck.h
@@ -1,0 +1,37 @@
+#ifndef _NTFS_FSCK_H
+#define _NTFS_FSCK_H
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#endif
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+	/* Do not #include <sys/mount.h> here : conflicts with <linux/fs.h> */
+#ifdef HAVE_MNTENT_H
+#include <mntent.h>
+#endif
+
+#include "volume.h"
+
+#define NTFS_BUF_SIZE_BITS		(13)
+#define NTFSCK_BYTE_TO_BITS		(3)
+#define NTFSCK_BM_BITS_SIZE	(NTFS_BUF_SIZE << 3)
+#define FB_ROUND_UP(x)		(((x) + ((NTFS_BUF_SIZE << 3) - 1)) & ~((NTFS_BUF_SIZE << 3) - 1))
+#define FB_ROUND_DOWN(x)	(((x) & ~(NTFS_BUF_SIZE - 1)) >> NTFS_BUF_SIZE_BITS)
+
+int ntfs_fsck_set_mftbmp_value(ntfs_volume *vol, u64 mft_no, int value);
+char ntfs_fsck_mftbmp_get(ntfs_volume *vol, const u64 bit);
+int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no);
+int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no);
+void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit);
+u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos);
+
+ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
+		ntfs_mount_flags flags __attribute__((unused)));
+void ntfs_fsck_umount(ntfs_volume *vol);
+#endif /* _NTFS_FSCK_H */

--- a/include/ntfs-3g/inode.h
+++ b/include/ntfs-3g/inode.h
@@ -165,6 +165,7 @@ struct _ntfs_inode {
 	le64 quota_charged;
 	le64 usn;
 	void *fsck_ibm;		/* for bitmap tracking in fsck */
+	u32 fsck_ibm_size;	/* fsck bitmap size */
 };
 
 typedef enum {

--- a/include/ntfs-3g/lcnalloc.h
+++ b/include/ntfs-3g/lcnalloc.h
@@ -28,6 +28,9 @@
 #include "runlist.h"
 #include "volume.h"
 
+#define LCNBMP_ALLOC_SIZE      4096
+#define MFTBMP_ALLOC_SIZE      4096
+
 /**
  * enum NTFS_CLUSTER_ALLOCATION_ZONES -
  */

--- a/include/ntfs-3g/support.h
+++ b/include/ntfs-3g/support.h
@@ -81,5 +81,25 @@
 	old_state;					\
 })
 
+/**
+ * round_up - round up to next specified power of 2
+ * @x: the value to round
+ * @y: multiple to round up to (must be a power of 2)
+ *
+ * Rounds @x up to next multiple of @y (which must be a power of 2).
+ * To perform arbitrary rounding up, use roundup() below.
+ */
+#define round_up(x, y) ((((x) - 1) | ((y) - 1)) + 1)
+
+/**
+ * round_down - round down to next specified power of 2
+ * @x: the value to round
+ * @y: multiple to round down to (must be a power of 2)
+ *
+ * Rounds @x down to next multiple of @y (which must be a power of 2).
+ * To perform arbitrary rounding down, use rounddown() below.
+ */
+#define round_down(x, y) ((x) & ~((y) - 1))
+
 #endif /* defined _NTFS_SUPPORT_H */
 

--- a/include/ntfs-3g/volume.h
+++ b/include/ntfs-3g/volume.h
@@ -295,6 +295,7 @@ struct _ntfs_volume {
 
 	s64 nr_clusters;	/* Volume size in clusters, hence also the
 				   number of bits in lcn_bitmap. */
+	s64 nr_sectors;		/* total number of sectors */
 	ntfs_inode *lcnbmp_ni;	/* ntfs_inode structure for FILE_Bitmap. */
 	ntfs_attr *lcnbmp_na;	/* ntfs_attr structure for the data attribute
 				   of FILE_Bitmap. Each bit represents a

--- a/include/ntfs-3g/volume.h
+++ b/include/ntfs-3g/volume.h
@@ -252,7 +252,8 @@ typedef enum {
 #define NTFS_V3_0(major, minor) ((major) == 3 && (minor) == 0)
 #define NTFS_V3_1(major, minor) ((major) == 3 && (minor) == 1)
 
-#define NTFS_BUF_SIZE 8192
+#define NTFS_BUF_SIZE			(8192)
+#define MFTBMP_CACHE_SIZE		(NTFS_BUF_SIZE)
 
 /**
  * struct _ntfs_volume - structure describing an open volume in memory.
@@ -351,9 +352,9 @@ struct _ntfs_volume {
 // #ifdef NTFSCK
 #if 1
 	u64 lost_found;		/* mft record number for lost_found directory */
-	u8 **fsck_lcn_bitmap;
+	u8 **fsck_lcn_bitmap;	/* lcn bitmap of fsck */
 	u64 max_flb_cnt;
-	u8 **fsck_mft_bitmap;
+	u8 **fsck_mft_bitmap;	/* mft bitmap of fsck */
 	u64 max_fmb_cnt;
 #endif
 

--- a/include/ntfs-3g/volume.h
+++ b/include/ntfs-3g/volume.h
@@ -347,7 +347,16 @@ struct _ntfs_volume {
 				   efs-encrypted files */
 	ntfs_volume_special_files special_files; /* Implementation of special files */
 	const char *abs_mnt_point; /* Mount point */
+
+// #ifdef NTFSCK
+#if 1
 	u64 lost_found;		/* mft record number for lost_found directory */
+	u8 **fsck_lcn_bitmap;
+	u64 max_flb_cnt;
+	u8 **fsck_mft_bitmap;
+	u64 max_fmb_cnt;
+#endif
+
 #ifdef XATTR_MAPPINGS
 	struct XATTRMAPPING *xattr_mapping;
 #endif /* XATTR_MAPPINGS */

--- a/libntfs-3g/Makefile.am
+++ b/libntfs-3g/Makefile.am
@@ -46,6 +46,7 @@ libntfs_3g_la_SOURCES =	\
 	unistr.c 	\
 	volume.c 	\
 	xattrs.c	\
+	fsck.c		\
 	lib_utils.c
 
 if NTFS_DEVICE_DEFAULT_IO_OPS

--- a/libntfs-3g/attrib.c
+++ b/libntfs-3g/attrib.c
@@ -2272,6 +2272,7 @@ retry:
 		ntfs_log_trace("Writing %lld bytes to vcn %lld, lcn %lld, ofs "
 			       "%lld.\n", (long long)to_write, (long long)rl->vcn,
 			       (long long)rl->lcn, (long long)ofs);
+
 		if (!NVolReadOnly(vol)) {
 
 			s64 wpos = (rl->lcn << vol->cluster_size_bits) + ofs;

--- a/libntfs-3g/bitmap.c
+++ b/libntfs-3g/bitmap.c
@@ -115,9 +115,9 @@ char ntfs_bit_get_and_set(u8 *bitmap, const u64 bit, const u8 new_value)
 static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
 				       s64 count, int value)
 {
-	s64 bufsize, br;
+	s64 bufsize, br, tmp;
 	u8 *buf, *lastbyte_buf;
-	int bit, firstbyte, lastbyte, lastbyte_pos, tmp, ret = -1;
+	int bit, firstbyte, lastbyte, lastbyte_pos, ret = -1;
 
 	if (!na || start_bit < 0 || count < 0) {
 		errno = EINVAL;
@@ -153,6 +153,7 @@ static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
 				errno = EIO;
 			goto free_err_out;
 		}
+
 		/* and set or clear the appropriate bits in it. */
 		while ((bit & 7) && count--) {
 			if (value)

--- a/libntfs-3g/bootsect.c
+++ b/libntfs-3g/bootsect.c
@@ -235,6 +235,7 @@ int ntfs_boot_sector_parse(ntfs_volume *vol, const NTFS_BOOT_SECTOR *bs)
 	}
 
 	vol->nr_clusters =  sectors >> (ffs(sectors_per_cluster) - 1);
+	vol->nr_sectors = sectors;
 
 	vol->mft_lcn = sle64_to_cpu(bs->mft_lcn);
 	vol->mftmirr_lcn = sle64_to_cpu(bs->mftmirr_lcn);

--- a/libntfs-3g/fsck.c
+++ b/libntfs-3g/fsck.c
@@ -1,0 +1,155 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifdef HAVE_STDLIB_H
+#include <stdlib.h>
+#endif
+#ifdef HAVE_STDIO_H
+#include <stdio.h>
+#endif
+#ifdef HAVE_STRING_H
+#include <string.h>
+#endif
+#ifdef HAVE_FCNTL_H
+#include <fcntl.h>
+#endif
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+#ifdef HAVE_ERRNO_H
+#include <errno.h>
+#endif
+#ifdef HAVE_SYS_STAT_H
+#include <sys/stat.h>
+#endif
+#ifdef HAVE_LIMITS_H
+#include <limits.h>
+#endif
+#ifdef HAVE_LOCALE_H
+#include <locale.h>
+#endif
+
+#if defined(__sun) && defined (__SVR4)
+#include <sys/mnttab.h>
+#endif
+
+#include "fsck.h"
+#include "debug.h"
+#include "logging.h"
+#include "misc.h"
+#include "bitmap.h"
+
+u8 zero_bm[NTFS_BUF_SIZE];
+
+/*
+ * function to set fsck mft bitmap value
+ */
+int ntfs_fsck_set_mftbmp_value(ntfs_volume *vol, u64 mft_no, int value)
+{
+	u32 bm_i = FB_ROUND_DOWN(mft_no >> NTFSCK_BYTE_TO_BITS);
+	s64 bm_pos = (s64)bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS);
+	s64 mft_diff = mft_no - bm_pos;
+
+	if (bm_i >= vol->max_fmb_cnt) {
+		ntfs_log_error("bm_i(%u) exceeded max_fmb_cnt(%"PRIu64")\n",
+				bm_i, vol->max_fmb_cnt);
+		return -EINVAL;
+	}
+
+	if (!vol->fsck_mft_bitmap[bm_i]) {
+		vol->fsck_mft_bitmap[bm_i] = (u8 *)ntfs_calloc(NTFS_BUF_SIZE);
+		if (!vol->fsck_mft_bitmap[bm_i])
+			return -ENOMEM;
+	}
+
+	ntfs_bit_set(vol->fsck_mft_bitmap[bm_i], mft_diff, value);
+	return 0;
+}
+
+/* fsck mft bitmap get */
+char ntfs_fsck_mftbmp_get(ntfs_volume *vol, const u64 bit)
+{
+	u32 bm_i = FB_ROUND_DOWN(bit >> NTFSCK_BYTE_TO_BITS);
+	s64 bm_pos = (s64)bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS);
+
+	if (bm_i >= vol->max_fmb_cnt || !vol->fsck_mft_bitmap[bm_i])
+		return 0;
+
+	return ntfs_bit_get(vol->fsck_mft_bitmap[bm_i], bit - bm_pos);
+}
+
+/* fsck mft bitmap clear */
+int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no)
+{
+	return ntfs_fsck_set_mftbmp_value(vol, mft_no, 0);
+}
+
+/* fsck mft bitmap set */
+int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no)
+{
+	return ntfs_fsck_set_mftbmp_value(vol, mft_no, 1);
+}
+
+void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit)
+{
+	while (length--)
+		ntfs_bit_set(bm, pos++, bit);
+}
+
+u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos)
+{
+	u32 bm_i = FB_ROUND_DOWN(pos);
+
+	if (bm_i >= vol->max_flb_cnt || !vol->fsck_lcn_bitmap[bm_i])
+		return zero_bm;
+
+	return vol->fsck_lcn_bitmap[bm_i];
+}
+
+ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
+		ntfs_mount_flags flags __attribute__((unused)))
+{
+	ntfs_volume *vol;
+
+	vol = ntfs_mount(path, flags);
+	if (!vol)
+		return NULL;
+
+	/* Initialize fsck lcn bitmap buffer array */
+	vol->max_flb_cnt = FB_ROUND_DOWN((vol->nr_clusters + 7)) + 1;
+	vol->fsck_lcn_bitmap = (u8 **)ntfs_calloc(sizeof(u8 *) * vol->max_flb_cnt);
+	if (!vol->fsck_lcn_bitmap) {
+		ntfs_umount(vol, FALSE);
+		return NULL;
+	}
+
+	/* Initialize fsck mft bitmap buffer array */
+	vol->max_fmb_cnt = FB_ROUND_DOWN(vol->mft_na->initialized_size >>
+				      vol->mft_record_size_bits) + 1;
+	vol->fsck_mft_bitmap = (u8 **)ntfs_calloc(sizeof(u8 *) * vol->max_fmb_cnt);
+	if (!vol->fsck_mft_bitmap) {
+		free(vol->fsck_lcn_bitmap);
+		ntfs_umount(vol, FALSE);
+		return NULL;
+	}
+
+	return vol;
+}
+
+void ntfs_fsck_umount(ntfs_volume *vol)
+{
+	int bm_i;
+
+	for (bm_i = 0; bm_i < vol->max_flb_cnt; bm_i++)
+		if (vol->fsck_lcn_bitmap[bm_i])
+			free(vol->fsck_lcn_bitmap[bm_i]);
+	free(vol->fsck_lcn_bitmap);
+
+	for (bm_i = 0; bm_i < vol->max_fmb_cnt; bm_i++)
+		if (vol->fsck_mft_bitmap[bm_i])
+			free(vol->fsck_mft_bitmap[bm_i]);
+	free(vol->fsck_mft_bitmap);
+
+	ntfs_umount(vol, FALSE);
+}

--- a/libntfs-3g/fsck.c
+++ b/libntfs-3g/fsck.c
@@ -95,6 +95,16 @@ int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no)
 	return ntfs_fsck_set_mftbmp_value(vol, mft_no, 1);
 }
 
+u8 *ntfs_fsck_find_mftbmp_block(ntfs_volume *vol, s64 mft_no)
+{
+	u32 bm_i = FB_ROUND_DOWN(mft_no);
+
+	if (bm_i >= vol->max_fmb_cnt || !vol->fsck_mft_bitmap[bm_i])
+		return zero_bm;
+
+	return vol->fsck_mft_bitmap[bm_i];
+}
+
 void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit)
 {
 	while (length--)

--- a/libntfs-3g/fsck.c
+++ b/libntfs-3g/fsck.c
@@ -44,6 +44,10 @@ u8 zero_bm[NTFS_BUF_SIZE];
 
 /*
  * function to set fsck mft bitmap value
+ *
+ * vol : ntfs_volume structure
+ * mft_no : mft number to set on mft bitmap
+ * value : 1 if set, 0 if clear
  */
 int ntfs_fsck_set_mftbmp_value(ntfs_volume *vol, u64 mft_no, int value)
 {
@@ -67,7 +71,7 @@ int ntfs_fsck_set_mftbmp_value(ntfs_volume *vol, u64 mft_no, int value)
 	return 0;
 }
 
-/* fsck mft bitmap get */
+/* get fsck mft bitmap */
 char ntfs_fsck_mftbmp_get(ntfs_volume *vol, const u64 bit)
 {
 	u32 bm_i = FB_ROUND_DOWN(bit >> NTFSCK_BYTE_TO_BITS);
@@ -79,13 +83,13 @@ char ntfs_fsck_mftbmp_get(ntfs_volume *vol, const u64 bit)
 	return ntfs_bit_get(vol->fsck_mft_bitmap[bm_i], bit - bm_pos);
 }
 
-/* fsck mft bitmap clear */
+/* clear fsck mft bitmap */
 int ntfs_fsck_mftbmp_clear(ntfs_volume *vol, u64 mft_no)
 {
 	return ntfs_fsck_set_mftbmp_value(vol, mft_no, 0);
 }
 
-/* fsck mft bitmap set */
+/* set fsck mft bitmap */
 int ntfs_fsck_mftbmp_set(ntfs_volume *vol, u64 mft_no)
 {
 	return ntfs_fsck_set_mftbmp_value(vol, mft_no, 1);
@@ -97,7 +101,7 @@ void ntfs_fsck_set_bitmap_range(u8 *bm, s64 pos, s64 length, u8 bit)
 		ntfs_bit_set(bm, pos++, bit);
 }
 
-u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos)
+u8 *ntfs_fsck_find_lcnbmp_block(ntfs_volume *vol, s64 pos)
 {
 	u32 bm_i = FB_ROUND_DOWN(pos);
 
@@ -107,13 +111,28 @@ u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos)
 	return vol->fsck_lcn_bitmap[bm_i];
 }
 
-int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit)
+#define FSCK_CHECK_AND_SET(buf, start_lcn, pos, length, bit, check) \
+do { \
+	int i = 0; \
+	while ((length)--) { \
+		if (ntfs_bit_get_and_set((buf), (pos) + i, (bit))) { \
+			if ((check) && (bit)) \
+				ntfs_log_info("Cluster Duplication #1 " \
+						" %"PRIu64"\n", (start_lcn) + i); \
+		} \
+		i++; \
+	} \
+} while (0);
+
+int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit,
+		BOOL check)
 {
 	s64 end = lcn + length - 1;
-	u32 bm_i = FB_ROUND_DOWN(lcn >> NTFSCK_BYTE_TO_BITS);
-	u32 bm_end = FB_ROUND_DOWN(end >> NTFSCK_BYTE_TO_BITS);
-	s64 bm_pos = (s64)bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS);
-	s64 lcn_diff = lcn - bm_pos;
+	s64 bm_i = FB_ROUND_DOWN(lcn >> NTFSCK_BYTE_TO_BITS);
+	s64 bm_end = FB_ROUND_DOWN(end >> NTFSCK_BYTE_TO_BITS);
+	s64 bm_bit = (s64)bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS);
+	s64 lcn_diff = lcn - bm_bit;
+	u8 *buf;
 
 	if (length <= 0)
 		return -EINVAL;
@@ -124,17 +143,19 @@ int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit)
 			return -ENOMEM;
 	}
 
+	buf = vol->fsck_lcn_bitmap[bm_i];
 	if (bm_end == bm_i) {
-		ntfs_fsck_set_bitmap_range(vol->fsck_lcn_bitmap[bm_i],
-				lcn_diff, length, bit);
+		FSCK_CHECK_AND_SET(buf, lcn, lcn_diff, length, bit, check);
 	} else {
-		ntfs_fsck_set_bitmap_range(vol->fsck_lcn_bitmap[bm_i], lcn_diff,
-					NTFSCK_BM_BITS_SIZE - lcn_diff,
-					bit);
+		s64 loop = NTFSCK_BM_BITS_SIZE - lcn_diff;
+
+		FSCK_CHECK_AND_SET(buf, lcn, lcn_diff, loop, bit, check);
+
 		length -= NTFSCK_BM_BITS_SIZE - lcn_diff;
 		bm_i++;
 
 		for (; bm_i <= bm_end; bm_i++) {
+			bm_bit = (s64)bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS);
 			if (length < 0) {
 				ntfs_log_error("length should not be negative here! : %"PRId64"\n",
 						length);
@@ -154,8 +175,8 @@ int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit)
 							length);
 					exit(1);
 				}
-				ntfs_fsck_set_bitmap_range(vol->fsck_lcn_bitmap[bm_i],
-						0, length, bit);
+				buf = vol->fsck_lcn_bitmap[bm_i];
+				FSCK_CHECK_AND_SET(buf, bm_bit, 0, length, bit, check);
 			} else {
 				/*
 				 * It is useful to use memset rather than setting
@@ -165,8 +186,21 @@ int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit)
 				 */
 				if (bit == 0)
 					memset(vol->fsck_lcn_bitmap[bm_i], 0, NTFS_BUF_SIZE);
-				else
+				else {
+					u64 *p_bmp;
+					int i;
+					for (i = 0; i < (NTFS_BUF_SIZE >> 3); i++, p_bmp++) {
+						p_bmp = (u64*)vol->fsck_lcn_bitmap[bm_i];
+						if (*p_bmp == 0) {
+							continue;
+						}
+
+						ntfs_log_info("Cluster Duplication #4 from %"PRIu64" to xxx\n",
+								bm_bit + ((i * 8) << 3));
+
+					}
 					memset(vol->fsck_lcn_bitmap[bm_i], 0xFF, NTFS_BUF_SIZE);
+				}
 				length -= NTFSCK_BM_BITS_SIZE;
 			}
 		}

--- a/libntfs-3g/fsck.c
+++ b/libntfs-3g/fsck.c
@@ -107,6 +107,74 @@ u8 *ntfs_fsck_get_lcnbmp_block(ntfs_volume *vol, s64 pos)
 	return vol->fsck_lcn_bitmap[bm_i];
 }
 
+int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit)
+{
+	s64 end = lcn + length - 1;
+	u32 bm_i = FB_ROUND_DOWN(lcn >> NTFSCK_BYTE_TO_BITS);
+	u32 bm_end = FB_ROUND_DOWN(end >> NTFSCK_BYTE_TO_BITS);
+	s64 bm_pos = (s64)bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS);
+	s64 lcn_diff = lcn - bm_pos;
+
+	if (length <= 0)
+		return -EINVAL;
+
+	if (!vol->fsck_lcn_bitmap[bm_i]) {
+		vol->fsck_lcn_bitmap[bm_i] = (u8 *)ntfs_calloc(NTFS_BUF_SIZE);
+		if (!vol->fsck_lcn_bitmap[bm_i])
+			return -ENOMEM;
+	}
+
+	if (bm_end == bm_i) {
+		ntfs_fsck_set_bitmap_range(vol->fsck_lcn_bitmap[bm_i],
+				lcn_diff, length, bit);
+	} else {
+		ntfs_fsck_set_bitmap_range(vol->fsck_lcn_bitmap[bm_i], lcn_diff,
+					NTFSCK_BM_BITS_SIZE - lcn_diff,
+					bit);
+		length -= NTFSCK_BM_BITS_SIZE - lcn_diff;
+		bm_i++;
+
+		for (; bm_i <= bm_end; bm_i++) {
+			if (length < 0) {
+				ntfs_log_error("length should not be negative here! : %"PRId64"\n",
+						length);
+				exit(1);
+			}
+
+			if (!vol->fsck_lcn_bitmap[bm_i]) {
+				vol->fsck_lcn_bitmap[bm_i] =
+					(u8 *)ntfs_calloc(NTFS_BUF_SIZE);
+				if (!vol->fsck_lcn_bitmap[bm_i])
+					return -ENOMEM;
+			}
+
+			if (bm_i == bm_end) {
+				if (length > NTFSCK_BM_BITS_SIZE) {
+					ntfs_log_error("the last rest of length could not be bigger than bm size:%"PRId64"\n",
+							length);
+					exit(1);
+				}
+				ntfs_fsck_set_bitmap_range(vol->fsck_lcn_bitmap[bm_i],
+						0, length, bit);
+			} else {
+				/*
+				 * It is useful to use memset rather than setting
+				 * each bit using ntfs_fsck_set_bitmap_range().
+				 * because this bitmap buffer should be filled as
+				 * the same value.
+				 */
+				if (bit == 0)
+					memset(vol->fsck_lcn_bitmap[bm_i], 0, NTFS_BUF_SIZE);
+				else
+					memset(vol->fsck_lcn_bitmap[bm_i], 0xFF, NTFS_BUF_SIZE);
+				length -= NTFSCK_BM_BITS_SIZE;
+			}
+		}
+	}
+
+	return 0;
+}
+
 ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
 		ntfs_mount_flags flags __attribute__((unused)))
 {

--- a/libntfs-3g/index.c
+++ b/libntfs-3g/index.c
@@ -1093,6 +1093,7 @@ static int ntfs_ibm_add(ntfs_index_context *icx)
 					icx->ni->mft_no);
 			return STATUS_ERROR;
 		}
+		icx->ni->fsck_ibm_size = sizeof(bmp);
 	}
 
 	return STATUS_OK;
@@ -1130,6 +1131,7 @@ int ntfs_ibm_modify(ntfs_index_context *icx, VCN vcn, int set)
 					ntfs_log_perror("Failed to realloc fsck_ibm");
 					goto err_na;
 				}
+				icx->ni->fsck_ibm_size = (na->data_size + 8) & ~7;
 			}
 		}
 	}

--- a/libntfs-3g/lcnalloc.c
+++ b/libntfs-3g/lcnalloc.c
@@ -45,6 +45,7 @@
 #include "lcnalloc.h"
 #include "logging.h"
 #include "misc.h"
+#include "fsck.h"
 
 /*
  * Plenty possibilities for big optimizations all over in the cluster
@@ -370,11 +371,13 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 			*byte |= bit;
 			writeback = 1;
 
-			/*
-			 * real lcn value = last_read_pos << 3 + lcn
-			 * set bm_i using real lcn
-			 * ntfs_bit_set(fsck_lcn_bitmap[bm_i], 0)
-			 */
+			/* set fsck lcn bitmap on fsck */
+			if (NVolFsck(vol)) {
+				LCN lcn_no = lcn + bmp_pos;
+				ntfs_fsck_set_lcnbmp_range(vol, lcn_no, 1, 1);
+				ntfs_log_trace("last_read_pos %"PRIu64", lcn %"PRIu64"\n",
+						last_read_pos, lcn_no);
+			}
 
 			if (NVolFreeSpaceKnown(vol)) {
 				if (vol->free_clusters <= 0)
@@ -606,6 +609,9 @@ int ntfs_cluster_free_from_rl(ntfs_volume *vol, runlist *rl)
 				goto out;
 			}
 			nr_freed += rl->length;
+
+			if (NVolFsck(vol))
+				ntfs_fsck_set_lcnbmp_range(vol, rl->lcn, rl->length, 0);
 		}
 	}
 
@@ -645,6 +651,9 @@ int ntfs_cluster_free_basic(ntfs_volume *vol, s64 lcn, s64 count)
 				goto out;
 		}
 		nr_freed += count;
+
+		if (NVolFsck(vol))
+			ntfs_fsck_set_lcnbmp_range(vol, lcn, count, 0);
 	}
 	ret = 0;
 out:
@@ -718,6 +727,9 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 					  to_free))
 			goto leave;
 		nr_freed = to_free;
+
+		if (NVolFsck(vol))
+			ntfs_fsck_set_lcnbmp_range(vol, rl->lcn + delta, to_free, 0);
 	}
 
 	/* Go to the next run and adjust the number of clusters left to free. */
@@ -759,6 +771,8 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 				goto out;
 			}
 			nr_freed += to_free;
+			if (NVolFsck(vol))
+				ntfs_fsck_set_lcnbmp_range(vol, rl->lcn, to_free, 0);
 		}
 
 		if (count >= 0)

--- a/libntfs-3g/lcnalloc.c
+++ b/libntfs-3g/lcnalloc.c
@@ -374,7 +374,7 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 			/* set fsck lcn bitmap on fsck */
 			if (NVolFsck(vol)) {
 				LCN lcn_no = lcn + bmp_pos;
-				ntfs_fsck_set_lcnbmp_range(vol, lcn_no, 1, 1);
+				ntfs_fsck_set_lcnbmp_range(vol, lcn_no, 1, 1, FALSE);
 				ntfs_log_trace("last_read_pos %"PRIu64", lcn %"PRIu64"\n",
 						last_read_pos, lcn_no);
 			}
@@ -611,7 +611,7 @@ int ntfs_cluster_free_from_rl(ntfs_volume *vol, runlist *rl)
 			nr_freed += rl->length;
 
 			if (NVolFsck(vol))
-				ntfs_fsck_set_lcnbmp_range(vol, rl->lcn, rl->length, 0);
+				ntfs_fsck_set_lcnbmp_range(vol, rl->lcn, rl->length, 0, FALSE);
 		}
 	}
 
@@ -653,7 +653,7 @@ int ntfs_cluster_free_basic(ntfs_volume *vol, s64 lcn, s64 count)
 		nr_freed += count;
 
 		if (NVolFsck(vol))
-			ntfs_fsck_set_lcnbmp_range(vol, lcn, count, 0);
+			ntfs_fsck_set_lcnbmp_range(vol, lcn, count, 0, FALSE);
 	}
 	ret = 0;
 out:
@@ -729,7 +729,7 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 		nr_freed = to_free;
 
 		if (NVolFsck(vol))
-			ntfs_fsck_set_lcnbmp_range(vol, rl->lcn + delta, to_free, 0);
+			ntfs_fsck_set_lcnbmp_range(vol, rl->lcn + delta, to_free, 0, FALSE);
 	}
 
 	/* Go to the next run and adjust the number of clusters left to free. */
@@ -772,7 +772,7 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 			}
 			nr_freed += to_free;
 			if (NVolFsck(vol))
-				ntfs_fsck_set_lcnbmp_range(vol, rl->lcn, to_free, 0);
+				ntfs_fsck_set_lcnbmp_range(vol, rl->lcn, to_free, 0, FALSE);
 		}
 
 		if (count >= 0)

--- a/libntfs-3g/mft.c
+++ b/libntfs-3g/mft.c
@@ -613,10 +613,6 @@ static int ntfs_is_mft(ntfs_inode *ni)
 	return 0;
 }
 
-#ifndef PAGE_SIZE
-#define PAGE_SIZE 4096
-#endif
-
 #define RESERVED_MFT_RECORDS   64
 
 /**
@@ -652,7 +648,7 @@ static int ntfs_mft_bitmap_find_free_rec(ntfs_volume *vol, ntfs_inode *base_ni)
 	 * Set the end of the pass making sure we do not overflow the mft
 	 * bitmap.
 	 */
-	size = PAGE_SIZE;
+	size = MFTBMP_ALLOC_SIZE;
 	pass_end = vol->mft_na->allocated_size >> vol->mft_record_size_bits;
 	ll = mftbmp_na->initialized_size << 3;
 	if (pass_end > ll)
@@ -678,7 +674,7 @@ static int ntfs_mft_bitmap_find_free_rec(ntfs_volume *vol, ntfs_inode *base_ni)
 		pass = 2;
 	}
 	pass_start = data_pos;
-	buf = ntfs_malloc(PAGE_SIZE);
+	buf = ntfs_malloc(MFTBMP_ALLOC_SIZE);
 	if (!buf)
 		goto leave;
 
@@ -691,7 +687,7 @@ static int ntfs_mft_bitmap_find_free_rec(ntfs_volume *vol, ntfs_inode *base_ni)
 	b = 0;
 #endif
 	/* Loop until a free mft record is found. */
-	for (; pass <= 2; size = PAGE_SIZE) {
+	for (; pass <= 2; size = MFTBMP_ALLOC_SIZE) {
 		/* Cap size to pass_end. */
 		ofs = data_pos >> 3;
 		ll = ((pass_end + 7) >> 3) - ofs;

--- a/libntfs-3g/runlist.c
+++ b/libntfs-3g/runlist.c
@@ -910,6 +910,22 @@ runlist_element *ntfs_mapping_pairs_decompress_i(const ntfs_volume *vol,
 				goto io_error;
 			for (deltaxcn = (s8)buf[b--]; b > b2; b--)
 				deltaxcn = (deltaxcn << 8) + buf[b];
+
+                       /*
+                        * normally if deltaxcn is zero, it is corrupted.
+                        * but deltaxcn can be 0, if it is the first entry of
+                        * $Bitmap/$Data cluster run.
+                        * Problem: How to distinguish corrupted offset(zero) and
+                        * first offset of $Bitmap/$Data cluster run.
+                        * now we will check it out of this function (caller).
+                        */
+                       if (NVolIsOnFsck(vol)) {
+                               if (deltaxcn == 0 && rlpos != 0) {
+                                       rl[rlpos].length = 0;
+                                       ntfs_debug_runlist_dump(rl);
+                               }
+                        }
+
 			/* Change the current lcn to it's new value. */
 			lcn += deltaxcn;
 #ifdef DEBUG
@@ -1057,7 +1073,7 @@ err_out:
 	if (NVolIsOnFsck(vol)) {
 		/* Setup terminating runlist element */
 		rl[rlpos].lcn = (LCN)LCN_ENOENT;
-		rl[rlpos].vcn = vcn;
+		rl[rlpos].vcn = rlpos ? rl[rlpos - 1].vcn + rl[rlpos -1].length : 0;
 		rl[rlpos].length = (s64)0;
 
 		if (old_rl && old_rl[0].length && rl[0].length) {

--- a/libntfs-3g/volume.c
+++ b/libntfs-3g/volume.c
@@ -438,6 +438,8 @@ mft_has_no_attr_list:
 	if (!filename || strcmp(filename, "$MFT")) {
 		ntfs_log_error("filename of $MFT record is not '$MFT'(%s)\n",
 				filename);
+		if (filename)
+			ntfs_attr_name_free(&filename);
 		goto error_exit;
 	}
 	ntfs_attr_name_free(&filename);

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -208,6 +208,7 @@ static void ntfsck_check_mft_record_unused(ntfs_volume *vol, s64 mft_num);
 static int ntfsck_set_mft_record_bitmap(ntfs_inode *ni, BOOL ondisk_mft_bmp_set);
 static int ntfsck_check_attr_list(ntfs_inode *ni);
 static inline BOOL ntfsck_opened_ni_vol(s64 mft_num);
+static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit);
 
 static int ntfsck_check_backup_boot_sector(ntfs_volume *vol, s64 cl_pos)
 {
@@ -234,6 +235,27 @@ static int ntfsck_check_backup_boot_sector(ntfs_volume *vol, s64 cl_pos)
 			 cl_pos);
 	free(backup_boot);
 	return 0;
+}
+
+static int fsck_get_lcnbmp_bit(ntfs_volume *vol, LCN lcn)
+{
+	u8 *flb;
+	u64 bm_pos = lcn >> 3;
+	u32 bm_off;
+
+	flb = ntfs_fsck_get_lcnbmp_block(vol, bm_pos);
+	bm_off = bm_pos & (NTFS_BUF_SIZE - 1);
+
+	return ntfs_bit_get(flb, bm_off);
+}
+
+static int ntfs_get_lcnbmp_bit(ntfs_volume *vol, LCN lcn)
+{
+	u8 flb;
+	s64 bm_pos = lcn >> NTFSCK_BYTE_TO_BITS;
+
+	ntfs_attr_pread(vol->lcnbmp_na, bm_pos, 1, &flb);
+	return ntfs_bit_get(&flb, lcn & 7);
 }
 
 static void ntfsck_check_orphaned_clusters(ntfs_volume *vol)
@@ -404,11 +426,12 @@ static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
 					"vcn(%"PRId64"), lcn(%"PRId64"), length(%"PRId64")\n",
 					ni->mft_no, rl[i].vcn, rl[i].lcn,
 					rl[i].length);
-			if (lcnbmp_set)
-				ntfs_fsck_set_lcnbmp_range(vol, rl[i].lcn, rl[i].length, set_bit);
+			ntfs_fsck_set_lcnbmp_range(vol, rl[i].lcn, rl[i].length, set_bit);
 
 			if (set_bit == 0)
-				ntfs_cluster_free_basic(vol, rl[i].lcn, rl[i].length);
+				ntfs_bitmap_clear_run(vol->lcnbmp_na, rl[i].lcn, rl[i].length);
+			else
+				ntfs_bitmap_set_run(vol->lcnbmp_na, rl[i].lcn, rl[i].length);
 
 			rsize = rl[i].length << vol->cluster_size_bits;
 			rl_data_size += rsize;
@@ -634,6 +657,7 @@ static int ntfsck_add_inode_to_parent(ntfs_volume *vol, ntfs_inode *parent_ni,
 			return STATUS_ERROR;
 		}
 	}
+	ntfsck_check_inode_non_resident(parent_ni, 1);
 	ntfs_inode_mark_dirty(parent_ni);
 	ntfsck_set_mft_record_bitmap(parent_ni, TRUE);
 
@@ -653,13 +677,6 @@ static int ntfsck_add_inode_to_parent(ntfs_volume *vol, ntfs_inode *parent_ni,
 
 	ntfs_fsck_mftbmp_set(vol, ni->mft_no);
 	ntfs_bitmap_set_bit(vol->mftbmp_na, ni->mft_no);
-
-	ntfsck_update_lcn_bitmap(ni);
-	/*
-	 * Recall ntfsck_update_lcn_bitmap() about parent_ni.
-	 * Because cluster can be allocated by adding index entry.
-	 */
-	ntfsck_update_lcn_bitmap(parent_ni);
 
 	return STATUS_OK;
 }
@@ -929,6 +946,7 @@ static int ntfsck_remove_filename(ntfs_inode *ni, FILE_NAME_ATTR *fn)
 	return STATUS_OK;
 }
 
+
 static int ntfsck_add_index_entry_orphaned_file(ntfs_volume *vol, s64 mft_no)
 {
 	ntfs_attr_search_ctx *ctx = NULL;
@@ -1040,7 +1058,9 @@ stack_of:
 							parent_ni->mft_no, ni->mft_no);
 					goto add_to_lostfound;
 				}
+			}
 
+			if (parent_ni) {
 				/* Check parent inode */
 				if (ntfsck_check_directory(parent_ni)) {
 					ntfs_log_error("Failed to check parent directory(%"PRIu64":%"PRIu64") "
@@ -1049,9 +1069,7 @@ stack_of:
 					/* parent is not normal, add to lost+found */
 					goto add_to_lostfound;
 				}
-			}
 
-			if (parent_ni) {
 				ret = ntfsck_add_inode_to_parent(vol, parent_ni, ni, fn, ctx);
 				if (!ret) {
 					nlink++;
@@ -1234,11 +1252,6 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 		}
 		fsck_err_fixed();
 	} else {
-		/*
-		 * Update number of clusters that is used for each
-		 * non-resident mft entries to bitmap.
-		 */
-		ntfsck_update_lcn_bitmap(ni);
 		ntfs_inode_close(ni);
 	}
 }
@@ -2744,7 +2757,6 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 			ntfs_inode_close(ni);
 			ntfs_list_add_tail(&dir->list, &ntfs_dirs_list);
 		} else {
-			ntfsck_update_lcn_bitmap(ni);
 			ret = ntfs_inode_close_in_dir(ni, ictx->ni);
 			if (ret) {
 				ntfs_log_error("Failed to close inode(%"PRIu64")\n",
@@ -3509,7 +3521,6 @@ err_continue:
 			dir_ni->fsck_ibm_size = 0;
 		}
 
-		ntfsck_update_lcn_bitmap(dir_ni);
 		ntfs_inode_close(dir_ni);
 		ntfs_list_del(&dir->list);
 		free(dir);
@@ -3533,6 +3544,7 @@ static int ntfsck_scan_index_entries(ntfs_volume *vol)
 static void ntfsck_check_mft_records(ntfs_volume *vol)
 {
 	s64 mft_num, nr_mft_records;
+	ntfs_inode *lost_found = NULL;
 
 	mrec_unused_chk = ntfs_malloc(vol->sector_size);
 	if (!mrec_unused_chk) {
@@ -3563,6 +3575,15 @@ static void ntfsck_check_mft_records(ntfs_volume *vol)
 	 * We need to update lcn bitmap for $MFT at last again.
 	 */
 	ntfsck_update_lcn_bitmap(vol->mft_ni);
+
+	lost_found = ntfs_inode_open(vol, vol->lost_found);
+	if (!lost_found) {
+		ntfs_log_error("Can't open lost+found directory\n");
+		return;
+	} else {
+		ntfsck_update_lcn_bitmap(lost_found);
+		ntfs_inode_close(lost_found);
+	}
 
 	fsck_end_step();
 
@@ -3772,7 +3793,6 @@ static int ntfsck_check_system_files(ntfs_volume *vol)
 
 		ntfs_inode_attach_all_extents(sys_ni);
 		ntfsck_set_mft_record_bitmap(sys_ni, FALSE);
-		ntfsck_update_lcn_bitmap(sys_ni);
 
 		if (mft_num > FILE_Extend) {
 			ntfs_inode_close(sys_ni);

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -245,7 +245,7 @@ static int fsck_get_lcnbmp_bit(ntfs_volume *vol, LCN lcn)
 	s64 bm_off;
 	s64 bm_i = FB_ROUND_DOWN(bm_pos);
 
-	flb = ntfs_fsck_get_lcnbmp_block(vol, bm_pos);
+	flb = ntfs_fsck_find_lcnbmp_block(vol, bm_pos);
 	bm_off = lcn - (bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS));
 
 	return ntfs_bit_get(flb, bm_off);
@@ -286,7 +286,7 @@ static void ntfsck_check_orphaned_clusters(ntfs_volume *vol)
 			break;
 		}
 
-		flb = ntfs_fsck_get_lcnbmp_block(vol, pos);
+		flb = ntfs_fsck_find_lcnbmp_block(vol, pos);
 
 		for (i = 0; i < count; i++, pos++) {
 			s64 cl;  /* current cluster */
@@ -374,7 +374,7 @@ static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 
 		while (rl[i].length) {
 			if (rl[i].lcn > (LCN)LCN_HOLE) {
-				ntfs_fsck_set_lcnbmp_range(ni->vol, rl[i].lcn, rl[i].length, 1);
+				ntfs_fsck_set_lcnbmp_range(ni->vol, rl[i].lcn, rl[i].length, 1, FALSE);
 				if (_ntfsck_ask_repair(ni->vol, FALSE))
 					ntfs_bitmap_set_run(ni->vol->lcnbmp_na, rl[i].lcn, rl[i].length);
 				ntfs_log_verbose("Cluster run of mft entry(%"PRIu64") "
@@ -431,20 +431,7 @@ static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
 					ni->mft_no, rl[i].vcn, rl[i].lcn,
 					rl[i].length);
 
-			/* TODO: should optimize logic */
-			if (set_bit == 1) {
-				int j = 0;
-				s64 bit = 0;
-				for (j = 0; j < rl[i].length; j++) {
-					bit = rl[i].lcn + j;
-					if (fsck_get_lcnbmp_bit(vol, bit)) {
-						check_failed("Cluster Duplication Detected! "
-								" %"PRIu64" ino %"PRIu64"\n",
-								bit, ni->mft_no);
-					}
-				}
-			}
-			ntfs_fsck_set_lcnbmp_range(vol, rl[i].lcn, rl[i].length, set_bit);
+			ntfs_fsck_set_lcnbmp_range(vol, rl[i].lcn, rl[i].length, set_bit, TRUE);
 
 			if (_ntfsck_ask_repair(vol, FALSE)) {
 				int ret = 0;
@@ -2425,7 +2412,8 @@ static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit)
 			continue;
 
 		if (CONV_TYPE_TO_BIT(a->type) & type_bitmap) {
-			ntfs_log_trace("inode %"PRIu64", type_bitmap %08x\n", ni->mft_no, type_bitmap);
+			ntfs_log_trace("SKIP: inode %"PRIu64", type %02x type_bitmap %08x\n",
+					ni->mft_no, a->type, type_bitmap);
 			continue;
 		}
 

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -978,6 +978,14 @@ stack_of:
 
 			parent_no = le64_to_cpu(fn->parent_directory);
 
+			/* when root index is initialized
+			 * in ntfsck_validate_index_blocks(),
+			 * root inode can be a orphaned inode */
+			if (ni->mft_no == FILE_root) {
+				ntfs_fsck_mftbmp_set(vol, FILE_root);
+				goto next_inode;
+			}
+
 			/*
 			 * Consider that the parent could be orphaned.
 			 */
@@ -1641,6 +1649,9 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 
 	ie_flags = ie_fn->file_attributes;
 
+	if (ie_flags & FILE_ATTR_VIEW_INDEX_PRESENT)
+		return ie_flags;
+
 	if (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY) {
 		/* mft record flags is set to directory */
 		if (ntfs_attr_exist(ni, AT_INDEX_ROOT, NTFS_INDEX_I30, 4)) {
@@ -2112,7 +2123,7 @@ static int ntfsck_check_non_resident_attr(ntfs_attr *na,
 	vol = na->ni->vol;
 	a =  actx->attr;
 
-	/* check cluster runlist and set bitmap */
+	/* check whole cluster runlist and set cluster bitmap of fsck */
 	if (ntfsck_check_attr_runlist(na, &rls, &need_fix, set_bit)) {
 		ntfs_log_error("Failed to get non-resident attribute(%d) "
 				"in directory(%"PRId64")", na->type, ni->mft_no);
@@ -2182,7 +2193,10 @@ static int ntfsck_check_non_resident_attr(ntfs_attr *na,
 	if (!ntfsck_ask_repair(vol))
 		goto out;
 
-	ntfs_non_resident_attr_shrink(na, new_size);
+	if (na->type == AT_INDEX_ALLOCATION)
+		ntfsck_initialize_index_attr(ni);
+	else
+		ntfs_non_resident_attr_shrink(na, new_size);
 
 	fsck_err_fixed();
 
@@ -2411,6 +2425,9 @@ static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit)
 		if (!a->non_resident)
 			continue;
 
+		/* skip already checked same attribute type,
+		 * because ntfsck_check_non_resident_attr()
+		 * check all same attribute type at once */
 		if (CONV_TYPE_TO_BIT(a->type) & type_bitmap) {
 			ntfs_log_trace("SKIP: inode %"PRIu64", type %02x type_bitmap %08x\n",
 					ni->mft_no, a->type, type_bitmap);
@@ -2915,21 +2932,17 @@ out:
 static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 					 ntfs_index_context *ictx)
 {
-	ntfs_attr *bmp_na;
+	ntfs_attr *bmp_na = NULL;
 	INDEX_ALLOCATION *ia;
-	FILE_NAME_ATTR *ie_fn;
 	INDEX_ENTRY *ie;
 	INDEX_ROOT *ir = ictx->ir;
-	ntfs_inode *ni = ictx->ni, *cni;
-	MFT_REF mref;
+	ntfs_inode *ni = ictx->ni;
 	VCN vcn;
 	u32 ir_size = le32_to_cpu(ir->index.index_length);
-	u32 ib_cnt = 0, i;
-	BOOL ib_corrupted = FALSE;
-	u8 *ir_buf, *ia_buf = NULL, *bmp_buf = NULL, *ibs, *index_end;
-	char *filename;
+	u8 *ir_buf = NULL, *ia_buf = NULL, *bmp_buf = NULL, *index_end;
 	u64 max_vcn_bits;
 	u32 vcn_step;
+	VCN max_vcn;
 
 	ictx->ia_na = ntfs_attr_open(ni, AT_INDEX_ALLOCATION,
 			ictx->name, ictx->name_len);
@@ -2939,36 +2952,12 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 	bmp_na = ntfs_attr_open(ictx->ni, AT_BITMAP, ictx->name, ictx->name_len);
 	if (!bmp_na) {
 		ntfs_log_error("Failed to open bitmap\n");
-		ntfs_attr_close(ictx->ia_na);
-		ictx->ia_na = NULL;
-		return;
+		goto out;
 	}
 
 	bmp_buf = malloc(bmp_na->data_size);
 	if (!bmp_buf) {
 		ntfs_log_error("Failed to allocate bitmap buffer\n");
-		ntfs_attr_close(ictx->ia_na);
-		ntfs_attr_close(bmp_na);
-		ictx->ia_na = NULL;
-		return;
-	}
-
-	ir_buf = malloc(le32_to_cpu(ir->index.index_length));
-	if (!ir_buf) {
-		ntfs_log_error("Failed to allocate ir buffer\n");
-		ntfs_free(bmp_buf);
-		ntfs_attr_close(ictx->ia_na);
-		ntfs_attr_close(bmp_na);
-		ictx->ia_na = NULL;
-		return;
-	}
-
-	memcpy(ir_buf, (u8 *)&ir->index + le32_to_cpu(ir->index.entries_offset),
-		       ir_size);
-
-	ia_buf = ntfs_malloc(ictx->ia_na->data_size);
-	if (!ia_buf) {
-		ntfs_log_error("Failed to allocate ia buffer\n");
 		goto out;
 	}
 
@@ -2977,81 +2966,26 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 		goto out;
 	}
 
-	max_vcn_bits = bmp_na->data_size * 8;
-
-	vcn_step = ictx->block_size >> ictx->vcn_size_bits;
-	ibs = ia_buf;
-	for (i = ictx->ia_na->data_size, vcn = 0; i > 0; i -= ictx->block_size, vcn += vcn_step) {
-		u32 bmp_pos;
-
-		if (max_vcn_bits <= vcn)
-			break;
-
-		bmp_pos = (vcn << ictx->vcn_size_bits) / ictx->block_size;
-		if (!ntfs_bit_get(bmp_buf, bmp_pos))
-			continue;
-
-		if (ntfs_attr_mst_pread(ictx->ia_na,
-					ntfs_ib_vcn_to_pos(ictx, vcn), 1,
-					ictx->block_size, ibs) != 1) {
-			ntfs_log_perror("Failed to read index blocks of inode(%"PRIu64"), %d",
-					ictx->ni->mft_no, errno);
-			ib_corrupted = TRUE;
-			goto out;
-		}
-
-		if (ntfs_index_block_inconsistent(vol, ictx->ia_na, (INDEX_ALLOCATION *)ibs,
-					ictx->block_size, ni->mft_no,
-					vcn))
-			ib_corrupted = TRUE;
-		else {
-			/* check index entries in a INDEX_ALLOCATION block */
-			ia = (INDEX_ALLOCATION *)ibs;
-			index_end = (u8 *)ia + ictx->block_size;
-			ie = (INDEX_ENTRY *)((u8 *)&ia->index +
-					le32_to_cpu(ia->index.entries_offset));
-
-			for (; (u8 *)ie < index_end;
-				ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
-				/* Bounds checks. */
-				if (((u8 *)ie < (u8 *)ia) ||
-					((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end) ||
-					((u8 *)ie + le16_to_cpu(ie->length) > index_end)) {
-					ib_corrupted = TRUE;
-					break;
-				}
-
-				/* The last entry cannot contain a name. */
-				if (ie->ie_flags & INDEX_ENTRY_END)
-					break;
-
-				if (!le16_to_cpu(ie->length))
-					break;
-			}
-		}
-		ibs += ictx->block_size;
-		ib_cnt++;
-	}
-
-	if (ib_corrupted == FALSE)
-		goto out;
-
-	if (ntfsck_initialize_index_attr(ni)) {
-		ntfs_log_perror("Failed to initialize index attributes of inode(%"PRIu64")\n",
-				ni->mft_no);
+	ir_buf = malloc(le32_to_cpu(ir->index.index_length));
+	if (!ir_buf) {
+		ntfs_log_error("Failed to allocate ir buffer\n");
 		goto out;
 	}
 
+	memcpy(ir_buf, (u8 *)&ir->index + le32_to_cpu(ir->index.entries_offset),
+		       ir_size);
+
+	/* check entries in INDEX_ROOT */
 	index_end = ir_buf + ir_size;
 	ie = (INDEX_ENTRY *)ir_buf;
-
-	for (;; ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
+	for (; (u8 *)ie < index_end;
+			ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
 		if ((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end ||
 		    (u8 *)ie + le16_to_cpu(ie->length) > index_end) {
 
 			ntfs_log_verbose("Index root entry out of bounds in"
 					" inode %"PRId64"\n", ni->mft_no);
-			break;
+			goto initialize_index;
 		}
 
 		/* The last entry cannot contain a name. */
@@ -3064,43 +2998,59 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 		/* The file name must not overflow from the entry */
 		if (ntfs_index_entry_inconsistent(vol, ie, COLLATION_FILE_NAME,
 				ni->mft_no, NULL) < 0)
-			continue;
-
-		ie_fn = &ie->key.file_name;
-		mref = le64_to_cpu(ie->indexed_file);
-		filename = ntfs_attr_name_get(ie_fn->file_name, ie_fn->file_name_length);
-		ntfs_log_info("Inserting entry to index root, mref : %"PRIu64", %s\n",
-			      MREF(le64_to_cpu(ie->indexed_file)), filename);
-		free(filename);
-
-		cni = ntfs_inode_open(vol, MREF(mref));
-		if (!cni)
-			continue;
-
-		if (ntfs_index_add_filename(ni, ie_fn,
-					    MK_MREF(cni->mft_no,
-					    le16_to_cpu(cni->mrec->sequence_number))))
-			ntfs_log_error("Failed to add index entry, errno : %d\n",
-					errno);
-		ntfs_inode_close(cni);
+			goto initialize_index;
 	}
 
-	ia = (INDEX_ALLOCATION *)ia_buf;
-	for (i = 0; i < ib_cnt; i++) {
+	ia_buf = ntfs_malloc(ictx->block_size);
+	if (!ia_buf) {
+		ntfs_log_error("Failed to allocate ia buffer\n");
+		goto out;
+	}
+
+	max_vcn_bits = bmp_na->data_size << NTFSCK_BYTE_TO_BITS;
+	max_vcn = ictx->ia_na->data_size >> ictx->vcn_size_bits;
+	vcn_step = ictx->block_size >> ictx->vcn_size_bits;
+
+	/* check index block and entries in INDEX_ALLOCATION */
+	for (vcn = 0; vcn < max_vcn; vcn += vcn_step) {
+		u32 bmp_pos;
+
+		if (max_vcn_bits <= vcn)
+			break;
+
+		bmp_pos = (vcn << ictx->vcn_size_bits) / ictx->block_size;
+		if (!ntfs_bit_get(bmp_buf, bmp_pos))
+			continue;
+
+		if (ntfs_attr_mst_pread(ictx->ia_na,
+					ntfs_ib_vcn_to_pos(ictx, vcn), 1,
+					ictx->block_size, ia_buf) != 1) {
+			ntfs_log_perror("Failed to read index blocks of inode(%"PRIu64"), %d",
+					ictx->ni->mft_no, errno);
+			goto initialize_index;
+		}
+
+		if (ntfs_index_block_inconsistent(vol, ictx->ia_na,
+					(INDEX_ALLOCATION *)ia_buf,
+					ictx->block_size, ni->mft_no, vcn)) {
+			goto initialize_index;
+		}
+
+		/* check index entries in a INDEX_ALLOCATION block */
+		ia = (INDEX_ALLOCATION *)ia_buf;
 		index_end = (u8 *)ia + ictx->block_size;
 		ie = (INDEX_ENTRY *)((u8 *)&ia->index +
 				le32_to_cpu(ia->index.entries_offset));
 
 		for (;; ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
 			/* Bounds checks. */
-			if ((u8 *)ie < (u8 *)ia || (u8 *)ie +
-				sizeof(INDEX_ENTRY_HEADER) > index_end ||
-				(u8 *)ie + le16_to_cpu(ie->length) >
-				index_end) {
+			if (((u8 *)ie < (u8 *)ia) ||
+					((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end) ||
+					((u8 *)ie + le16_to_cpu(ie->length) > index_end)) {
 
 				ntfs_log_verbose("Index entry out of bounds in directory inode "
-						 "%"PRId64".\n", ni->mft_no);
-				break;
+						"%"PRId64".\n", ni->mft_no);
+				goto initialize_index;
 			}
 
 			/* The last entry cannot contain a name. */
@@ -3112,42 +3062,54 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 
 			/* The file name must not overflow from the entry */
 			if (ntfs_index_entry_inconsistent(vol, ie,
-							  COLLATION_FILE_NAME,
-							  ni->mft_no,
-							  NULL))
-				continue;
-
-			ie_fn = &ie->key.file_name;
-			mref = le64_to_cpu(ie->indexed_file);
-			filename = ntfs_attr_name_get(ie_fn->file_name,
-					ie_fn->file_name_length);
-			ntfs_log_info("Inserting entry to $IA, mref : %"PRIu64", %s\n",
-				      MREF(le64_to_cpu(ie->indexed_file)), filename);
-			free(filename);
-
-			cni = ntfs_inode_open(vol, MREF(mref));
-			if (!cni)
-				continue;
-
-			if (ntfs_index_add_filename(ni, ie_fn,
-					MK_MREF(cni->mft_no,
-						le16_to_cpu(cni->mrec->sequence_number))))
-				ntfs_log_error("Failed to add index entry, errno : %d\n",
-						errno);
-			ntfs_inode_close(cni);
+						COLLATION_FILE_NAME, ni->mft_no, NULL))
+				goto initialize_index;
 		}
-		ia = (INDEX_ALLOCATION *)((u8 *)ia + ictx->block_size);
 	}
 
 out:
-	ntfs_free(ir_buf);
+	if (ir_buf)
+		ntfs_free(ir_buf);
+
 	if (bmp_buf)
 		ntfs_free(bmp_buf);
+
 	if (ia_buf)
 		ntfs_free(ia_buf);
-	ntfs_attr_close(ictx->ia_na);
-	ntfs_attr_close(bmp_na);
-	ictx->ia_na = NULL;
+
+	if (bmp_na)
+		ntfs_attr_close(bmp_na);
+
+	if (ictx->ia_na) {
+		ntfs_attr_close(ictx->ia_na);
+		ictx->ia_na = NULL;
+	}
+
+	return;
+
+initialize_index:
+	ntfs_log_info("inode(%"PRIu64") index is initialized\n", ni->mft_no);
+
+	if (ntfsck_initialize_index_attr(ni))
+		ntfs_log_perror("Failed to initialize index attributes of inode(%"PRIu64")\n",
+				ni->mft_no);
+
+	if (ni->mft_no == FILE_root) {
+		/* clear bitmap for already opened mft to add orphaned candidate */
+		ntfs_fsck_mftbmp_clear(vol, FILE_MFT);
+		ntfsck_check_inode_non_resident(vol->mft_ni, 0);
+		ntfs_fsck_mftbmp_clear(vol, FILE_MFTMirr);
+		ntfsck_check_inode_non_resident(vol->mftmirr_ni, 0);
+		ntfs_fsck_mftbmp_clear(vol, FILE_Volume);
+		ntfsck_check_inode_non_resident(vol->vol_ni, 0);
+		ntfs_fsck_mftbmp_clear(vol, FILE_root);
+		ntfsck_check_inode_non_resident(ni, 0);
+		ntfs_fsck_mftbmp_clear(vol, FILE_Bitmap);
+		ntfsck_check_inode_non_resident(vol->lcnbmp_ni, 0);
+		ntfs_fsck_mftbmp_clear(vol, FILE_Secure);
+		ntfsck_check_inode_non_resident(vol->secure_ni, 0);
+	}
+	goto out;
 }
 
 static int _ntfsck_remove_index(ntfs_inode *parent_ni, ntfs_inode *ni)

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -464,6 +464,12 @@ static int ntfsck_set_lcnbmp_range(s64 lcn, s64 length, u8 bit)
 	return 0;
 }
 
+static void ntfsck_clear_attr_lcnbmp(ntfs_attr *na)
+{
+	ntfs_attr_map_whole_runlist(na);
+	ntfsck_setbit_runlist(na->ni, na->rl, 0, NULL, TRUE);
+}
+
 static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 {
 	ntfs_attr_search_ctx *actx;
@@ -2076,6 +2082,9 @@ static int ntfsck_initialize_index_attr(ntfs_inode *ni)
 	 */
 	ia_na = ntfs_attr_open(ni, AT_INDEX_ALLOCATION, NTFS_INDEX_I30, 4);
 	if (ia_na) {
+		/* clear fsck cluster(lcn) bitmap */
+		ntfsck_clear_attr_lcnbmp(ia_na);
+
 		if (ntfs_attr_rm(ia_na)) {
 			ntfs_log_error("Failed to remove $IA attr. of inode(%"PRId64")\n",
 					ni->mft_no);

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -206,18 +206,85 @@ static FILE_NAME_ATTR *ntfsck_find_file_name_attr(ntfs_inode *ni,
 		FILE_NAME_ATTR *ie_fn, ntfs_attr_search_ctx *actx);
 static int ntfsck_check_directory(ntfs_inode *ni);
 static int ntfsck_check_file(ntfs_inode *ni);
-static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
-		struct rl_size *rls);
+static int ntfsck_check_runlist(ntfs_attr *na, u8 set_bit, struct rl_size *rls);
 static int ntfsck_check_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 		ntfs_index_context *ictx);
+static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
+		ntfs_index_context *ictx);
+static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
+		FILE_NAME_ATTR *ie_fn);
 static int ntfsck_initialize_index_attr(ntfs_inode *ni);
-static void ntfsck_check_mft_record_unused(ntfs_volume *vol, s64 mft_num);
 static int ntfsck_set_mft_record_bitmap(ntfs_inode *ni, BOOL ondisk_mft_bmp_set);
 static int ntfsck_check_attr_list(ntfs_inode *ni);
 static inline BOOL ntfsck_opened_ni_vol(s64 mft_num);
+static ntfs_inode *ntfsck_get_opened_ni_vol(ntfs_volume *vol, s64 mft_num);
 static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit);
 static void ntfsck_check_mft_records(ntfs_volume *vol);
+static void ntfsck_free_mft_records(ntfs_volume *vol, ntfs_inode *ni);
+static void ntfsck_check_mft_record_unused(ntfs_volume *vol, s64 mft_num);
+static void ntfsck_delete_orphaned_mft(ntfs_volume *vol, u64 mft_no);
 
+#define ntfsck_delete_mft	ntfsck_delete_orphaned_mft
+
+static ntfs_inode *ntfsck_open_inode(ntfs_volume *vol, u64 mft_no)
+{
+	ntfs_inode *ni;
+	ni = ntfsck_get_opened_ni_vol(vol, mft_no);
+	if (!ni)
+		ni = ntfs_inode_open(vol, mft_no);
+	return ni;
+}
+
+static int ntfsck_close_inode(ntfs_inode *ni)
+{
+	u64 mft_no;
+	mft_no = ni->mft_no;
+
+	if (ntfsck_opened_ni_vol(mft_no) == TRUE)
+		return STATUS_OK;
+
+	if (ntfs_inode_close(ni)) {
+		ntfs_log_perror("Failed to close inode(%"PRIu64")\n", mft_no);
+		return STATUS_ERROR;
+	}
+
+	return STATUS_OK;
+}
+
+static int ntfsck_close_inode_in_dir(ntfs_inode *ni, ntfs_inode *dir_ni)
+{
+	int res = 0;
+
+	res = ntfs_inode_sync_in_dir(ni, dir_ni);
+	if (res) {
+		ntfs_log_perror("%s failed\n", __func__);
+		if (errno != EIO)
+			errno = EBUSY;
+	} else
+		res = ntfsck_close_inode(ni);
+	return (res);
+}
+
+static void ntfsck_delete_inode(ntfs_inode *ni)
+{
+	ntfs_volume *vol;
+
+	if (!ni) {
+		ntfs_log_error("Can't delete orphaned inode: ni is NULL\n");
+		return;
+	}
+	vol = ni->vol;
+
+	/* Do not delete system file */
+	if (utils_is_metadata(ni) == 1) {
+		ntfsck_close_inode(ni);
+		return;
+	}
+	ntfsck_check_inode_non_resident(ni, 0);
+	ntfsck_free_mft_records(vol, ni);
+}
+
+/* update lcn bitmap to disk, not set in fsck lcn bitmap */
 static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 {
 	ntfs_attr_search_ctx *actx;
@@ -233,6 +300,11 @@ static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 		if (!actx->attr->non_resident)
 			continue;
 
+		/*
+		 * FIXME:
+		 * don't use ntfs_mapping_pairs_decompress,
+		 * use ntfs_mapping_pairs_decompress for fsck'
+		 */
 		rl = ntfs_mapping_pairs_decompress(ni->vol, actx->attr, NULL);
 		if (!rl) {
 			ntfs_log_error("Failed to decompress runlist(mft_no:%"PRIu64", type:0x%x). "
@@ -243,7 +315,6 @@ static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 
 		while (rl[i].length) {
 			if (rl[i].lcn > (LCN)LCN_HOLE) {
-				ntfs_fsck_set_lcnbmp_range(ni->vol, rl[i].lcn, rl[i].length, 1, FALSE);
 				if (_ntfsck_ask_repair(ni->vol, FALSE))
 					ntfs_bitmap_set_run(ni->vol->lcnbmp_na, rl[i].lcn, rl[i].length);
 				ntfs_log_verbose("Cluster run of mft entry(%"PRIu64") "
@@ -264,7 +335,7 @@ static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 static void ntfsck_clear_attr_lcnbmp(ntfs_attr *na)
 {
 	ntfs_attr_map_whole_runlist(na);
-	ntfsck_check_runlist(na->ni, na->rl, 0, NULL);
+	ntfsck_check_runlist(na, 0, NULL);
 }
 
 /*
@@ -279,17 +350,21 @@ static void ntfsck_clear_attr_lcnbmp(ntfs_attr *na)
  * @rls : structure for runlist length, it contains allocated size and
  *	  real allocated size. it may be NULL, don't return calculated size.
  */
-static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
-		struct rl_size *rls)
+static int ntfsck_check_runlist(ntfs_attr *na, u8 set_bit, struct rl_size *rls)
 {
 	ntfs_volume *vol;
+	ntfs_inode *ni;
+	runlist *rl;
 	s64 rl_alloc_size = 0;	/* rl allocated size (including HOLE length) */
 	s64 rl_data_size = 0;	/* rl data size (real allocated size) */
 	s64 rsize;		/* a cluster run size */
 	int i = 0;
 
-	if (!ni || !rl)
+	if (!na || !na->ni || !na->rl)
 		return STATUS_ERROR;
+
+	ni = na->ni;
+	rl = na->rl;
 
 	vol = ni->vol;
 
@@ -301,6 +376,8 @@ static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
 					rl[i].length);
 
 			ntfs_fsck_set_lcnbmp_range(vol, rl[i].lcn, rl[i].length, set_bit, TRUE);
+
+			/* Do not clear bitmap on disk, it may trigger cluster duplication */
 
 			rsize = rl[i].length << vol->cluster_size_bits;
 			rl_data_size += rsize;
@@ -366,6 +443,7 @@ static void ntfsck_free_mft_records(ntfs_volume *vol, ntfs_inode *ni)
 static int ntfsck_find_and_check_index(ntfs_inode *parent_ni, ntfs_inode *ni,
 		FILE_NAME_ATTR *fn, BOOL check_flag)
 {
+	ntfs_volume *vol;
 	ntfs_index_context *ictx;
 
 	if (!parent_ni || !ni || !fn)
@@ -378,8 +456,21 @@ static int ntfsck_find_and_check_index(ntfs_inode *parent_ni, ntfs_inode *ni,
 		return STATUS_ERROR;
 	}
 
+	/* ntfs_index_lookup() just compare file name,
+	 * not whole $FILE_NAME_ATTR */
 	if (!ntfs_index_lookup(fn, sizeof(FILE_NAME_ATTR), ictx)) {
 		u64 mft_no = 0;
+
+		mft_no = le64_to_cpu(ictx->entry->indexed_file);
+		if ((MSEQNO_LE(ictx->entry->indexed_file) !=
+					le16_to_cpu(ni->mrec->sequence_number)) ||
+				(MREF(mft_no) != ni->mft_no)) {
+			/* found index and orphaned inode is different */
+			ntfs_log_error("mft number of inode(%"PRIu64") and parent index(%"PRIu64") "
+					"are different\n", MREF(mft_no), ni->mft_no);
+			ntfs_index_ctx_put(ictx);
+			return STATUS_ERROR;
+		}
 
 		/* If check_flag set FALSE, when found $FN in parent index, return error */
 		if (check_flag == FALSE) {
@@ -390,31 +481,41 @@ static int ntfsck_find_and_check_index(ntfs_inode *parent_ni, ntfs_inode *ni,
 			return STATUS_ERROR;
 		}
 
-		/* If check_flags set TRUE, check founded inode */
-		mft_no = le64_to_cpu(ictx->entry->indexed_file);
-		if (ni->mft_no != MREF(mft_no)) {
-			/* found index and orphaned inode is different */
-			ntfs_log_error("mft number of inode(%"PRIu64") and parent index(%"PRIu64") "
-					"are different\n", mft_no, ni->mft_no);
-			ntfs_index_ctx_put(ictx);
-			return STATUS_ERROR;
-		}
-
-		if (ntfsck_check_inode(ni, ictx->entry, ictx)) {
-			/* Inode check failed, remove index and inode */
-			ntfs_log_error("Failed to check inode(%"PRId64") "
-					"for repairing orphan inode\n", ni->mft_no);
-
-			if (ntfs_index_rm(ictx)) {
-				ntfs_log_error("Failed to remove index entry of inode(%"PRId64")\n",
+		/* If check_flags set TRUE, check inode of founded index */
+		vol = ni->vol;
+		if (ntfs_fsck_mftbmp_get(vol, ni->mft_no)) {
+			/* Check file type */
+			if (ntfsck_check_file_type(ni, ictx, fn) < 0) {
+				ntfs_log_debug("failed to check file type(%"PRIu64")\n",
 						ni->mft_no);
 				ntfs_index_ctx_put(ictx);
 				return STATUS_ERROR;
 			}
-			ntfs_inode_mark_dirty(ictx->ni);
 
-			ntfs_index_ctx_put(ictx);
-			return STATUS_ERROR;
+			/* check $FILE_NAME */
+			if (ntfsck_check_file_name_attr(ni, fn, ictx) < 0) {
+				ntfs_log_debug("failed to check file name attribute(%"PRIu64")\n",
+						ni->mft_no);
+				ntfs_index_ctx_put(ictx);
+				return STATUS_ERROR;
+			}
+		} else {
+			/* TODO: should be modified how to check inode */
+			if (ntfsck_check_inode(ni, ictx->entry, ictx)) {
+				/* Inode check failed, remove index and inode */
+				ntfs_log_error("Failed to check inode(%"PRId64") "
+						"for repairing orphan inode\n", ni->mft_no);
+
+				if (ntfs_index_rm(ictx)) {
+					ntfs_log_error("Failed to remove index entry of inode(%"PRId64")\n",
+							ni->mft_no);
+					ntfs_index_ctx_put(ictx);
+					return STATUS_ERROR;
+				}
+				ntfs_inode_mark_dirty(ictx->ni);
+				ntfs_index_ctx_put(ictx);
+				return STATUS_ERROR;
+			}
 		}
 	} else {
 		ntfs_index_ctx_put(ictx);
@@ -493,11 +594,11 @@ static int ntfsck_add_inode_to_parent(ntfs_volume *vol, ntfs_inode *parent_ni,
 	}
 
 	if (!ntfs_fsck_mftbmp_get(vol, parent_ni->mft_no)) {
-		ntfsck_check_inode_non_resident(parent_ni, 1);
+		ntfs_log_info("parent(%"PRIu64") of orphaned inode(%"PRIu64") mft bitmap not set\n",
+				parent_ni->mft_no, ni->mft_no);
 	}
 
-//	ntfsck_set_mft_record_bitmap(parent_ni, TRUE);
-	ntfsck_set_mft_record_bitmap(parent_ni, FALSE);
+	ntfsck_set_mft_record_bitmap(parent_ni, TRUE);
 	ntfs_inode_mark_dirty(parent_ni);
 
 	/* check again after adding $FN to index */
@@ -514,8 +615,7 @@ static int ntfsck_add_inode_to_parent(ntfs_volume *vol, ntfs_inode *parent_ni,
 	ntfs_inode_mark_dirty(ctx->ntfs_ino);
 	ntfs_inode_mark_dirty(ni);
 
-//	ntfsck_set_mft_record_bitmap(ni, TRUE);
-	ntfsck_set_mft_record_bitmap(ni, FALSE);
+	ntfsck_set_mft_record_bitmap(ni, TRUE);
 
 	return STATUS_OK;
 }
@@ -538,7 +638,7 @@ static int ntfsck_add_inode_to_lostfound(ntfs_inode *ni, FILE_NAME_ATTR *fn,
 	}
 
 	vol = ni->vol;
-	lost_found = ntfs_inode_open(vol, vol->lost_found);
+	lost_found = ntfsck_open_inode(vol, vol->lost_found);
 	if (!lost_found) {
 		ntfs_log_error("Can't open lost+found directory\n");
 		return ret;
@@ -571,6 +671,8 @@ static int ntfsck_add_inode_to_lostfound(ntfs_inode *ni, FILE_NAME_ATTR *fn,
 	memcpy(new_fn, fn, sizeof(FILE_NAME_ATTR));
 	memcpy(new_fn->file_name, ucs_name, ucs_namelen * sizeof(ntfschar));
 	new_fn->file_name_length = ucs_namelen;
+	new_fn->parent_directory = MK_LE_MREF(lost_found->mft_no,
+			le16_to_cpu(lost_found->mrec->sequence_number));
 
 	ntfs_attr_reinit_search_ctx(ctx);
 	fn = ntfsck_find_file_name_attr(ni, fn, ctx);
@@ -605,7 +707,7 @@ err_out:
 	if (new_fn)
 		ntfs_free(new_fn);
 	if (lost_found)
-		ntfs_inode_close(lost_found);
+		ntfsck_close_inode(lost_found);
 	return ret;
 }
 
@@ -643,7 +745,7 @@ static void ntfsck_delete_orphaned_inode(ntfs_inode **ni)
 
 	/* Do not delete system file */
 	if (utils_is_metadata(*ni) == 1) {
-		ntfs_inode_close(*ni);
+		ntfsck_close_inode(*ni);
 		*ni = NULL;
 		return;
 	}
@@ -822,8 +924,10 @@ stack_of:
 	while (!ntfs_list_empty(&ot_list_head)) {
 		entry = ntfs_list_entry(ot_list_head.next, struct orphan_mft, ot_list);
 
-		ni = ntfs_inode_open(vol, entry->mft_no);
+		ni = ntfsck_open_inode(vol, entry->mft_no);
 		if (!ni) {
+			ntfs_log_error("Failed to open orphaned inode(%"PRIu64"), check next\n",
+					entry->mft_no);
 			ntfsck_delete_orphaned_mft(vol, entry->mft_no);
 			ret = STATUS_OK;
 			goto next_inode;
@@ -833,7 +937,6 @@ stack_of:
 		ctx = ntfs_attr_get_search_ctx(ni, NULL);
 		if (!ctx) {
 			ntfs_log_error("Failed to allocate attribute context\n");
-			ntfsck_delete_orphaned_inode(&ni);
 			ret = STATUS_OK;
 			goto next_inode;
 		}
@@ -869,11 +972,12 @@ stack_of:
 					/* Do not delete ni on orphan list and check parent */
 					ntfs_attr_put_search_ctx(ctx);
 					ctx = NULL;
-					ntfs_inode_close(ni);
+					ntfsck_close_inode(ni);
 					entry = p_entry;
 					goto stack_of;
 				}
 
+				/* TODO: set mft record unused for parent_no ??? */
 				goto add_to_lostfound;
 			}
 
@@ -881,10 +985,11 @@ stack_of:
 			 * Add orphan inode to parent
 			 */
 			if (!parent_ni && parent_no != (u64)-1) {
-				parent_ni = ntfs_inode_open(vol, MREF(parent_no));
+				parent_ni = ntfsck_open_inode(vol, MREF(parent_no));
 				if (!parent_ni) {
 					ntfs_log_error("Failed to open parent inode(%"PRIu64")\n",
 							parent_no);
+					/* TODO: make parent inode unused ?? */
 					goto add_to_lostfound;
 				}
 
@@ -893,16 +998,14 @@ stack_of:
 					ntfs_log_info("Different sequence number of parent(%"PRIu64
 							") and inode(%"PRIu64")\n",
 							parent_ni->mft_no, ni->mft_no);
-					goto add_to_lostfound;
-				}
-
-				/* Check parent inode */
-				if (ntfsck_check_directory(parent_ni)) {
-					ntfs_log_error("Failed to check parent directory(%"PRIu64":%"PRIu64") "
-							"for repairing orphan inode\n",
-							parent_ni->mft_no, ni->mft_no);
-					/* parent is not normal, add to lost+found */
-					goto add_to_lostfound;
+					printf("Delete orphaned inode(%"PRIu64")\n", ni->mft_no);
+					ntfs_attr_record_rm(ctx);
+					NInoClearDirty(parent_ni);
+					NInoFileNameClearDirty(parent_ni);
+					NInoAttrListClearDirty(parent_ni);
+					ntfsck_close_inode(parent_ni);
+					parent_ni = NULL;
+					continue;
 				}
 			}
 
@@ -910,11 +1013,18 @@ stack_of:
 				ret = ntfsck_add_inode_to_parent(vol, parent_ni, ni, fn, ctx);
 				if (!ret) {
 					nlink++;
+					ntfsck_close_inode(parent_ni);
+					parent_ni = NULL;
 					continue; /* success adding to parent, go to next $FN */
 				}
 
 				ntfs_log_error("Failed to add inode(%"PRIu64") to parent(%"PRIu64")\n",
 						ni->mft_no, parent_ni->mft_no);
+				NInoClearDirty(parent_ni);
+				NInoFileNameClearDirty(parent_ni);
+				NInoAttrListClearDirty(parent_ni);
+				ntfsck_close_inode(parent_ni);
+				parent_ni = NULL;
 			}
 			/* failed to add inode to parent */
 add_to_lostfound:
@@ -933,7 +1043,7 @@ add_to_lostfound:
 				ret = STATUS_OK;
 				nlink++;
 			}
-		}
+		} /* while (!ntfs_attr_lookup(AT_FILE_NAME, ... */
 
 		if (nlink == 0) {
 			ntfsck_delete_orphaned_inode(&ni);
@@ -954,12 +1064,12 @@ next_inode:
 			ntfs_inode_sync_in_dir(ni, parent_ni);
 
 		if (parent_ni) {
-			ntfs_inode_close(parent_ni);
+			ntfsck_close_inode(parent_ni);
 			parent_ni = NULL;
 		}
 
 		if (ni) {
-			ntfs_inode_close(ni);
+			ntfsck_close_inode(ni);
 			ni = NULL;
 		}
 		ntfs_list_del(&entry->ot_list);
@@ -967,6 +1077,26 @@ next_inode:
 	} /* while (!ntfs_list_empty(&ot_list_head)) */
 
 	return ret;
+}
+
+/* return STATUS_OK, mft is extend mft record, else return STATUS_ERROR */
+static int ntfsck_check_if_extent_mft_record(ntfs_volume *vol, s64 mft_num)
+{
+	s64 pos = mft_num * vol->mft_record_size;
+	s64 count = vol->sector_size;
+	u64 base_mft;
+
+	if (ntfs_attr_pread(vol->mft_na, pos, count, mrec_unused_chk) != count) {
+		ntfs_log_perror("Couldn't read $MFT record %lld",
+				(long long)mft_num);
+		return STATUS_ERROR;
+	}
+
+	base_mft = MREF_LE(mrec_unused_chk->base_mft_record);
+	if (base_mft == 0)
+		return STATUS_ERROR;	/* base mft */
+
+	return STATUS_OK;	/* extent mft */
 }
 
 static void ntfsck_check_mft_record_unused(ntfs_volume *vol, s64 mft_num)
@@ -1007,48 +1137,42 @@ static void ntfsck_check_mft_record_unused(ntfs_volume *vol, s64 mft_num)
 s64 clear_mft_cnt;
 static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 {
-	int is_used;
-	int always_exist_sys_meta_num = vol->major_ver >= 3 ? 11 : 10;
-	ntfs_inode *ni;
+	ntfs_inode *ni = NULL;;
+	ntfs_inode *parent_ni = NULL;
 	struct orphan_mft *of;
+	int is_used;
+	ntfs_attr_search_ctx *ctx = NULL;
+	FILE_NAME_ATTR *fn;
+	u64 parent_no;
+	int nlink;
 
-	is_used = utils_mftrec_in_use(vol, mft_num);
+	if (ntfs_fsck_mftbmp_get(vol, mft_num))
+		return;
+
+	is_used = check_mftrec_in_use(vol, mft_num, 0);
 	if (is_used < 0) {
 		check_failed("Error getting bit value for record %"PRId64".\n",
 			mft_num);
 		return;
 	} else if (!is_used) {
-		if (mft_num <= always_exist_sys_meta_num) {
+		if (mft_num < FILE_Extend) {
 			check_failed("Record(%"PRId64") unused. Fixing or fail about system files.\n",
 					mft_num);
 			return;
 		}
-
-		if (ntfs_fsck_mftbmp_get(vol, mft_num)) {
-			ni = ntfs_inode_open(vol, mft_num);
-			if (ni) {
-				ntfsck_set_mft_record_bitmap(ni, FALSE);
-				ntfs_inode_close(ni);
-				return;
-			}
-		}
-
-		ntfsck_check_mft_record_unused(vol, mft_num);
-		/* TODO: below function is needed? */
-		ntfs_fsck_mftbmp_clear(vol, mft_num);
 		return;
 	}
 
-	ntfs_log_verbose("MFT record %"PRId64"\n", mft_num);
-
-	is_used = ntfs_fsck_mftbmp_get(vol, mft_num);
-	if (is_used)
-		return;
-
-	ni = ntfs_inode_open(vol, mft_num);
+	ni = ntfsck_open_inode(vol, mft_num);
 	if (!ni) {
-		fsck_err_found();
-		ntfs_log_trace("Clear the bit of mft no(%"PRId64") "
+		/* check this mft is extend mft or not */
+		if (!ntfsck_check_if_extent_mft_record(vol, mft_num)) {
+			/* extent mft */
+			return;
+		}
+
+//		fsck_err_found();
+		ntfs_log_info("Clear the bit of mft no(%"PRId64") "
 				"in the $MFT/$BITMAP corresponding orphaned MFT record\n",
 				mft_num);
 		if (_ntfsck_ask_repair(vol, FALSE)) {
@@ -1058,21 +1182,72 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 				return;
 			}
 			ntfsck_check_mft_record_unused(vol, mft_num);
-			/* TODO: below function should use mft bitmap cache */
 			ntfs_fsck_mftbmp_clear(vol, mft_num);
+			check_mftrec_in_use(vol, mft_num, 1);
 			clear_mft_cnt++;
-			fsck_err_fixed();
+//			fsck_err_fixed();
 		}
 		return;
 	}
 
-	/* set mft bitmap on disk, but not set in fsck mft bitmap */
+	ctx = ntfs_attr_get_search_ctx(ni, NULL);
+	if (!ctx) {
+		ntfs_log_error("Failed to allocate attribute context\n");
+		ntfsck_close_inode(ni);
+		return;
+	}
 
+	nlink = 0;
+	while (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
+				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+		fn = (FILE_NAME_ATTR *)((u8 *)ctx->attr +
+				le16_to_cpu(ctx->attr->value_offset));
+
+		parent_no = le64_to_cpu(fn->parent_directory);
+		if (parent_no != (u64)-1) {
+			parent_ni = ntfsck_open_inode(vol, MREF(parent_no));
+			if (!parent_ni) {
+				ntfs_log_error("Failed to open parent inode(%"PRIu64")\n",
+						parent_no);
+				continue;
+			}
+
+			if (ntfsck_cmp_parent_mft_sequence(parent_ni, fn) < 0) {
+				/* do not add inode to parent */
+				ntfs_log_info("Different sequence number of parent(%"PRIu64
+						") and inode(%"PRIu64")\n",
+						parent_ni->mft_no, ni->mft_no);
+				printf("Remove filename of inode(%"PRIu64")\n", ni->mft_no);
+				ntfsck_remove_filename(ni, fn);
+				ntfsck_close_inode(parent_ni);
+				continue;
+			}
+			ntfsck_close_inode(parent_ni);
+		}
+		nlink++;
+	} /* while (!ntfs_attr_lookup(AT_FILE_NAME, ... */
+
+	if (nlink == 0) {
+		printf("Delete orphaned candidate inode(%"PRIu64")\n", ni->mft_no);
+		ntfsck_delete_orphaned_inode(&ni);
+		ntfs_attr_put_search_ctx(ctx);
+		return;
+	}
+
+	if (ctx) {
+		ntfs_attr_put_search_ctx(ctx);
+		ctx = NULL;
+	}
+
+	/* orphaned inode */
 	if (utils_is_metadata(ni) == 1) {
 		ntfs_log_info("Metadata %"PRIu64" is found as orphaned file\n",
 				ni->mft_no);
-		ntfs_inode_close(ni);
-		return;
+		/* system files can be orphaned inode,
+		 * because root inode can be initialized in
+		 * ntfsck_validate_index_blocks(vol, ictx).
+		 * so, also check system files.
+		 */
 	}
 
 	of = (struct orphan_mft *)calloc(1, sizeof(struct orphan_mft));
@@ -1082,9 +1257,10 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 	}
 
 	of->mft_no = mft_num;
-	ntfs_list_add(&of->oc_list, &oc_list_head);
+	ntfs_list_add_tail(&of->oc_list, &oc_list_head);
 
-	ntfs_inode_close(ni);
+//	ntfs_log_info("close inode (%"PRIu64")\n", ni->mft_no);
+	ntfsck_close_inode(ni);
 }
 
 #if DEBUG
@@ -1583,6 +1759,7 @@ static int32_t ntfsck_check_file_type(ntfs_inode *ni, ntfs_index_context *ictx,
 	return (int32_t)ie_flags;
 }
 
+/* TODO: this function is useless call mapping_paris_decompress_on_fsck directly */
 static runlist *_ntfsck_decompose_runlist(ntfs_attr_search_ctx *actx,
 		runlist *old_rl, BOOL *need_fix)
 {
@@ -1897,7 +2074,7 @@ static int ntfsck_check_attr_runlist(ntfs_attr *na, struct rl_size *rls,
 	ntfs_dump_runlist(rl);
 #endif
 
-	ret = ntfsck_check_runlist(na->ni, na->rl, set_bit, rls);
+	ret = ntfsck_check_runlist(na, set_bit, rls);
 	if (ret)
 		return STATUS_ERROR;
 
@@ -1972,17 +2149,21 @@ static int ntfsck_check_non_resident_attr(ntfs_attr *na,
 
 	/* if need_fix is set to TRUE, apply modified runlist to cluster runs */
 	if (need_fix == TRUE) {
-		check_failed("Non-resident cluster run of inode(%"PRId64":%d) "
+		check_failed("Non-resident cluster run of inode(%"PRId64")(%02x:%"PRIu64") "
 				"corrupted. rl_size(%"PRIx64":%"PRIx64"). Truncate it",
-				ni->mft_no, na->type, rls.alloc_size, rls.real_size);
+				ni->mft_no, na->type, na->data_size, rls.alloc_size, rls.real_size);
 
 		if (ntfsck_ask_repair(vol)) {
 			/*
 			 * keep a valid runlist as long as possible.
 			 * if truncate zero, call with second parameter to 0
 			 */
-			if (ntfsck_update_runlist(na, rls.alloc_size))
+			if (ntfsck_update_runlist(na, rls.alloc_size)) {
+				/* FIXME: why ntfsck_update_runlist failed? and
+				 * what should it do? */
+				fsck_err_fixed();
 				return STATUS_ERROR;
+			}
 
 			fsck_err_fixed();
 		}
@@ -2010,6 +2191,9 @@ static int ntfsck_check_non_resident_attr(ntfs_attr *na,
 	 * Reset non-residnet if sizes are invalid,
 	 * And then make it resident attribute.
 	 */
+
+	/* TODO: check more detail */
+
 	if (alloc_size != rls.alloc_size || data_size > alloc_size) {
 		new_size = 0;
 	} else {
@@ -2253,7 +2437,7 @@ static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit)
 	ntfs_attr_search_ctx *ctx;
 	ntfs_attr *na;
 	ATTR_RECORD *a;
-	ATTR_TYPES type_bitmap = AT_UNUSED;
+	unsigned long type_bitmap = 0;
 	int ret = STATUS_OK;
 
 	ctx = ntfs_attr_get_search_ctx(ni, NULL);
@@ -2268,8 +2452,9 @@ static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit)
 		/* skip already checked same attribute type,
 		 * because ntfsck_check_non_resident_attr()
 		 * check all same attribute type at once */
-		if (CONV_TYPE_TO_BIT(a->type) & type_bitmap) {
-			ntfs_log_trace("SKIP: inode %"PRIu64", type %02x type_bitmap %08x\n",
+		if ((a->type >= AT_FIRST_USER_DEFINED_ATTRIBUTE) ||
+				(CONV_TYPE_TO_BIT(a->type) & type_bitmap)) {
+			ntfs_log_trace("SKIP: inode %"PRIu64", type %02x type_bitmap %08lx\n",
 					ni->mft_no, a->type, type_bitmap);
 			continue;
 		}
@@ -2287,8 +2472,10 @@ static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit)
 		ret = ntfsck_check_non_resident_attr(na, ctx, NULL, set_bit);
 		type_bitmap |= CONV_TYPE_TO_BIT(a->type);
 		ntfs_attr_close(na);
-		if (ret)
-			continue;
+		if (ret) {
+			ntfs_attr_put_search_ctx(ctx);
+			return STATUS_ERROR;
+		}
 	}
 
 	if (ret == -1 && errno == ENOENT)
@@ -2399,7 +2586,7 @@ static int ntfsck_check_attr_list(ntfs_inode *ni)
 		goto out;
 	}
 
-	_ntfsck_check_attr_list_type(ctx);
+	ret = _ntfsck_check_attr_list_type(ctx);
 
 out:
 	ntfs_attr_put_search_ctx(ctx);
@@ -2481,6 +2668,12 @@ static int ntfsck_check_system_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 		ret = ntfsck_check_directory(ni);
 	}
 
+	/* TODO: check index
+	if (ni->mrec->flags & MFT_RECORD_IS_VIEW_INDEX) {
+		ret = ntfsck_check_index(ni);
+	}
+	*/
+
 	/* TODO: check system file more detail respectively. */
 
 	ntfsck_set_mft_record_bitmap(ni, FALSE);
@@ -2532,12 +2725,10 @@ static inline int ntfsck_is_directory(FILE_NAME_ATTR *ie_fn)
 static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 			       ntfs_index_context *ictx)
 {
-#ifdef DEBUG
-	char *filename;
-#endif
 	ntfs_inode *ni;
 	struct dir *dir;
 	MFT_REF mref;
+	u64 mft_no;
 	int ret = STATUS_OK;
 	FILE_NAME_ATTR *ie_fn = &ie->key.file_name;
 
@@ -2545,33 +2736,44 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 		return STATUS_ERROR;
 
 	mref = le64_to_cpu(ie->indexed_file);
-	if (ntfsck_opened_ni_vol(MREF(mref)) == TRUE)
+	mft_no = MREF(mref);
+	if ((ntfsck_opened_ni_vol(MREF(mref)) == TRUE) || mft_no == FILE_root)
 		return STATUS_OK;
 
 #ifdef DEBUG
+	char *filename;
 	filename = ntfs_attr_name_get(ie_fn->file_name, ie_fn->file_name_length);
-	ntfs_log_verbose("ntfsck_check_index %"PRIu64", %s\n",
-			MREF(mref), filename);
+	ntfs_log_info("ntfsck_check_index %"PRIu64", %s, ictx->ni %"PRIu64"\n",
+			mft_no, filename, ictx->ni->mft_no);
+	free(filename);
 #endif
 
-	ni = ntfs_inode_open(vol, MREF(mref));
+	ni = ntfsck_open_inode(vol, mft_no);
 	if (ni) {
 		BOOL is_mft_checked = FALSE;
 
 		/*
-		 * check base_mft_record before calling utils_is_metadata().
-		 * cause utils_is_metadata() consider extent inode,
-		 * if base_mft_record is not zero
+		 * check if mft record is already checked
 		 */
-		if (MREF_LE(ni->mrec->base_mft_record) != 0) {
-			ntfs_log_error("Inode(%"PRIu64") is not base inode\n",
-					ni->mft_no);
-			ret = STATUS_ERROR;
-			ntfs_inode_close(ni);
-			goto remove_index;
+		if (ntfs_fsck_mftbmp_get(vol, ni->mft_no)) {
+			is_mft_checked = TRUE;
+
+			/* Check file type */
+			if (ntfsck_check_file_type(ni, ictx, ie_fn) < 0) {
+				ntfsck_close_inode(ni);
+				goto remove_index;
+			}
+
+			/* check $FILE_NAME */
+			if (ntfsck_check_file_name_attr(ni, ie_fn, ictx) < 0) {
+				ntfsck_close_inode(ni);
+				goto remove_index;
+			}
+			ntfsck_close_inode(ni);
+			return STATUS_OK;
 		}
 
-		/* skip checking for system files */
+		/* checking for system files or not */
 		if ((utils_is_metadata(ni) == 1) ||
 				((utils_is_metadata(ictx->ni) == 1) &&
 				 (ictx->ni->mft_no != FILE_root))) {
@@ -2581,9 +2783,6 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 			 */
 			ret = ntfsck_check_system_inode(ni, ie, ictx);
 		} else {
-			if (ntfs_fsck_mftbmp_get(vol, ni->mft_no))
-				is_mft_checked = TRUE;
-
 			ret = ntfsck_check_inode(ni, ie, ictx);
 			if (ret) {
 				ntfs_log_error("Failed to check inode(%"PRIu64") "
@@ -2591,8 +2790,10 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 						ni->mft_no, ictx->ni->mft_no);
 
 				NInoFileNameClearDirty(ni);
+				NInoAttrListClearDirty(ni);
 				NInoClearDirty(ni);
-				ntfs_inode_close(ni);
+				/* TODO: distinguish delete or not, as error type */
+				ntfsck_delete_inode(ni);
 				goto remove_index;
 			}
 		}
@@ -2601,16 +2802,16 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 			dir = (struct dir *)calloc(1, sizeof(struct dir));
 			if (!dir) {
 				ntfs_log_error("Failed to allocate for subdir.\n");
-				ntfs_inode_close(ni);
+				ntfsck_close_inode(ni);
 				ret = STATUS_ERROR;
 				goto err_out;
 			}
 
 			dir->mft_no = ni->mft_no;
-			ntfs_inode_close(ni);
+			ntfsck_close_inode(ni);
 			ntfs_list_add_tail(&dir->list, &ntfs_dirs_list);
 		} else {
-			ret = ntfs_inode_close_in_dir(ni, ictx->ni);
+			ret = ntfsck_close_inode_in_dir(ni, ictx->ni);
 			if (ret) {
 				ntfs_log_error("Failed to close inode(%"PRIu64")\n",
 						ni->mft_no);
@@ -2620,23 +2821,24 @@ static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
 	} else {
 		char *crtname;
 
-		ntfs_log_error("Failed to open inode(%"PRIu64")\n", MREF(mref));
+		ntfs_log_error("Failed to open inode(%"PRIu64")\n", mft_no);
 
 remove_index:
 		crtname = ntfs_attr_name_get(ie_fn->file_name, ie_fn->file_name_length);
 		check_failed("Index entry(%"PRIu64":%s) "
-				"is corrupted, Removing index entry from parent(%"PRIu64")",
-				MREF(mref), crtname,
-				MREF_LE(ie_fn->parent_directory));
+				"is corrupted, Removing index entry from parent(%"PRIu64":%"PRIu64")",
+				mft_no, crtname,
+				MREF_LE(ie_fn->parent_directory), ictx->ni->mft_no);
+
 		if (ntfsck_ask_repair(vol)) {
 			ictx->entry = ie;
 			ret = ntfs_index_rm(ictx);
 			if (ret) {
 				ntfs_log_error("Failed to remove index entry of inode(%"PRIu64":%s)\n",
-						MREF(mref), crtname);
+						mft_no, crtname);
 			} else {
 				ntfs_log_verbose("Index entry of inode(%"PRIu64":%s) is deleted\n",
-						MREF(mref), crtname);
+						mft_no, crtname);
 				ret = STATUS_FIXED;
 				fsck_err_fixed();
 				if (ictx->actx)
@@ -3034,7 +3236,7 @@ create_lf:
 			free(ucs_name);
 		}
 	} else {
-		lf_ni = ntfs_inode_open(vol, lf_mftno);
+		lf_ni = ntfsck_open_inode(vol, lf_mftno);
 		if (!lf_ni)
 			ntfs_log_verbose("Failed to open %s(%"PRIu64").\n",
 					FILENAME_LOST_FOUND, lf_mftno);
@@ -3053,7 +3255,7 @@ create_lf:
 
 			ntfs_log_error("Failed to remove index of %s(%"PRIu64")\n",
 					FILENAME_LOST_FOUND, lf_ni->mft_no);
-			ntfs_inode_close(lf_ni);
+			ntfsck_close_inode(lf_ni);
 			lf_ni = NULL;
 		}
 	}
@@ -3063,8 +3265,8 @@ create_lf:
 			ntfs_log_error("Failed to open/check '%s'\n", FILENAME_LOST_FOUND);
 	} else {
 		vol->lost_found = lf_ni->mft_no;
-		ntfsck_update_lcn_bitmap(lf_ni);
-		ntfs_inode_close(lf_ni);
+		ntfsck_set_mft_record_bitmap(lf_ni, TRUE);
+		ntfsck_close_inode(lf_ni);
 	}
 }
 
@@ -3072,7 +3274,7 @@ static ntfs_inode *ntfsck_check_root_inode(ntfs_volume *vol)
 {
 	ntfs_inode *ni;
 
-	ni = ntfs_inode_open(vol, FILE_root);
+	ni = ntfsck_open_inode(vol, FILE_root);
 	if (!ni) {
 		ntfs_log_error("Couldn't open the root directory.\n");
 		goto err_out;
@@ -3101,7 +3303,7 @@ static ntfs_inode *ntfsck_check_root_inode(ntfs_volume *vol)
 
 err_out:
 	if (ni)
-		ntfs_inode_close(ni);
+		ntfsck_close_inode(ni);
 	return NULL;
 }
 
@@ -3123,7 +3325,7 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 		return -1;
 	}
 
-	dir_ni = ntfs_inode_open(vol, FILE_root);
+	dir_ni = ntfsck_open_inode(vol, FILE_root);
 	if (!dir_ni) {
 		free(dir);
 		ntfs_log_error("Failed to open root inode\n");
@@ -3131,13 +3333,13 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 	}
 
 	dir->mft_no = dir_ni->mft_no;
-	ntfs_inode_close(dir_ni);
+	ntfsck_close_inode(dir_ni);
 	ntfs_list_add(&dir->list, &ntfs_dirs_list);
 
 	while (!ntfs_list_empty(&ntfs_dirs_list)) {
 
 		dir = ntfs_list_entry(ntfs_dirs_list.next, struct dir, list);
-		dir_ni = ntfs_inode_open(vol, dir->mft_no);
+		dir_ni = ntfsck_open_inode(vol, dir->mft_no);
 		if (!dir_ni) {
 			ntfs_log_perror("Failed to open inode (%"PRIu64")\n",
 					dir->mft_no);
@@ -3318,7 +3520,7 @@ err_continue:
 			dir_ni->fsck_ibm_size = 0;
 		}
 
-		ntfs_inode_close(dir_ni);
+		ntfsck_close_inode(dir_ni);
 		ntfs_list_del(&dir->list);
 		free(dir);
 	}
@@ -3341,7 +3543,6 @@ static int ntfsck_scan_index_entries(ntfs_volume *vol)
 static void ntfsck_check_mft_records(ntfs_volume *vol)
 {
 	s64 mft_num, nr_mft_records;
-	ntfs_inode *lost_found = NULL;
 
 	fsck_start_step("Check mft entries in volume...\n");
 
@@ -3355,28 +3556,11 @@ static void ntfsck_check_mft_records(ntfs_volume *vol)
 	 * array buffer.
 	 */
 	check_mftrec_in_use(vol, FILE_first_user, 1);
-	for (mft_num = FILE_first_user; mft_num < nr_mft_records; mft_num++)
+	for (mft_num = FILE_MFT; mft_num < nr_mft_records; mft_num++)
 		ntfsck_verify_mft_record(vol, mft_num);
 
 	if (clear_mft_cnt)
 		ntfs_log_info("Clear MFT bitmap count:%"PRId64"\n", clear_mft_cnt);
-
-	/*
-	 * $MFT could be updated after reviving orphaned mft entries.
-	 * We need to update lcn bitmap for $MFT at last again.
-	 */
-	ntfsck_update_lcn_bitmap(vol->mft_ni);
-
-	if (vol->lost_found) {
-		lost_found = ntfs_inode_open(vol, vol->lost_found);
-		if (!lost_found) {
-			ntfs_log_error("Can't open lost+found directory\n");
-			return;
-		} else {
-			ntfsck_update_lcn_bitmap(lost_found);
-			ntfs_inode_close(lost_found);
-		}
-	}
 
 	fsck_end_step();
 }
@@ -3425,7 +3609,6 @@ static inline BOOL ntfsck_opened_ni_vol(s64 mft_num)
 	case FILE_Volume:
 	case FILE_Bitmap:
 	case FILE_Secure:
-	case FILE_root:
 		is_opened = TRUE;
 	}
 
@@ -3461,8 +3644,18 @@ static int ntfsck_validate_system_file(ntfs_inode *ni)
 	ntfs_volume *vol = ni->vol;
 
 	switch (ni->mft_no) {
-	case FILE_Bitmap:
-	{
+	case FILE_MFT:
+	case FILE_MFTMirr:
+	case FILE_LogFile:
+	case FILE_Volume:
+	case FILE_AttrDef:
+	case FILE_Boot:
+	case FILE_Secure:
+	case FILE_UpCase:
+	case FILE_Extend:
+		ntfsck_check_inode_non_resident(ni, 1);
+		break;
+	case FILE_Bitmap: {
 		s64 max_lcnbmp_size;
 
 		if (ntfs_attr_map_whole_runlist(vol->lcnbmp_na)) {
@@ -3471,9 +3664,9 @@ static int ntfsck_validate_system_file(ntfs_inode *ni)
 		}
 
 		/* Check cluster run of $DATA attribute */
-		if (ntfsck_check_runlist(ni, vol->lcnbmp_na->rl, 1, NULL)) {
+		if (ntfsck_check_runlist(vol->lcnbmp_na, 1, NULL)) {
 			ntfs_log_error("Failed to check and setbit runlist. "
-				       "Leaving inconsistent metadata.\n");
+					"Leaving inconsistent metadata.\n");
 			return -EIO;
 		}
 
@@ -3485,8 +3678,8 @@ static int ntfsck_validate_system_file(ntfs_inode *ni)
 		if (max_lcnbmp_size > vol->lcnbmp_na->data_size) {
 			u8 *zero_bm;
 			s64 written;
-			s64 zero_bm_size = max_lcnbmp_size -
-						vol->lcnbmp_na->data_size;
+			s64 zero_bm_size =
+				max_lcnbmp_size - vol->lcnbmp_na->data_size;
 
 			check_failed("$Bitmap size is smaller than expected "
 					"(%"PRId64"< %"PRId64")",
@@ -3530,7 +3723,7 @@ static int ntfsck_check_system_files(ntfs_volume *vol)
 	s64 mft_num;
 	int ret = STATUS_ERROR;
 	int is_used;
-	int go_through = 0;
+	BOOL trivial;	/* represent system file is trivial or not */
 
 	fsck_start_step("Check system files...\n");
 
@@ -3557,42 +3750,51 @@ static int ntfsck_check_system_files(ntfs_volume *vol)
 		if (vol->major_ver < 3 && mft_num == FILE_Extend)
 			continue;
 
+		trivial = FALSE;
+
 		sys_ni = ntfsck_get_opened_ni_vol(vol, mft_num);
 		if (!sys_ni) {
-			go_through = 1;
 			if (mft_num == FILE_root)
-				sys_ni = root_ni;
-			else {
-				sys_ni = ntfs_inode_open(vol, mft_num);
-				if (!sys_ni) {
-					ntfs_log_error("Failed to open %"PRId64" system file\n",
-							mft_num);
-					ret = STATUS_ERROR;
-					goto put_index_ctx;
-				}
+				continue;
+
+			/* check only already opened inode and reserved inode */
+			if (mft_num < FILE_reserved12)
+				continue;
+
+			sys_ni = ntfsck_open_inode(vol, mft_num);
+			if (!sys_ni) {
+				ntfs_log_info("Failed to open system file(%"PRId64")\n",
+						mft_num);
+				continue;
 			}
+			trivial = TRUE;
 		}
 
 		is_used = utils_mftrec_in_use(vol, mft_num);
 		if (is_used < 0) {
-			ntfs_log_error("MFT bitmap of system file(%"PRIu64") "
-					"is not set\n", mft_num);
-			ret = STATUS_ERROR;
-			ntfs_inode_close(sys_ni);
-			goto put_index_ctx;
+			ntfs_log_error("Can't read system file(%"PRIu64") bitmap\n",
+					mft_num);
+			ntfsck_close_inode(sys_ni);
+			goto check_trivial;
 		}
 
 		ntfs_inode_attach_all_extents(sys_ni);
 		ntfsck_set_mft_record_bitmap(sys_ni, FALSE);
 
-		if (mft_num > FILE_Extend) {
-			ntfs_inode_close(sys_ni);
+		/* do not check any more about reserved inode */
+		if (mft_num >= FILE_reserved12) {
+			ntfsck_close_inode(sys_ni);
 			continue;
 		}
 
+		/* Validate mft entry of system file */
+		ret = ntfsck_validate_system_file(sys_ni);
+		if (ret)
+			goto check_trivial;
+
 		sys_ctx = ntfs_attr_get_search_ctx(sys_ni, NULL);
 		if (!sys_ctx) {
-			ntfs_inode_close(sys_ni);
+			ntfsck_close_inode(sys_ni);
 			ret = STATUS_ERROR;
 			goto put_index_ctx;
 		}
@@ -3603,8 +3805,8 @@ static int ntfsck_check_system_files(ntfs_volume *vol)
 			ntfs_log_error("Failed to lookup file name attribute of %"PRId64" system file\n",
 					mft_num);
 			ntfs_attr_put_search_ctx(sys_ctx);
-			ntfs_inode_close(sys_ni);
-			goto put_index_ctx;
+			ntfsck_close_inode(sys_ni);
+			goto check_trivial;
 		}
 
 		fn = (FILE_NAME_ATTR *)((u8 *)sys_ctx->attr +
@@ -3618,98 +3820,56 @@ static int ntfsck_check_system_files(ntfs_volume *vol)
 		ret = ntfs_index_lookup(fn,
 				le32_to_cpu(sys_ctx->attr->value_length), ictx);
 		if (ret) {
-			ntfs_log_error("Failed to find index entry of inode(%"PRId64") system file\n",
-					mft_num);
+			ntfs_log_error("There's no system file entry"
+					"(%"PRId64") in root\n", mft_num);
 			ntfs_attr_put_search_ctx(sys_ctx);
-			ntfs_inode_close(sys_ni);
-			ret = STATUS_ERROR;
-			goto put_index_ctx;
+			ntfsck_close_inode(sys_ni);
+			goto check_trivial;
 		}
 		ntfs_attr_put_search_ctx(sys_ctx);
 
 		/* TODO: Validate index entry of system file */
 
-		/* Validate mft entry of system file */
-		ret = ntfsck_validate_system_file(sys_ni);
-		if (ret)
-			goto put_index_ctx;
-
 		ntfs_index_ctx_reinit(ictx);
 		if (ntfsck_opened_ni_vol(mft_num) == TRUE)
 			continue;
-		ntfs_inode_close(sys_ni);
-		go_through = 0;
+
+		ntfsck_close_inode(sys_ni);
+		continue;
+
+check_trivial:
+		if (trivial == FALSE) {
+			ret = STATUS_ERROR;
+			goto put_index_ctx;
+		} else {
+			continue;
+		}
 	}
+
+	ret = STATUS_OK;
 
 put_index_ctx:
 	ntfs_index_ctx_put(ictx);
 put_attr_ctx:
 	ntfs_attr_put_search_ctx(root_ctx);
 close_inode:
-	ntfs_inode_close(root_ni);
+	ntfsck_close_inode(root_ni);
 
 	fsck_end_step();
-
-	if (go_through)
-		ret = STATUS_OK;
 	return ret;
-}
-
-static int ntfsck_check_orphaned_mft(ntfs_volume *vol)
-{
-	struct orphan_mft *entry;
-	ntfs_inode *root_ni;
-
-	/* check lost found directory */
-	if (!vol->lost_found) {
-		root_ni = ntfs_inode_open(vol, FILE_root);
-		if (!root_ni) {
-			ntfs_log_error("Failed to open root inode\n");
-			return STATUS_ERROR;
-		}
-
-		ntfsck_check_lost_found(vol, root_ni);
-		ntfs_inode_close(root_ni);
-	}
-
-	/* check orphaned mft */
-	while (!ntfs_list_empty(&oc_list_head)) {
-		entry = ntfs_list_entry(oc_list_head.next, struct orphan_mft, oc_list);
-
-		check_failed("Found an orphaned file(mft no: %"PRId64"). "
-				"Try to add index entry", entry->mft_no);
-
-		if (ntfsck_ask_repair(vol)) {
-			/* close inode to avoid nested call of ntfs_inode_open() */
-
-			if (ntfsck_add_index_entry_orphaned_file(vol, entry)) {
-				/*
-				 * error returned.
-				 * inode is already freed and closed in that function,
-				 * do not need to call ntfs_inode_close()
-				 */
-				return STATUS_ERROR;
-			}
-			fsck_err_fixed();
-		} else {
-			ntfs_list_del(&entry->oc_list);
-			free(entry);
-		}
-	}
-	return STATUS_OK;
 }
 
 typedef u8 *(*get_bmp_func)(ntfs_volume *, s64);
 
-static int ntfsck_apply_bitmap(ntfs_volume *vol, ntfs_attr *na, get_bmp_func func)
+static int ntfsck_apply_bitmap(ntfs_volume *vol, ntfs_attr *na, get_bmp_func func, int direction)
 {
 	s64 count, pos, total, remain;
 	s64 rcnt, wcnt;
 	u8 *disk_bm;
 	u8 *fsck_bm;
-	int i;
-	unsigned long *ondisk_bmp;
-	unsigned long *fsck_bmp;
+	unsigned long i;
+	unsigned long *dbml;
+	unsigned long *fbml;
 
 	if (na != vol->lcnbmp_na && na != vol->mftbmp_na)
 		return STATUS_ERROR;
@@ -3729,14 +3889,17 @@ static int ntfsck_apply_bitmap(ntfs_volume *vol, ntfs_attr *na, get_bmp_func fun
 	/* apply btimap(fsck OR lcnbmp) to disk */
 	while (1) {
 		/* read bitmap from disk */
+		memset(disk_bm, 0, NTFS_BUF_SIZE);
 		rcnt = ntfs_attr_pread(na, pos, count, disk_bm);
 		if (rcnt == STATUS_ERROR) {
 			ntfs_log_error("Couldn't get $Bitmap $DATA");
 			break;
 		}
 
-		if (rcnt != count)
-			continue; /* read again */
+		if (rcnt != count) {
+			ntfs_log_error("Couldn't get $Bitmap, read count error\n");
+			break;
+		}
 
 		fsck_bm = func(vol, pos);
 
@@ -3745,18 +3908,40 @@ static int ntfsck_apply_bitmap(ntfs_volume *vol, ntfs_attr *na, get_bmp_func fun
 
 		/* ondisk lcnbmp OR fsck lcnbmp */
 		for (i = 0; i < (count / sizeof(unsigned long)); i++) {
-			ondisk_bmp = (unsigned long *)disk_bm + i;
-			fsck_bmp = (unsigned long *)fsck_bm + i;
-			*ondisk_bmp |= *fsck_bmp;
+			dbml = (unsigned long *)disk_bm + i;
+			fbml = (unsigned long *)fsck_bm + i;
+			if (*dbml != *fbml) {
+#ifdef DEBUG
+				printf("%s bitmap:\n", na->type == 0xb0 ? "MFT" : "LCN");
+				ntfs_log_info("1:difference pos(%"PRIu64":%lu:%"PRIu64
+						"): %0lx:%0lx\n", pos, i,
+						(pos + i) * sizeof(unsigned long) << 3, *dbml, *fbml);
+#endif
+				*dbml |= *fbml;
+#ifdef DEBUG
+				ntfs_log_info("2:difference pos(%"PRIu64":%lu:%"PRIu64
+						"): %0lx:%0lx\n\n", pos, i,
+						(pos + i) * sizeof(unsigned long) << 3, *dbml, *fbml);
+#endif
+			}
 		}
 
+		if (direction != 1)
+			ntfs_log_info("fsck/disk bitmap inode(%"PRIu64":%02x),bitmap pos(%"PRIu64":%"PRIu64
+					") are different\n", na->ni->mft_no, na->type, pos, count);
+
 		if (_ntfsck_ask_repair(vol, FALSE)) {
-			wcnt = ntfs_attr_pwrite(na, pos, count, disk_bm);
+			if (direction == 1)
+				wcnt = ntfs_attr_pwrite(na, pos, count, disk_bm);
+			else
+				wcnt = ntfs_attr_pwrite(na, pos, count, fsck_bm);
+
 			if (wcnt != count) {
 				ntfs_log_error("Cluster bitmap write failed, "
 						"pos:%"PRId64 "count:%"PRId64", writtne:%"PRId64"\n",
 						pos, count, wcnt);
-				/* TODO: continue? error? */
+				free(disk_bm);
+				return STATUS_ERROR;
 			}
 
 		}
@@ -3772,6 +3957,95 @@ next:
 	}
 
 	free(disk_bm);
+	return STATUS_OK;
+}
+
+static int ntfsck_check_orphaned_mft(ntfs_volume *vol)
+{
+	struct orphan_mft *entry = NULL;
+	struct ntfs_list_head *pos;
+	struct ntfs_list_head *tmp;
+	ntfs_inode *root_ni;
+	ntfs_inode *ni;
+
+	fsck_start_step("Check orphaned mft...\n");
+
+	ntfs_list_for_each_safe(pos, tmp, &oc_list_head) {
+		entry = ntfs_list_entry(pos, struct orphan_mft, oc_list);
+
+		ni = ntfsck_open_inode(vol, entry->mft_no);
+		if (!ni) {
+			ntfs_log_error("Failed to open orphaned inode(%"PRIu64"), check next\n",
+					entry->mft_no);
+			ntfsck_delete_orphaned_mft(vol, entry->mft_no);
+			ntfs_list_del(&entry->oc_list);
+			free(entry);
+			continue;
+		}
+
+		if (ni->attr_list) {
+			if (ntfsck_check_attr_list(ni))
+				goto err_check_inode;
+
+			if (ntfs_inode_attach_all_extents(ni))
+				goto err_check_inode;
+		}
+
+		ntfsck_update_lcn_bitmap(ni);
+		/* FALSE or TRUE? */
+		ntfsck_close_inode(ni);
+		continue;
+
+err_check_inode:
+		ntfs_log_error("Failed to previous check inode(%"PRIu64")\n", ni->mft_no);
+		ntfsck_delete_orphaned_inode(&ni);
+		ntfs_list_del(&entry->oc_list);
+		free(entry);
+		continue;
+	}
+
+	ntfsck_apply_bitmap(vol, vol->lcnbmp_na, ntfs_fsck_find_lcnbmp_block, 1);
+	ntfsck_apply_bitmap(vol, vol->mftbmp_na, ntfs_fsck_find_mftbmp_block, 1);
+
+	/* check lost found directory */
+	if (!vol->lost_found) {
+		root_ni = ntfsck_open_inode(vol, FILE_root);
+		if (!root_ni) {
+			ntfs_log_error("Failed to open root inode\n");
+			return STATUS_ERROR;
+		}
+
+		ntfsck_check_lost_found(vol, root_ni);
+		ntfsck_close_inode(root_ni);
+	}
+
+	/* check orphaned mft */
+	while (!ntfs_list_empty(&oc_list_head)) {
+		entry = ntfs_list_entry(oc_list_head.next, struct orphan_mft, oc_list);
+
+		check_failed("Found an orphaned file(mft no: %"PRId64"). "
+				"Try to add index entry", entry->mft_no);
+
+		if (ntfsck_ask_repair(vol)) {
+			if (ntfsck_add_index_entry_orphaned_file(vol, entry)) {
+				/*
+				 * error returned.
+				 * inode is already freed and closed in that function,
+				 */
+				printf("failed to add entry(%"PRIu64") orphaned file\n", entry->mft_no);
+				return STATUS_ERROR;
+			}
+			fsck_err_fixed();
+		} else {
+			ntfs_list_del(&entry->oc_list);
+			free(entry);
+		}
+	}
+
+	ntfsck_apply_bitmap(vol, vol->lcnbmp_na, ntfs_fsck_find_lcnbmp_block, 0);
+	ntfsck_apply_bitmap(vol, vol->mftbmp_na, ntfs_fsck_find_mftbmp_block, 0);
+
+	fsck_end_step();
 	return STATUS_OK;
 }
 
@@ -3998,22 +4272,19 @@ conflict_option:
 	if (ntfsck_replay_log(vol))
 		goto err_out;
 
-	if (ntfsck_scan_index_entries(vol)) {
-		ntfs_log_error("Stop processing fsck due to critical problems\n");
-		goto err_out;
-	}
-
 	mrec_unused_chk = ntfs_malloc(vol->sector_size);
 	if (!mrec_unused_chk) {
 		ntfs_log_perror("Couldn't allocate mrec_unused_chk buffer");
 		goto err_out;
 	}
 
+	if (ntfsck_scan_index_entries(vol)) {
+		ntfs_log_error("Stop processing fsck due to critical problems\n");
+		goto err_out;
+	}
+
 	/* apply mft bitmap & cluster bitmap to disk */
 	ntfsck_check_mft_records(vol);
-
-	ntfsck_apply_bitmap(vol, vol->lcnbmp_na, ntfs_fsck_find_lcnbmp_block);
-	ntfsck_apply_bitmap(vol, vol->mftbmp_na, ntfs_fsck_find_mftbmp_block);
 
 	ntfsck_check_orphaned_mft(vol);
 

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -2927,7 +2927,7 @@ err_out:
 }
 
 /*
- * set bitmap of current index context's all parent vcn.
+ * set bitmap of current index allocation's all parent vcn.
  */
 static int ntfsck_set_index_bitmap(ntfs_inode *ni, ntfs_index_context *ictx,
 		ntfs_attr *bm_na)
@@ -2941,16 +2941,29 @@ static int ntfsck_set_index_bitmap(ntfs_inode *ni, ntfs_index_context *ictx,
 	if (!ictx->ib)
 		return STATUS_ERROR;
 
+	if (ni != ictx->ni)
+		ntfs_log_error("inode(%p) and ictx->ni(%p) are different\n",
+				ni, ictx->ni);
+
 	ih = &ictx->ib->index;
 	if ((ih->ih_flags & NODE_MASK) != LEAF_NODE)
 		return STATUS_OK;
 
+	vcn = ictx->parent_vcn[ictx->pindex];
 	pos = (vcn << ictx->vcn_size_bits) / ictx->block_size;
 	bpos = pos / 8;
 
-	if (bm_na->data_size < bpos + 1)
+	if (ictx->ni->fsck_ibm_size < bpos + 1) {
 		ictx->ni->fsck_ibm = ntfs_realloc(ictx->ni->fsck_ibm,
 				(bm_na->data_size + 8) & ~7);
+		if (!ictx->ni->fsck_ibm) {
+			ntfs_log_perror("Failed to realloc fsck_ibm(%"PRId64")",
+					bm_na->data_size);
+			return STATUS_ERROR;
+		}
+
+		ictx->ni->fsck_ibm_size = (bm_na->data_size + 8) & ~7;
+	}
 
 	for (i = ictx->pindex; i > 0; i--) {
 		vcn = ictx->parent_vcn[i];
@@ -2980,8 +2993,22 @@ static int ntfsck_check_index_bitmap(ntfs_inode *ni, ntfs_attr *bm_na)
 		return STATUS_ERROR;
 	}
 
-	if (ibm_size != bm_na->data_size)
-		ntfs_log_info("\nbitmap changed during check_inodes\n\n");
+	if (ibm_size != ni->fsck_ibm_size) {
+		/* FIXME: if ni->fsck_ibm_size is larget than ibm_size,
+		 * it could allocate cluster in ntfs_attr_pwrite() */
+		ntfs_log_info("\n\nBitmap changed during check_inodes\n");
+		check_failed("Inode(%"PRIu64") $IA bitmap size are different. Fix it", ni->mft_no);
+		if (ntfsck_ask_repair(vol)) {
+			/* TODO: should modify while loop for insufficient write() */
+			wcnt = ntfs_attr_pwrite(bm_na, 0, ni->fsck_ibm_size, ni->fsck_ibm);
+			if (wcnt == ni->fsck_ibm_size)
+				fsck_err_fixed();
+			else
+				ntfs_log_error("Can't write $BITMAP(%"PRId64") "
+						"of inode(%"PRIu64")\n", wcnt, ni->mft_no);
+		}
+		goto out;
+	}
 
 	if (memcmp(ni->fsck_ibm, ni_ibm, ibm_size)) {
 #ifdef DEBUG
@@ -3001,6 +3028,7 @@ static int ntfsck_check_index_bitmap(ntfs_inode *ni, ntfs_attr *bm_na)
 #endif
 		check_failed("Inode(%"PRIu64") $IA bitmap different. Fix it", ni->mft_no);
 		if (ntfsck_ask_repair(vol)) {
+			/* TODO: should reimpelemt with loop for insufficient write */
 			wcnt = ntfs_attr_pwrite(bm_na, 0, ibm_size, ni->fsck_ibm);
 			if (wcnt == ibm_size)
 				fsck_err_fixed();
@@ -3010,6 +3038,7 @@ static int ntfsck_check_index_bitmap(ntfs_inode *ni, ntfs_attr *bm_na)
 		}
 	}
 
+out:
 	free(ni_ibm);
 
 	return STATUS_OK;
@@ -3532,6 +3561,7 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 					ntfs_log_perror("Failed to allocate fsck_ibm memory\n");
 					goto err_continue;
 				}
+				dir_ni->fsck_ibm_size = bm_na->allocated_size;
 			}
 		}
 
@@ -3611,6 +3641,7 @@ err_continue:
 		if (dir_ni && dir_ni->fsck_ibm) {
 			free(dir_ni->fsck_ibm);
 			dir_ni->fsck_ibm = NULL;
+			dir_ni->fsck_ibm_size = 0;
 		}
 
 		ntfsck_update_lcn_bitmap(dir_ni);

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -146,6 +146,13 @@ struct rl_size {
 };
 
 NTFS_LIST_HEAD(ntfs_dirs_list);
+NTFS_LIST_HEAD(oc_list_head); /* Orphaned mft records Candidate list */
+
+struct orphan_mft {
+	u64 mft_no;
+	struct ntfs_list_head oc_list;	/* Orphan Candidate list */
+	struct ntfs_list_head ot_list;	/* Orphan Tree list */
+} orphan_mft_t;
 
 int parse_count = 1;
 
@@ -238,117 +245,6 @@ static int ntfsck_check_backup_boot_sector(ntfs_volume *vol, s64 cl_pos)
 	return 0;
 }
 
-static int fsck_get_lcnbmp_bit(ntfs_volume *vol, LCN lcn)
-{
-	u8 *flb;
-	s64 bm_pos = lcn >> NTFSCK_BYTE_TO_BITS;
-	s64 bm_off;
-	s64 bm_i = FB_ROUND_DOWN(bm_pos);
-
-	flb = ntfs_fsck_find_lcnbmp_block(vol, bm_pos);
-	bm_off = lcn - (bm_i << (NTFS_BUF_SIZE_BITS + NTFSCK_BYTE_TO_BITS));
-
-	return ntfs_bit_get(flb, bm_off);
-}
-
-static int ntfs_get_lcnbmp_bit(ntfs_volume *vol, LCN lcn)
-{
-	u8 flb;
-	s64 bm_pos = lcn >> NTFSCK_BYTE_TO_BITS;
-
-	ntfs_attr_pread(vol->lcnbmp_na, bm_pos, 1, &flb);
-	return ntfs_bit_get(&flb, lcn & 7);
-}
-
-static void ntfsck_check_orphaned_clusters(ntfs_volume *vol)
-{
-	s64 pos = 0, wpos, i, count, written;
-	s64 clear_lcn_cnt = 0;
-	s64 set_lcn_cnt = 0;
-	BOOL backup_boot_check = FALSE, repair = FALSE;
-	u8 bm[NTFS_BUF_SIZE], *flb;
-
-	fsck_start_step("Check cluster bitmap...\n");
-
-	while (1) {
-		wpos = pos;
-		count = ntfs_attr_pread(vol->lcnbmp_na, pos, NTFS_BUF_SIZE, bm);
-		if (count == -1) {
-			ntfs_log_error("Couldn't get $Bitmap $DATA");
-			break;
-		}
-
-		if (count == 0) {
-			/* the backup bootsector need not be accounted for */
-			if (((vol->nr_clusters + 7) >> 3) > pos)
-				ntfs_log_error("$Bitmap size is smaller than expected (%"PRId64" < %"PRId64")\n",
-						pos, vol->lcnbmp_na->data_size);
-			break;
-		}
-
-		flb = ntfs_fsck_find_lcnbmp_block(vol, pos);
-
-		for (i = 0; i < count; i++, pos++) {
-			s64 cl;  /* current cluster */
-
-			if (flb[i] == bm[i])
-				continue;
-
-			for (cl = pos * 8; cl < (pos + 1) * 8; cl++) {
-				char lbmp_bit, fsck_bmp_bit;
-
-				if (cl >= vol->nr_clusters)
-					break;
-
-				lbmp_bit = ntfs_bit_get(bm, i * 8 + cl % 8);
-				fsck_bmp_bit = ntfs_bit_get(flb, i * 8 + cl % 8);
-				if (fsck_bmp_bit != lbmp_bit) {
-					if (!fsck_bmp_bit && backup_boot_check == FALSE &&
-					    cl == vol->nr_clusters / 2) {
-						if (!ntfsck_check_backup_boot_sector(vol, cl)) {
-							backup_boot_check = TRUE;
-							continue;
-						}
-					}
-
-					if (fsck_bmp_bit == 0 && lbmp_bit == 1) {
-						fsck_err_found();
-						clear_lcn_cnt++;
-						ntfs_log_trace("Found orphaned cluster bit(%"PRId64") "
-								"in $Bitmap. Clear it\n", cl);
-					} else {
-						fsck_err_found();
-						set_lcn_cnt++;
-						ntfs_log_trace("Found missing cluster bit(%"PRId64") "
-								"in $Bitmap. Set it\n", cl);
-					}
-					if (_ntfsck_ask_repair(vol, FALSE)) {
-						ntfs_bit_set(bm, i * 8 + cl % 8, !lbmp_bit);
-						repair = TRUE;
-						fsck_err_fixed();
-					}
-				}
-			}
-		}
-
-		if (repair == TRUE) {
-			written = ntfs_attr_pwrite(vol->lcnbmp_na, wpos, count, bm);
-			if (written != count)
-				ntfs_log_error("lcn bitmap write failed, pos:%"PRId64 ", "
-						"count:%"PRId64", written:%"PRId64"\n",
-					wpos, count, written);
-			repair = FALSE;
-		}
-	}
-
-	if (clear_lcn_cnt || set_lcn_cnt)
-		ntfs_log_info("Total lcn bitmap clear:%"PRId64", "
-			      "Total missing lcn bitmap:%"PRId64"\n",
-			      clear_lcn_cnt, set_lcn_cnt);
-
-	fsck_end_step();
-}
-
 static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 {
 	ntfs_attr_search_ctx *actx;
@@ -432,17 +328,6 @@ static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
 					rl[i].length);
 
 			ntfs_fsck_set_lcnbmp_range(vol, rl[i].lcn, rl[i].length, set_bit, TRUE);
-
-			if (_ntfsck_ask_repair(vol, FALSE)) {
-				int ret = 0;
-
-				if (set_bit == 0)
-					ret = ntfs_bitmap_clear_run(vol->lcnbmp_na, rl[i].lcn, rl[i].length);
-				else
-					ret = ntfs_bitmap_set_run(vol->lcnbmp_na, rl[i].lcn, rl[i].length);
-				if (ret)
-					ntfs_log_error("Error: set/clear ntfs lcn bitmap\n");
-			}
 
 			rsize = rl[i].length << vol->cluster_size_bits;
 			rl_data_size += rsize;
@@ -927,37 +812,46 @@ static int ntfsck_remove_filename(ntfs_inode *ni, FILE_NAME_ATTR *fn)
 	return STATUS_OK;
 }
 
+/* get entry of orphan mft candidate list */
+static struct orphan_mft *ntfsck_get_oc_list_entry(struct ntfs_list_head *head, u64 mft_no)
+{
+	struct orphan_mft *entry = NULL;
+	struct ntfs_list_head *pos;
 
-static int ntfsck_add_index_entry_orphaned_file(ntfs_volume *vol, s64 mft_no)
+	ntfs_list_for_each(pos, head) {
+		entry = ntfs_list_entry(pos, struct orphan_mft, oc_list);
+		if (entry->mft_no == mft_no)
+			return entry;
+	}
+	return NULL;
+}
+
+static int ntfsck_add_index_entry_orphaned_file(ntfs_volume *vol, struct orphan_mft *e)
 {
 	ntfs_attr_search_ctx *ctx = NULL;
 	FILE_NAME_ATTR *fn;
 	ntfs_inode *parent_ni = NULL;
 	ntfs_inode *ni = NULL;
 	u64 parent_no;
-	struct orphan_mft {
-		s64 mft_no;
-		struct ntfs_list_head list;
-	};
-	NTFS_LIST_HEAD(ntfs_orphan_list);
-	struct orphan_mft *of;
+	struct orphan_mft *entry;
+	NTFS_LIST_HEAD(ot_list_head);
 	int ret = STATUS_OK;
 	int nlink = 0;
 
+	if (!e)
+		return -EINVAL;
+
+	entry = e;
 stack_of:
-	of = (struct orphan_mft *)calloc(1, sizeof(struct orphan_mft));
-	if (!of)
-		return -ENOMEM;
+	ntfs_list_del(&entry->oc_list);
+	ntfs_list_add(&entry->ot_list, &ot_list_head);
 
-	of->mft_no = mft_no;
-	ntfs_list_add(&of->list, &ntfs_orphan_list);
+	while (!ntfs_list_empty(&ot_list_head)) {
+		entry = ntfs_list_entry(ot_list_head.next, struct orphan_mft, ot_list);
 
-	while (!ntfs_list_empty(&ntfs_orphan_list)) {
-		of = ntfs_list_entry(ntfs_orphan_list.next, struct orphan_mft, list);
-
-		ni = ntfs_inode_open(vol, of->mft_no);
+		ni = ntfs_inode_open(vol, entry->mft_no);
 		if (!ni) {
-			ntfsck_delete_orphaned_mft(vol, of->mft_no);
+			ntfsck_delete_orphaned_mft(vol, entry->mft_no);
 			ret = STATUS_OK;
 			goto next_inode;
 		}
@@ -991,25 +885,10 @@ stack_of:
 			 */
 
 			if (!ntfs_fsck_mftbmp_get(vol, MREF(parent_no))) {
-				if (check_mftrec_in_use(vol, MREF(parent_no), 1)) {
-					struct ntfs_list_head *pos;
-					struct orphan_mft *tof;
+				struct orphan_mft *p_entry;
 
-					/*
-					 * Lookup parent in list to avoid infinite loop
-					 * issue by circular parent number.
-					 * TODO: change the linear lookup with hash table.
-					 */
-					ntfs_list_for_each(pos, &ntfs_orphan_list) {
-						tof = ntfs_list_entry(pos, struct orphan_mft, list);
-						if (tof->mft_no == MREF(parent_no)) {
-							ntfs_log_error("Found same parent number(%"PRIu64
-									") in orphan list\n",
-									MREF(parent_no));
-							goto add_to_lostfound;
-						}
-					}
-
+				p_entry = ntfsck_get_oc_list_entry(&oc_list_head, MREF(parent_no));
+				if (p_entry) {
 					/*
 					 * Parent is also orphaned file!
 					 */
@@ -1018,14 +897,10 @@ stack_of:
 					ntfs_attr_put_search_ctx(ctx);
 					ctx = NULL;
 					ntfs_inode_close(ni);
-					mft_no = MREF(parent_no);
+					entry = p_entry;
 					goto stack_of;
 				}
-				/*
-				 * Parent inode is deleted!
-				 */
-				ntfs_log_verbose("!! FOUND Deleted parent inode(%"PRIu64"), "
-						"inode(%"PRIu64")\n", MREF(parent_no), ni->mft_no);
+
 				goto add_to_lostfound;
 			}
 
@@ -1114,10 +989,9 @@ next_inode:
 			ntfs_inode_close(ni);
 			ni = NULL;
 		}
-
-		ntfs_list_del(&of->list);
-		free(of);
-	} /* while (!ntfs_list_empty(&ntfs_orphan_list)) */
+		ntfs_list_del(&entry->ot_list);
+		free(entry);
+	} /* while (!ntfs_list_empty(&ot_list_head)) */
 
 	return ret;
 }
@@ -1163,6 +1037,7 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 	int is_used;
 	int always_exist_sys_meta_num = vol->major_ver >= 3 ? 11 : 10;
 	ntfs_inode *ni;
+	struct orphan_mft *of;
 
 	is_used = utils_mftrec_in_use(vol, mft_num);
 	if (is_used < 0) {
@@ -1179,14 +1054,14 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 		if (ntfs_fsck_mftbmp_get(vol, mft_num)) {
 			ni = ntfs_inode_open(vol, mft_num);
 			if (ni) {
-				ntfsck_set_mft_record_bitmap(ni, TRUE);
+				ntfsck_set_mft_record_bitmap(ni, FALSE);
 				ntfs_inode_close(ni);
 				return;
 			}
 		}
 
 		ntfsck_check_mft_record_unused(vol, mft_num);
-		/* TODO: below function should use mft bitmap cache */
+		/* TODO: below function is needed? */
 		ntfs_fsck_mftbmp_clear(vol, mft_num);
 		return;
 	}
@@ -1227,24 +1102,16 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 		return;
 	}
 
-	check_failed("Found an orphaned file(mft no: %"PRId64"). "
-			"Try to add index entry", mft_num);
-	if (ntfsck_ask_repair(vol)) {
-		/* close inode to avoid nested call of ntfs_inode_open() */
-		ntfs_inode_close(ni);
-
-		if (ntfsck_add_index_entry_orphaned_file(vol, mft_num)) {
-			/*
-			 * error returned.
-			 * inode is already freed and closed in that function,
-			 * do not need to call ntfs_inode_close()
-			 */
-			return;
-		}
-		fsck_err_fixed();
-	} else {
-		ntfs_inode_close(ni);
+	of = (struct orphan_mft *)calloc(1, sizeof(struct orphan_mft));
+	if (!of) {
+		ntfs_log_error("orphan_mft malloc failed");
+		return;
 	}
+
+	of->mft_no = mft_num;
+	ntfs_list_add(&of->oc_list, &oc_list_head);
+
+	ntfs_inode_close(ni);
 }
 
 #if DEBUG
@@ -3223,6 +3090,7 @@ create_lf:
 			ntfs_log_error("Failed to open/check '%s'\n", FILENAME_LOST_FOUND);
 	} else {
 		vol->lost_found = lf_ni->mft_no;
+		ntfsck_update_lcn_bitmap(lf_ni);
 		ntfs_inode_close(lf_ni);
 	}
 }
@@ -3288,8 +3156,6 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 		ntfs_log_error("Failed to open root inode\n");
 		return -1;
 	}
-
-	ntfsck_check_lost_found(vol, dir_ni);
 
 	dir->mft_no = dir_ni->mft_no;
 	ntfs_inode_close(dir_ni);
@@ -3504,12 +3370,6 @@ static void ntfsck_check_mft_records(ntfs_volume *vol)
 	s64 mft_num, nr_mft_records;
 	ntfs_inode *lost_found = NULL;
 
-	mrec_unused_chk = ntfs_malloc(vol->sector_size);
-	if (!mrec_unused_chk) {
-		ntfs_log_perror("Couldn't allocate mrec_unused_chk buffer");
-		return;
-	}
-
 	fsck_start_step("Check mft entries in volume...\n");
 
 	// For each mft record, verify that it contains a valid file record.
@@ -3534,18 +3394,18 @@ static void ntfsck_check_mft_records(ntfs_volume *vol)
 	 */
 	ntfsck_update_lcn_bitmap(vol->mft_ni);
 
-	lost_found = ntfs_inode_open(vol, vol->lost_found);
-	if (!lost_found) {
-		ntfs_log_error("Can't open lost+found directory\n");
-		return;
-	} else {
-		ntfsck_update_lcn_bitmap(lost_found);
-		ntfs_inode_close(lost_found);
+	if (vol->lost_found) {
+		lost_found = ntfs_inode_open(vol, vol->lost_found);
+		if (!lost_found) {
+			ntfs_log_error("Can't open lost+found directory\n");
+			return;
+		} else {
+			ntfsck_update_lcn_bitmap(lost_found);
+			ntfs_inode_close(lost_found);
+		}
 	}
 
 	fsck_end_step();
-
-	free(mrec_unused_chk);
 }
 
 static int ntfsck_reset_dirty(ntfs_volume *vol)
@@ -3822,6 +3682,126 @@ close_inode:
 	return ret;
 }
 
+static int ntfsck_check_orphaned_mft(ntfs_volume *vol)
+{
+	struct orphan_mft *entry;
+	ntfs_inode *root_ni;
+
+	/* check lost found directory */
+	if (!vol->lost_found) {
+		root_ni = ntfs_inode_open(vol, FILE_root);
+		if (!root_ni) {
+			ntfs_log_error("Failed to open root inode\n");
+			return STATUS_ERROR;
+		}
+
+		ntfsck_check_lost_found(vol, root_ni);
+		ntfs_inode_close(root_ni);
+	}
+
+	/* check orphaned mft */
+	while (!ntfs_list_empty(&oc_list_head)) {
+		entry = ntfs_list_entry(oc_list_head.next, struct orphan_mft, oc_list);
+
+		check_failed("Found an orphaned file(mft no: %"PRId64"). "
+				"Try to add index entry", entry->mft_no);
+
+		if (ntfsck_ask_repair(vol)) {
+			/* close inode to avoid nested call of ntfs_inode_open() */
+
+			if (ntfsck_add_index_entry_orphaned_file(vol, entry)) {
+				/*
+				 * error returned.
+				 * inode is already freed and closed in that function,
+				 * do not need to call ntfs_inode_close()
+				 */
+				return STATUS_ERROR;
+			}
+			fsck_err_fixed();
+		} else {
+			ntfs_list_del(&entry->oc_list);
+			free(entry);
+		}
+	}
+	return STATUS_OK;
+}
+
+typedef u8 *(*get_bmp_func)(ntfs_volume *, s64);
+
+static int ntfsck_apply_bitmap(ntfs_volume *vol, ntfs_attr *na, get_bmp_func func)
+{
+	s64 count, pos, total, remain;
+	s64 rcnt, wcnt;
+	u8 *disk_bm;
+	u8 *fsck_bm;
+	int i;
+	unsigned long *ondisk_bmp;
+	unsigned long *fsck_bmp;
+
+	if (na != vol->lcnbmp_na && na != vol->mftbmp_na)
+		return STATUS_ERROR;
+
+	disk_bm = ntfs_calloc(NTFS_BUF_SIZE);
+	if (!disk_bm)
+		return STATUS_ERROR;
+
+	pos = 0;
+	count = NTFS_BUF_SIZE;
+	total = na->data_size;
+	remain = total;
+
+	if (total < count)
+		count = total;
+
+	/* apply btimap(fsck OR lcnbmp) to disk */
+	while (1) {
+		/* read bitmap from disk */
+		rcnt = ntfs_attr_pread(na, pos, count, disk_bm);
+		if (rcnt == STATUS_ERROR) {
+			ntfs_log_error("Couldn't get $Bitmap $DATA");
+			break;
+		}
+
+		if (rcnt != count)
+			continue; /* read again */
+
+		fsck_bm = func(vol, pos);
+
+		if (!memcmp(fsck_bm, disk_bm, count))
+			goto next;
+
+		/* ondisk lcnbmp OR fsck lcnbmp */
+		for (i = 0; i < (count / sizeof(unsigned long)); i++) {
+			ondisk_bmp = (unsigned long *)disk_bm + i;
+			fsck_bmp = (unsigned long *)fsck_bm + i;
+			*ondisk_bmp |= *fsck_bmp;
+		}
+
+		if (_ntfsck_ask_repair(vol, FALSE)) {
+			wcnt = ntfs_attr_pwrite(na, pos, count, disk_bm);
+			if (wcnt != count) {
+				ntfs_log_error("Cluster bitmap write failed, "
+						"pos:%"PRId64 "count:%"PRId64", writtne:%"PRId64"\n",
+						pos, count, wcnt);
+				/* TODO: continue? error? */
+			}
+
+		}
+
+next:
+		pos += count;
+		remain -= count;
+		if (remain && remain < NTFS_BUF_SIZE)
+			count = remain;
+
+		if (!remain)
+			break;
+	}
+
+	free(disk_bm);
+	return STATUS_OK;
+}
+
 /**
  * main - Does just what C99 claim it does.
  *
@@ -3995,9 +3975,21 @@ conflict_option:
 		goto err_out;
 	}
 
+	mrec_unused_chk = ntfs_malloc(vol->sector_size);
+	if (!mrec_unused_chk) {
+		ntfs_log_perror("Couldn't allocate mrec_unused_chk buffer");
+		goto err_out;
+	}
+
+	/* apply mft bitmap & cluster bitmap to disk */
 	ntfsck_check_mft_records(vol);
 
-	ntfsck_check_orphaned_clusters(vol);
+	ntfsck_apply_bitmap(vol, vol->lcnbmp_na, ntfs_fsck_find_lcnbmp_block);
+	ntfsck_apply_bitmap(vol, vol->mftbmp_na, ntfs_fsck_find_mftbmp_block);
+
+	ntfsck_check_orphaned_mft(vol);
+
+	free(mrec_unused_chk);
 
 err_out:
 	errors = fsck_errors - fsck_fixes;

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -199,7 +199,7 @@ static FILE_NAME_ATTR *ntfsck_find_file_name_attr(ntfs_inode *ni,
 		FILE_NAME_ATTR *ie_fn, ntfs_attr_search_ctx *actx);
 static int ntfsck_check_directory(ntfs_inode *ni);
 static int ntfsck_check_file(ntfs_inode *ni);
-static int ntfsck_setbit_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
+static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
 		struct rl_size *rls, BOOL lcnbmp_set);
 static int ntfsck_check_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 		ntfs_index_context *ictx);
@@ -437,7 +437,7 @@ static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 static void ntfsck_clear_attr_lcnbmp(ntfs_attr *na)
 {
 	ntfs_attr_map_whole_runlist(na);
-	ntfsck_setbit_runlist(na->ni, na->rl, 0, NULL, TRUE);
+	ntfsck_check_runlist(na->ni, na->rl, 0, NULL, TRUE);
 }
 
 /*
@@ -452,7 +452,7 @@ static void ntfsck_clear_attr_lcnbmp(ntfs_attr *na)
  * @rls : structure for runlist length, it contains allocated size and
  *	  real allocated size. it may be NULL, don't return calculated size.
  */
-static int ntfsck_setbit_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
+static int ntfsck_check_runlist(ntfs_inode *ni, runlist *rl, u8 set_bit,
 		struct rl_size *rls, BOOL lcnbmp_set)
 {
 	ntfs_volume *vol;
@@ -524,7 +524,7 @@ static void ntfsck_check_non_resident_cluster(ntfs_inode *ni, u8 set_bit)
 			continue;
 		}
 
-		if (ntfsck_setbit_runlist(ni, rl, set_bit, NULL, TRUE)) {
+		if (ntfsck_check_runlist(ni, rl, set_bit, NULL, TRUE)) {
 			ntfs_log_error("Failed to check and setbit runlist. "
 					"Leaving inconsistent metadata.\n");
 			/* continue */
@@ -2096,8 +2096,8 @@ out:
  * (TODO) more documentation.
  *
  */
-static int ntfsck_decompose_setbit_runlist(ntfs_attr *na, struct rl_size *rls,
-		BOOL *need_fix)
+static int ntfsck_check_attr_runlist(ntfs_attr *na, struct rl_size *rls,
+		BOOL *need_fix, int set_bit)
 {
 	runlist *rl = NULL;
 	int ret = STATUS_OK;
@@ -2118,7 +2118,7 @@ static int ntfsck_decompose_setbit_runlist(ntfs_attr *na, struct rl_size *rls,
 	ntfs_dump_runlist(rl);
 #endif
 
-	ret = ntfsck_setbit_runlist(na->ni, na->rl, 1, rls, FALSE);
+	ret = ntfsck_check_runlist(na->ni, na->rl, set_bit, rls, FALSE);
 	if (ret)
 		return STATUS_ERROR;
 
@@ -2159,7 +2159,7 @@ static int ntfsck_update_runlist(ntfs_attr *na, s64 new_size)
 }
 
 static int ntfsck_check_non_resident_attr(ntfs_attr *na,
-		ntfs_attr_search_ctx *actx, struct rl_size *out_rls)
+		ntfs_attr_search_ctx *actx, struct rl_size *out_rls, int set_bit)
 {
 	BOOL need_fix = FALSE;
 	ntfs_volume *vol;
@@ -2185,7 +2185,7 @@ static int ntfsck_check_non_resident_attr(ntfs_attr *na,
 	a =  actx->attr;
 
 	/* check cluster runlist and set bitmap */
-	if (ntfsck_decompose_setbit_runlist(na, &rls, &need_fix)) {
+	if (ntfsck_check_attr_runlist(na, &rls, &need_fix, set_bit)) {
 		ntfs_log_error("Failed to get non-resident attribute(%d) "
 				"in directory(%"PRId64")", na->type, ni->mft_no);
 		return STATUS_ERROR;
@@ -2464,7 +2464,7 @@ static int ntfsck_set_mft_record_bitmap(ntfs_inode *ni, BOOL ondisk_mft_bmp_set)
 /*
  * check all cluster runlist of non-resident attributes of a inode
  */
-static int ntfsck_check_inode_non_resident(ntfs_inode *ni)
+static int ntfsck_check_inode_non_resident(ntfs_inode *ni, int set_bit)
 {
 	ntfs_attr_search_ctx *ctx;
 	ntfs_attr *na;
@@ -2490,7 +2490,7 @@ static int ntfsck_check_inode_non_resident(ntfs_inode *ni)
 			return STATUS_ERROR;
 		}
 
-		ret = ntfsck_check_non_resident_attr(na, ctx, NULL);
+		ret = ntfsck_check_non_resident_attr(na, ctx, NULL, set_bit);
 		ntfs_attr_close(na);
 		if (ret)
 			continue;
@@ -2629,7 +2629,7 @@ static int ntfsck_check_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 	if (ntfsck_check_inode_fields(ictx->ni, ni, ie))
 		goto err_out;
 
-	ret = ntfsck_check_inode_non_resident(ni);
+	ret = ntfsck_check_inode_non_resident(ni, 1);
 	if (ret)
 		goto err_out;
 
@@ -2673,7 +2673,7 @@ static int ntfsck_check_system_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 		ntfs_inode_attach_all_extents(ni);
 	}
 
-	ret = ntfsck_check_inode_non_resident(ni);
+	ret = ntfsck_check_inode_non_resident(ni, 1);
 	if (ret)
 		goto err_out;
 
@@ -3343,7 +3343,7 @@ static ntfs_inode *ntfsck_check_root_inode(ntfs_volume *vol)
 			goto err_out;
 	}
 
-	if (ntfsck_check_inode_non_resident(ni)) {
+	if (ntfsck_check_inode_non_resident(ni, 1)) {
 		ntfs_log_error("Failed to check non resident attribute of root directory.\n");
 		exit(STATUS_ERROR);
 	}
@@ -3727,7 +3727,7 @@ static int ntfsck_validate_system_file(ntfs_inode *ni)
 		}
 
 		/* Check cluster run of $DATA attribute */
-		if (ntfsck_setbit_runlist(ni, vol->lcnbmp_na->rl, 1, NULL, FALSE)) {
+		if (ntfsck_check_runlist(ni, vol->lcnbmp_na->rl, 1, NULL, FALSE)) {
 			ntfs_log_error("Failed to check and setbit runlist. "
 				       "Leaving inconsistent metadata.\n");
 			return -EIO;


### PR DESCRIPTION
- fix index entry length corruption

- check cluster duplication, and remove possibility of cluster duplication in fsck
- remove unnecessary function.
- change lost+found added filename renaming policy
