### PR TITLE
all: fix static analysis issues #3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,21 @@
 CHANGE NOTES for ntfsprogs-plus
 
+v0.9.13
+Fix checking fsck lcnbmp over the maximum cluster number.
+Adjust maximum fsck bitmap buffer index count.
+Add checking cluster number of runlist which exceeds maximum cluster number.
+Add checking base mft record when open inode.
+Fix checking index entry length boundary condition.
+Do not delete system files when initialize root directory.
+
+ETC
+  Fix static analysis issues.
+  Restore ntfsresize utility.
+  Rename ntfs-3g to ntfs
+  Add progress bar and related option.
+  Change output of error message to standard out(STDOUT) stream.
+  Fix print condition on interactive mode.
+
 v0.9.12
 Check and repair duplicate clusters problem.
 Fix some bugs.

--- a/configure.ac
+++ b/configure.ac
@@ -26,7 +26,7 @@
 
 # Autoconf
 AC_PREREQ([2.71])
-AC_INIT([ntfsprogs-plus],[0.9.12],[linkinjeon@kernel.org])
+AC_INIT([ntfsprogs-plus],[0.9.13],[linkinjeon@kernel.org])
 AC_CONFIG_SRCDIR([config.h.in])
 LIBNTFS_VERSION="90"
 

--- a/libntfs/reparse.c
+++ b/libntfs/reparse.c
@@ -264,10 +264,8 @@ static char *search_absolute(ntfs_volume *vol, ntfschar *path,
 	    && ((ni->mrec->flags & MFT_RECORD_IS_DIRECTORY ? isdir : !isdir)
 		|| (ni->flags & FILE_ATTR_REPARSE_POINT)))
 		if (ntfs_ucstombs(path, count, &target, 0) < 0) {
-			if (target) {
-				free(target);
-				target = (char*)NULL;
-			}
+			if (target)
+				ntfs_attr_name_free(&target);
 		}
 	if (ni)
 		ntfs_inode_close(ni);
@@ -375,10 +373,9 @@ static char *search_relative(ntfs_inode *ni, ntfschar *path, int count)
 		}
 	}
 
-	if (ok && (ntfs_ucstombs(path, count, &target, 0) < 0)) {
-		free(target); // needed ?
-		target = (char*)NULL;
-	}
+	if (ok && (ntfs_ucstombs(path, count, &target, 0) < 0))
+		ntfs_attr_name_free(&target);
+
 	return (target);
 }
 
@@ -420,7 +417,7 @@ static int ntfs_drive_letter(ntfs_volume *vol, ntfschar letter)
 			}
 	}
 	if (drive)
-		free(drive);
+		ntfs_attr_name_free(&drive);
 	return (ret);
 }
 
@@ -606,8 +603,7 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
 				strcat(fulltarget,"/");
 				strcat(fulltarget,target);
 			}
-			free(target);
-			target = NULL;
+			ntfs_attr_name_free(&target);
 		}
 	}
 			/*
@@ -641,9 +637,7 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
 			}
 		}
 		if (target)
-			free(target);
-		if (sz > 0)
-			ntfs_attr_name_free(&sz);
+			ntfs_attr_name_free(&target);
 	}
 	return (fulltarget);
 }
@@ -718,8 +712,7 @@ char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, int count,
 				strcat(fulltarget,"/");
 				strcat(fulltarget,target);
 			}
-			free(target);
-			target = NULL;
+			ntfs_attr_name_free(&target);
 		}
 	}
 			/*
@@ -751,7 +744,7 @@ char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, int count,
 			}
 		}
 		if (target)
-			free(target);
+			ntfs_attr_name_free(&target);
 	}
 	return (fulltarget);
 }
@@ -1369,7 +1362,7 @@ int ntfs_reparse_set_wsl_symlink(ntfs_inode *ni,
 			free(reparse);
 		}
 	}
-	free(utarget);
+	ntfs_attr_name_free(&utarget);
 	return (res);
 }
 

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -3813,9 +3813,10 @@ err_continue:
 
 	progress_update(&prog, total_cnt);
 
-	total_cnt -= checked_cnt;
-	if (total_cnt < 0)
+	if (total_cnt < checked_cnt)
 		total_cnt = 0;
+	else
+		total_cnt -= checked_cnt;
 
 	return 0;
 }


### PR DESCRIPTION
Use ntfs_attr_name_free() for related name resource from ntfs_ucstombs()
Fix comparing unsinged variable with negative value