### PR TITLE
ntfsck: fix index bitmap related size and max bits

### DIFF
--- a/libntfs/index.c
+++ b/libntfs/index.c
@@ -1134,15 +1134,19 @@ static int ntfs_ibm_add(ntfs_index_context *icx)
 int ntfs_ibm_modify(ntfs_index_context *icx, VCN vcn, int set)
 {
 	u8 byte;
+
+	/* ib index for vcn */
 	s64 pos = ntfs_ibm_vcn_to_pos(icx, vcn);
-	u32 bpos = pos / 8;
-	u32 bit = 1 << (pos % 8);
+	/* byte position in bitmap for ib index of vcn */
+	u32 bpos = pos / BITS_PER_BYTE;
+	/* bit position in byte for ib index of vcn */
+	u32 bit = 1 << (pos % BITS_PER_BYTE);
 	ntfs_attr *na;
 	int ret = STATUS_ERROR;
 
 	ntfs_log_trace("%s vcn: %lld\n", set ? "set" : "clear", (long long)vcn);
 
-	na = ntfs_attr_open(icx->ni, AT_BITMAP,  icx->name, icx->name_len);
+	na = ntfs_attr_open(icx->ni, AT_BITMAP, icx->name, icx->name_len);
 	if (!na) {
 		ntfs_log_perror("Failed to open $BITMAP attribute");
 		return -1;


### PR DESCRIPTION
When cluster size is lower than 4K, calculation vcn bitmap location in index bitmap is wrong in some cases. Fix it.

When fsck bitmap of inode initilize in ntfsck_scan_index_entries_btree, initialze with wrong size of bitmap, fix it.