### PR TITLE
Change pre-scanning mft records to informational message, and fixed install-exec-hook for subdir building

### DIFF
--- a/include/problem.h
+++ b/include/problem.h
@@ -94,4 +94,7 @@ void ntfs_init_problem_ctx(problem_context_t *pctx, ntfs_inode *ni, ntfs_attr *n
 void ntfs_print_problem(ntfs_volume *vol, problem_code_t code, problem_context_t *pctx);
 BOOL ntfs_fix_problem(ntfs_volume *vol, problem_code_t code, problem_context_t *pctx);
 BOOL ntfs_ask_repair(const ntfs_volume *vol);
+
+#define ntfs_print_message		ntfs_print_problem
+
 #endif

--- a/libntfs/Makefile.am
+++ b/libntfs/Makefile.am
@@ -61,16 +61,21 @@ endif
 # And create ldscript or symbolic link from /usr
 install-exec-hook: install-rootlibLTLIBRARIES
 if INSTALL_LIBRARY
-	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
-		$(MV) -f "$(DESTDIR)/$(libdir)"/libntfs.so* "$(DESTDIR)/$(rootlibdir)";  \
+	@if test "x$(rootlibdir)" != "x$(libdir)"; then \
+		$(MKDIR_P) "$(DESTDIR)$(rootlibdir)" || exit 1; \
+		if test -f "$(DESTDIR)$(libdir)/libntfs.so"; then \
+			mv -f "$(DESTDIR)$(libdir)/libntfs.so"* "$(DESTDIR)$(rootlibdir)/" || exit 1; \
+		else \
+			echo "WARNING: libntfs.so not found, skipping relocation"; \
+		fi; \
 	fi
 if GENERATE_LDSCRIPT
-	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
-		$(install_sh_PROGRAM) "libntfs.script.so" "$(DESTDIR)/$(libdir)/libntfs.so"; \
+	@if test "x$(rootlibdir)" != "x$(libdir)"; then \
+		$(INSTALL_PROGRAM) "$(builddir)/libntfs.script.so" "$(DESTDIR)$(libdir)/libntfs.so" || exit 1; \
 	fi
 else
-	if [ ! "$(DESTDIR)/$(rootlibdir)" -ef "$(DESTDIR)/$(libdir)" ]; then \
-		$(LN_S) "$(rootlibdir)/libntfs.so" "$(DESTDIR)/$(libdir)/libntfs.so"; \
+	@if test "x$(rootlibdir)" != "x$(libdir)"; then \
+		(cd "$(DESTDIR)$(libdir)" && rm -f libntfs.so && $(LN_S) "$(rootlibdir)/libntfs.so" libntfs.so) || exit 1; \
 	fi
 endif
 endif

--- a/libntfs/problem.c
+++ b/libntfs/problem.c
@@ -7,11 +7,11 @@
 static struct ntfs_problem problem_table[] = {
 	/* Pre-scan MFT */
 	{ PR_PRE_SCAN_MFT,
-		"Scan all mft entries and apply those lcn bitmap to disk",
+		"Scan all mft entries and apply those lcn bitmap to disk.",
 		PR_PREEN_NOMSG | PR_NO_NOMSG,
 	},
 	{ PR_RESET_LOG_FILE,
-		"Reset logfile",
+		"Reset logfile.",
 		PR_PREEN_NOMSG | PR_NO_NOMSG,
 	},
 	{ PR_MFT_FLAG_MISMATCH,
@@ -399,6 +399,7 @@ void ntfs_print_problem(ntfs_volume *vol, problem_code_t code, problem_context_t
 
 	message = p->desc;
 	print_message(pctx, message);
+	fprintf(stderr, "\n");
 	fflush(stderr);
 }
 

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -3974,12 +3974,15 @@ static int ntfsck_reset_dirty(ntfs_volume *vol)
 
 static int ntfsck_replay_log(ntfs_volume *vol __attribute__((unused)))
 {
-	fsck_start_step("Replay logfile...");
+	fsck_start_step("Reset logfile...");
 	problem_context_t pctx = {0, };
 
 	/*
 	 * For now, Just reset logfile.
 	 */
+
+	ntfs_log_info("ntfsck does not support log replay, just reset it\n");
+
 	if (ntfs_fix_problem(vol, PR_RESET_LOG_FILE, &pctx)) {
 		if (ntfs_logfile_reset(vol)) {
 			check_failed("ntfs logfile reset failed, errno : %d\n", errno);
@@ -4553,11 +4556,7 @@ static void ntfsck_scan_mft_records(ntfs_volume *vol)
 			vol->mft_record_size_bits;
 	ntfs_log_verbose("Scanning maximum %"PRId64" MFT records.\n", nr_mft_records);
 
-	if (!ntfs_fix_problem(vol, PR_PRE_SCAN_MFT, &pctx)) {
-		total_cnt = nr_mft_records;
-		fsck_end_step();
-		return;
-	}
+	ntfs_print_message(vol, PR_PRE_SCAN_MFT, &pctx);
 
 	progress_init(&prog, 0, nr_mft_records, 1000, pb_flags);
 
@@ -4570,7 +4569,6 @@ static void ntfsck_scan_mft_records(ntfs_volume *vol)
 			total_cnt++;
 		progress_update(&prog, mft_num + 1);
 	}
-
 
 	fsck_end_step();
 }


### PR DESCRIPTION
1. change default fsck mode to auto mode. And remove 'Fix it' message for scan mft and apply it's bitmap before main fsck logic
2. fix install-exec-hook for subdir building. 