### PR TITLE
ntfsck: fix runlist cluster number exceeds the maximum cluster number

### DIFF
--- a/libntfs/acls.c
+++ b/libntfs/acls.c
@@ -4399,6 +4399,7 @@ struct MAPPING *ntfs_do_user_mapping(struct MAPLIST *firstitem)
 			    && !ntfs_valid_pattern(sid)) {
 				ntfs_log_error("Bad implicit SID pattern %s\n",
 					item->sidstr);
+				free(sid);
 				sid = (SID*)NULL;
 				}
 			if (sid) {
@@ -4416,6 +4417,8 @@ struct MAPPING *ntfs_do_user_mapping(struct MAPLIST *firstitem)
 						firstmapping = mapping;
 					lastmapping = mapping;
 				}
+				free(sid);
+				sid = (SID*)NULL;
 			}
 		}
 	}
@@ -4444,7 +4447,7 @@ struct MAPPING *ntfs_do_group_mapping(struct MAPLIST *firstitem)
 	BOOL secondstep;
 	BOOL ok;
 	int step;
-	SID *sid;
+	SID *sid = NULL;
 	int gid;
 
 	firstmapping = (struct MAPPING*)NULL;
@@ -4475,6 +4478,8 @@ struct MAPPING *ntfs_do_group_mapping(struct MAPLIST *firstitem)
 			if (ok
 			    && (gid
 				 || (!item->uidstr[0] && !item->gidstr[0]))) {
+				if (sid)
+					free(sid);
 				sid = encodesid(item->sidstr);
 				if (sid && !item->uidstr[0] && !item->gidstr[0]
 				    && !ntfs_valid_pattern(sid)) {

--- a/libntfs/compress.c
+++ b/libntfs/compress.c
@@ -1952,10 +1952,13 @@ int ntfs_compressed_close(ntfs_attr *na, runlist_element *wrl, s64 offs,
 				}
 			} else
 				done = TRUE;
-			free(inbuf);
 		}
 	}
 	if (done && !valid_compressed_run(na,wrl,TRUE,"end compressed close"))
 		done = FALSE;
+
+	if (inbuf)
+		free(inbuf);
+
 	return (!done);
 }

--- a/libntfs/dir.c
+++ b/libntfs/dir.c
@@ -587,9 +587,11 @@ u64 ntfs_inode_lookup_by_mbsname(ntfs_inode *dir_ni, const char *name)
 			{
 				/* Generate unicode name. */
 			uname_len = ntfs_mbstoucs(cached_name, &uname);
-			if (uname_len >= 0)
+			if (uname_len >= 0) {
 				inum = ntfs_inode_lookup_by_name(dir_ni,
 						uname, uname_len);
+				free(uname);
+			}
 			else
 				inum = (s64)-1;
 		}

--- a/libntfs/index.c
+++ b/libntfs/index.c
@@ -1830,7 +1830,8 @@ out:
 static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 			   INDEX_ENTRY *ie, INDEX_BLOCK *ib)
 {
-	INDEX_ENTRY *ie_roam, *ie_dup;
+	INDEX_ENTRY *ie_roam = NULL;
+	INDEX_ENTRY *ie_dup = NULL;
 	int freed_space;
 	BOOL full;
 	int ret = STATUS_ERROR;

--- a/libntfs/reparse.c
+++ b/libntfs/reparse.c
@@ -607,6 +607,7 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
 				strcat(fulltarget,target);
 			}
 			free(target);
+			target = NULL;
 		}
 	}
 			/*
@@ -641,6 +642,8 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
 		}
 		if (target)
 			free(target);
+		if (sz)
+			ntfs_attr_name_free(&sz);
 	}
 	return (fulltarget);
 }
@@ -716,6 +719,7 @@ char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, int count,
 				strcat(fulltarget,target);
 			}
 			free(target);
+			target = NULL;
 		}
 	}
 			/*

--- a/libntfs/unistr.c
+++ b/libntfs/unistr.c
@@ -1453,6 +1453,8 @@ ntfschar *ntfs_str2ucs(const char *s, int *len)
 		return NULL;
 	}
 	if (!ucs || !*len) {
+		if (ucs)
+			free(ucs);
 		ucs  = AT_UNNAMED;
 		*len = 0;
 	}

--- a/libntfs/volume.c
+++ b/libntfs/volume.c
@@ -495,7 +495,7 @@ error_exit:
 static int ntfs_mftmirr_load(ntfs_volume *vol)
 {
 	int err;
-	char *filename;
+	char *filename = NULL;
 	FILE_NAME_ATTR *fn;
 	ntfs_attr_search_ctx *ctx = NULL;
 
@@ -553,6 +553,8 @@ static int ntfs_mftmirr_load(ntfs_volume *vol)
 
 error_exit:
 	err = errno;
+	if (filename)
+		ntfs_attr_name_free(&filename);
 	if (ctx)
 		ntfs_attr_put_search_ctx(ctx);
 	if (vol->mftmirr_na) {
@@ -1600,6 +1602,7 @@ skip_compare_mft:
 		ntfs_log_error("Attribute definition table is too big (max "
 			       "24-bit allowed).\n");
 		errno = EINVAL;
+		ntfs_attr_close(na);
 		goto error_exit;
 	}
 	vol->attrdef_len = na->data_size;
@@ -1674,8 +1677,10 @@ error_exit:
 	eo = errno;
 	if (ctx)
 		ntfs_attr_put_search_ctx(ctx);
-	free(m);
-	free(m2);
+	if (m)
+		free(m);
+	if (m2)
+		free(m2);
 	__ntfs_volume_release(vol);
 	errno = eo;
 	return NULL;

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -106,9 +106,16 @@ int cluster_find(ntfs_volume *vol, LCN c_begin, LCN c_end, cluster_cb *cb, void 
 				if ((a_begin > c_end) || (a_end < c_begin))
 					continue;	// before or after search range
 
-				if ((*cb) (m_ctx->inode, a_ctx->attr, runs+j, data))
-					return 1;
+				if ((*cb) (m_ctx->inode, a_ctx->attr, runs+j, data)) {
+					result = 1;
+					goto done;
+				}
 				found = TRUE;
+			}
+
+			if (runs) {
+				runs = NULL;
+				free(runs);
 			}
 		}
 
@@ -124,8 +131,12 @@ int cluster_find(ntfs_volume *vol, LCN c_begin, LCN c_end, cluster_cb *cb, void 
 		ntfs_log_info("* %s inode found\n", (count ? "one" : "no"));
 	result = 0;
 done:
-	ntfs_attr_put_search_ctx(a_ctx);
-	mft_put_search_ctx(m_ctx);
+	if (runs)
+		free(runs);
+	if (a_ctx)
+		ntfs_attr_put_search_ctx(a_ctx);
+	if (m_ctx)
+		mft_put_search_ctx(m_ctx);
 
 	return result;
 }

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -266,7 +266,13 @@ static int ntfsck_close_inode_in_dir(ntfs_inode *ni, ntfs_inode *dir_ni)
 /* update lcn bitmap to disk, not set in fsck lcn bitmap */
 static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 {
+	ntfs_volume *vol;
 	ntfs_attr_search_ctx *actx;
+
+	if (!ni)
+		return -EINVAL;
+
+	vol = ni->vol;
 
 	actx = ntfs_attr_get_search_ctx(ni, NULL);
 	if (!actx)
@@ -295,6 +301,20 @@ static int ntfsck_update_lcn_bitmap(ntfs_inode *ni)
 			 * before check and alloc cluster to avoid
 			 * cluster duplication in ntfsck
 			 */
+			/* lcn corrupted */
+			if (rl[i].lcn >= vol->nr_clusters) {
+				/* truncate runlist */
+				rl[i].lcn = LCN_ENOENT;
+				rl[i].length = 0;
+				break;
+			}
+
+			/* length corrupted */
+			if (rl[i].lcn + rl[i].length >= vol->nr_clusters) {
+				/* adjust length */
+				rl[i].length = vol->nr_clusters - rl[i].lcn;
+			}
+
 			if (rl[i].lcn > (LCN)LCN_HOLE)
 				ntfs_bitmap_set_run(ni->vol->lcnbmp_na, rl[i].lcn, rl[i].length);
 			++i;
@@ -348,6 +368,20 @@ static int ntfsck_check_runlist(ntfs_attr *na, u8 set_bit, struct rl_size *rls, 
 	ntfs_init_problem_ctx(&pctx, ni, na, NULL, NULL, ni->mrec, NULL, NULL);
 
 	while (rl && rl[i].length) {
+		/* lcn corrupted */
+		if (rl[i].lcn >= vol->nr_clusters) {
+			/* truncate runlist */
+			rl[i].lcn = LCN_ENOENT;
+			rl[i].length = 0;
+			break;
+		}
+
+		/* length corrupted */
+		if (rl[i].lcn + rl[i].length >= vol->nr_clusters) {
+			/* adjust length */
+			rl[i].length = vol->nr_clusters - rl[i].lcn;
+		}
+
 		if (rl[i].lcn > LCN_HOLE) {
 			ntfs_log_trace("%s cluster run of mft entry(%"PRIu64") in memory : "
 					"vcn(%"PRId64"), lcn(%"PRId64"), length(%"PRId64")\n",

--- a/src/ntfslabel.c
+++ b/src/ntfslabel.c
@@ -307,11 +307,15 @@ static int set_new_serial(ntfs_volume *vol)
 				res = 0;
 				}
 		}
-		free(bs);
-		free(oldbs);
 	}
 	if (res)
 		ntfs_log_info("Error setting a new serial number\n");
+
+	if (bs)
+		free(bs);
+	if (oldbs)
+		free(oldbs);
+
 	return (res);
 }
 
@@ -378,6 +382,8 @@ static int change_label(ntfs_volume *vol, char *label)
 
 	label_len = ntfs_mbstoucs(label, &new_label);
 	if (label_len == -1) {
+		if (new_label)
+			free(new_label);
 		ntfs_log_perror("Unable to convert label string to Unicode");
 		return 1;
 	}


### PR DESCRIPTION
Found some cases that runlist cluster number exceeds the maximum cluster numbers.
Fix runlist to truncate it which has wrong cluster number.