### PR TITLE
allow building of 1.0.0 in subdir 

### DIFF
--- a/libntfs/Makefile.am
+++ b/libntfs/Makefile.am
@@ -61,18 +61,6 @@ endif
 # And create ldscript or symbolic link from /usr
 install-exec-hook: install-rootlibLTLIBRARIES
 if INSTALL_LIBRARY
-	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
-		$(MV) -f "$(DESTDIR)/$(libdir)"/libntfs.so* "$(DESTDIR)/$(rootlibdir)";  \
-	fi
-if GENERATE_LDSCRIPT
-	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
-		$(install_sh_PROGRAM) "libntfs.script.so" "$(DESTDIR)/$(libdir)/libntfs.so"; \
-	fi
-else
-	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
-		$(LN_S) "$(rootlibdir)/libntfs.so" "$(DESTDIR)/$(libdir)/libntfs.so"; \
-	fi
-endif
 endif
 
 uninstall-local:


### PR DESCRIPTION
The following code block fails when building in a subdirectory.


https://github.com/ntfsprogs-plus/ntfsprogs-plus/blob/9cd989100e33623b0acd44c2edc14b6c8c89229b/libntfs/Makefile.am#L62-L76

the check code fails to match as seen below

    if [ ! "/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/.sysroot/ntfsprogs-plus.target//lib" -ef "/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/.sysroot/ntfsprogs-plus.target//usr/lib" ]; then \
            /usr/bin/mv -f "/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/.sysroot/ntfsprogs-plus.target//usr/lib"/libntfs.so* "/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/.sysroot/ntfsprogs-plus.target//lib";  \
    fi
    /usr/bin/mv: target '/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/.sysroot/ntfsprogs-plus.target//lib': No such file or directory

This potential PR works around the build error. Probably should be done better to “correctly compare”