### PR TITLE
Fix checking $INDEX_ALLOCATION size fields of system directory

### DIFF
--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -2961,15 +2961,9 @@ static int ntfsck_check_system_inode(ntfs_inode *ni, INDEX_ENTRY *ie,
 	if (ntfsck_check_inode_fields(ictx->ni, ni, ie))
 		goto err_out;
 
-	/*
-	 * Directory system file is Root and $Extend only.
-	 * Root directory is already checked in ntfsck_check_system_files()
-	 * FIXME: in case of $Extend, ntfsck_check_directory() return failure
-	 *
 	if (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY) {
 		ret = ntfsck_check_directory(ni);
 	}
-	*/
 
 	/* TODO: check index
 	if (ni->mrec->flags & MFT_RECORD_IS_VIEW_INDEX) {


### PR DESCRIPTION
When disk is formatted on Windows, Windows create some hidden system directories under $Extend.
Those sub-directories (like $Deleted) has pre-allocated $INDEX_ALLOCATION block.
So if when checking $INDEX_ALLOCATION size fields, fsck should use allocated_size not data_size.
Fix it.


make test script independent from test repository. test_all_images.sh just call "test_all.sh" in top directory of tests repository