### PR TITLE
style: normalize indentation in source files

### DIFF
--- a/include/acls.h
+++ b/include/acls.h
@@ -44,19 +44,21 @@
  *	when checking, check one is present
  */
 
-          /* flags which are set to mean exec, write or read */
+/* flags which are set to mean exec, write or read */
 
 #define FILE_READ (FILE_READ_DATA)
-#define FILE_WRITE (FILE_WRITE_DATA | FILE_APPEND_DATA \
-		| READ_CONTROL | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA)
+#define FILE_WRITE \
+	(FILE_WRITE_DATA | FILE_APPEND_DATA \
+	 | READ_CONTROL | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA)
 #define FILE_EXEC (FILE_EXECUTE)
 #define DIR_READ FILE_LIST_DIRECTORY
-#define DIR_WRITE (FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_DELETE_CHILD \
-	 	| READ_CONTROL | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA)
+#define DIR_WRITE \
+	(FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_DELETE_CHILD \
+	 | READ_CONTROL | FILE_WRITE_ATTRIBUTES | FILE_WRITE_EA)
 #define DIR_EXEC (FILE_TRAVERSE)
 
-          /* flags tested for meaning exec, write or read */
-	  /* tests for write allow for interpretation of a sticky bit */
+/* flags tested for meaning exec, write or read */
+/* tests for write allow for interpretation of a sticky bit */
 
 #define FILE_GREAD (FILE_READ_DATA | GENERIC_READ)
 #define FILE_GWRITE (FILE_WRITE_DATA | FILE_APPEND_DATA | GENERIC_WRITE)
@@ -65,19 +67,19 @@
 #define DIR_GWRITE (FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | GENERIC_WRITE)
 #define DIR_GEXEC (FILE_TRAVERSE | GENERIC_EXECUTE)
 
-	/* standard owner (and administrator) rights */
+/* standard owner (and administrator) rights */
 
-#define OWNER_RIGHTS (DELETE | READ_CONTROL | WRITE_DAC | WRITE_OWNER \
-			| SYNCHRONIZE \
-			| FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES \
-			| FILE_READ_EA | FILE_WRITE_EA)
+#define OWNER_RIGHTS \
+	(DELETE | READ_CONTROL | WRITE_DAC | WRITE_OWNER \
+	 | SYNCHRONIZE | FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES \
+	 | FILE_READ_EA | FILE_WRITE_EA)
 
-	/* standard world rights */
+/* standard world rights */
 
-#define WORLD_RIGHTS (READ_CONTROL | FILE_READ_ATTRIBUTES | FILE_READ_EA \
-			| SYNCHRONIZE)
+#define WORLD_RIGHTS \
+	(READ_CONTROL | FILE_READ_ATTRIBUTES | FILE_READ_EA | SYNCHRONIZE)
 
-          /* inheritance flags for files and directories */
+/* inheritance flags for files and directories */
 
 #define FILE_INHERITANCE NO_PROPAGATE_INHERIT_ACE
 #define DIR_INHERITANCE (OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE)
@@ -136,9 +138,9 @@ int ntfs_sid_size(const SID * sid);
 unsigned int ntfs_attr_size(const char *attr);
 
 const SID *ntfs_find_usid(const struct MAPPING *usermapping,
-			uid_t uid, SID *pdefsid);
+		uid_t uid, SID *pdefsid);
 const SID *ntfs_find_gsid(const struct MAPPING *groupmapping,
-			gid_t gid, SID *pdefsid);
+		gid_t gid, SID *pdefsid);
 uid_t ntfs_find_user(const struct MAPPING *usermapping, const SID *usid);
 gid_t ntfs_find_group(const struct MAPPING *groupmapping, const SID * gsid);
 const SID *ntfs_acl_owner(const char *secattr);
@@ -157,24 +159,24 @@ struct POSIX_SECURITY *ntfs_build_basic_posix(
 struct POSIX_SECURITY *ntfs_replace_acl(const struct POSIX_SECURITY *oldpxdesc,
 		const struct POSIX_ACL *newacl, int count, BOOL deflt);
 struct POSIX_SECURITY *ntfs_build_permissions_posix(
-			struct MAPPING* const mapping[],
-			const char *securattr,
-			const SID *usid, const SID *gsid, BOOL isdir);
+		struct MAPPING* const mapping[],
+		const char *securattr,
+		const SID *usid, const SID *gsid, BOOL isdir);
 struct POSIX_SECURITY *ntfs_merge_descr_posix(const struct POSIX_SECURITY *first,
-			const struct POSIX_SECURITY *second);
+		const struct POSIX_SECURITY *second);
 char *ntfs_build_descr_posix(struct MAPPING* const mapping[],
-			struct POSIX_SECURITY *pxdesc,
-			int isdir, const SID *usid, const SID *gsid);
+		struct POSIX_SECURITY *pxdesc,
+		int isdir, const SID *usid, const SID *gsid);
 
 #endif /* POSIXACLS */
 
 int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
-			const SID *usid, const SID *gsid,
-			BOOL fordir, le16 inherited);
+		const SID *usid, const SID *gsid,
+		BOOL fordir, le16 inherited);
 int ntfs_build_permissions(const char *securattr,
-			const SID *usid, const SID *gsid, BOOL isdir);
+		const SID *usid, const SID *gsid, BOOL isdir);
 char *ntfs_build_descr(mode_t mode,
-			int isdir, const SID * usid, const SID * gsid);
+		int isdir, const SID * usid, const SID * gsid);
 struct MAPLIST *ntfs_read_mapping(FILEREADER reader, void *fileid);
 struct MAPPING *ntfs_do_user_mapping(struct MAPLIST *firstitem);
 struct MAPPING *ntfs_do_group_mapping(struct MAPLIST *firstitem);

--- a/include/attrib.h
+++ b/include/attrib.h
@@ -252,8 +252,8 @@ extern void NAttrSet##func_name(ntfs_attr *na);		\
 extern void NAttrClear##func_name(ntfs_attr *na);
 
 GenNAttrIno(Compressed, FILE_ATTR_COMPRESSED)
-GenNAttrIno(Encrypted, 	FILE_ATTR_ENCRYPTED)
-GenNAttrIno(Sparse, 	FILE_ATTR_SPARSE_FILE)
+GenNAttrIno(Encrypted,	FILE_ATTR_ENCRYPTED)
+GenNAttrIno(Sparse,	FILE_ATTR_SPARSE_FILE)
 #undef GenNAttrIno
 
 /**
@@ -263,7 +263,7 @@ GenNAttrIno(Sparse, 	FILE_ATTR_SPARSE_FILE)
  */
 typedef union {
 	u8 _default;	/* Unnamed u8 to serve as default when just using
-			   a_val without specifying any of the below. */
+					   a_val without specifying any of the below. */
 	STANDARD_INFORMATION std_inf;
 	ATTR_LIST_ENTRY al_entry;
 	FILE_NAME_ATTR filename;
@@ -290,8 +290,8 @@ extern void ntfs_attr_init(ntfs_attr *na, const BOOL non_resident,
 		const s64 initialized_size, const s64 compressed_size,
 		const u8 compression_unit);
 
-	/* warning : in the following "name" has to be freeable */
-	/* or one of constants AT_UNNAMED, NTFS_INDEX_I30 or STREAM_SDS */
+/* warning : in the following "name" has to be freeable */
+/* or one of constants AT_UNNAMED, NTFS_INDEX_I30 or STREAM_SDS */
 extern ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 		ntfschar *name, u32 name_len);
 extern void ntfs_attr_close(ntfs_attr *na);
@@ -303,7 +303,7 @@ extern s64 ntfs_attr_pwrite(ntfs_attr *na, const s64 pos, s64 count,
 extern int ntfs_attr_pclose(ntfs_attr *na);
 
 extern void *ntfs_attr_readall(ntfs_inode *ni, const ATTR_TYPES type,
-			       ntfschar *name, u32 name_len, s64 *data_size);
+		ntfschar *name, u32 name_len, s64 *data_size);
 
 extern s64 ntfs_attr_mst_pread(ntfs_attr *na, const s64 pos,
 		const s64 bk_cnt, const u32 bk_size, void *dst);
@@ -388,7 +388,7 @@ extern void ntfs_set_attribute_value_length(ATTR_RECORD *a, s64 length);
  * errno describes the error.
  */
 extern s64 ntfs_get_attribute_value(const ntfs_volume *vol,
-				    const ATTR_RECORD *a, u8 *b);
+		const ATTR_RECORD *a, u8 *b);
 extern BOOL ntfs_is_valid_attr_type(const ATTR_RECORD *a);
 
 extern void  ntfs_attr_name_free(char **name);
@@ -396,7 +396,7 @@ extern char *ntfs_attr_name_get(const ntfschar *uname, const int uname_len);
 extern int   ntfs_attr_exist(ntfs_inode *ni, const ATTR_TYPES type,
 		const ntfschar *name, u32 name_len);
 extern int   ntfs_attr_remove(ntfs_inode *ni, const ATTR_TYPES type,
-			      ntfschar *name, u32 name_len);
+		ntfschar *name, u32 name_len);
 extern s64   ntfs_attr_get_free_bits(ntfs_attr *na);
 extern int ntfs_attr_data_read(ntfs_inode *ni,
 		ntfschar *stream_name, int stream_name_len,

--- a/include/attrlist.h
+++ b/include/attrlist.h
@@ -1,6 +1,6 @@
 /*
- * attrlist.h - Exports for attribute list attribute handling.  
- * 		Originated from Linux-NTFS project.
+ * attrlist.h - Exports for attribute list attribute handling.
+ *		Originated from Linux-NTFS project.
  *
  * Copyright (c) 2004 Anton Altaparmakov
  * Copyright (c) 2004 Yura Pakhuchiy

--- a/include/bitmap.h
+++ b/include/bitmap.h
@@ -81,7 +81,7 @@ static __inline__ int ntfs_bitmap_clear_bit(ntfs_attr *na, s64 bit)
  */
 static __inline__ u32 ntfs_rol32(u32 word, unsigned int shift)
 {
-        return (word << shift) | (word >> (32 - shift));
+	return (word << shift) | (word >> (32 - shift));
 }
 
 /*
@@ -92,7 +92,7 @@ static __inline__ u32 ntfs_rol32(u32 word, unsigned int shift)
  */
 static __inline__ u32 ntfs_ror32(u32 word, unsigned int shift)
 {
-        return (word >> shift) | (word << (32 - shift));
+	return (word >> shift) | (word << (32 - shift));
 }
 
 #endif /* defined _NTFS_BITMAP_H */

--- a/include/cache.h
+++ b/include/cache.h
@@ -38,7 +38,7 @@ struct CACHED_INODE {
 	const char *pathname;
 	size_t varsize;
 	union ALIGNMENT payload[0];
-		/* above fields must match "struct CACHED_GENERIC" */
+	/* above fields must match "struct CACHED_GENERIC" */
 	u64 inum;
 } ;
 
@@ -48,7 +48,7 @@ struct CACHED_NIDATA {
 	const char *pathname;	/* not used */
 	size_t varsize;		/* not used */
 	union ALIGNMENT payload[0];
-		/* above fields must match "struct CACHED_GENERIC" */
+	/* above fields must match "struct CACHED_GENERIC" */
 	u64 inum;
 	ntfs_inode *ni;
 } ;
@@ -59,7 +59,7 @@ struct CACHED_LOOKUP {
 	const char *name;
 	size_t namesize;
 	union ALIGNMENT payload[0];
-		/* above fields must match "struct CACHED_GENERIC" */
+	/* above fields must match "struct CACHED_GENERIC" */
 	u64 parent;
 	u64 inum;
 } ;
@@ -70,7 +70,7 @@ enum {
 } ;
 
 typedef int (*cache_compare)(const struct CACHED_GENERIC *cached,
-				const struct CACHED_GENERIC *item);
+		const struct CACHED_GENERIC *item);
 typedef void (*cache_free)(const struct CACHED_GENERIC *cached);
 typedef int (*cache_hash)(const struct CACHED_GENERIC *cached);
 
@@ -96,20 +96,20 @@ struct CACHE_HEADER {
 	struct CACHED_GENERIC entry[0];
 } ;
 
-	/* cast to generic, avoiding gcc warnings */
+/* cast to generic, avoiding gcc warnings */
 #define GENERIC(pstr) ((const struct CACHED_GENERIC*)(const void*)(pstr))
 
 struct CACHED_GENERIC *ntfs_fetch_cache(struct CACHE_HEADER *cache,
-			const struct CACHED_GENERIC *wanted,
-			cache_compare compare);
+		const struct CACHED_GENERIC *wanted,
+		cache_compare compare);
 struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
-			const struct CACHED_GENERIC *item,
-			cache_compare compare);
+		const struct CACHED_GENERIC *item,
+		cache_compare compare);
 int ntfs_invalidate_cache(struct CACHE_HEADER *cache,
-			const struct CACHED_GENERIC *item,
-			cache_compare compare, int flags);
+		const struct CACHED_GENERIC *item,
+		cache_compare compare, int flags);
 int ntfs_remove_cache(struct CACHE_HEADER *cache,
-			struct CACHED_GENERIC *item, int flags);
+		struct CACHED_GENERIC *item, int flags);
 
 void ntfs_create_lru_caches(ntfs_volume *vol);
 void ntfs_free_lru_caches(ntfs_volume *vol);

--- a/include/compress.h
+++ b/include/compress.h
@@ -30,12 +30,12 @@ extern s64 ntfs_compressed_attr_pread(ntfs_attr *na, s64 pos, s64 count,
 		void *b);
 
 extern s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *brl, s64 wpos,
-				s64 offs, s64 to_write, s64 rounded,
-				const void *b, int compressed_part,
-				VCN *update_from);
+		s64 offs, s64 to_write, s64 rounded,
+		const void *b, int compressed_part,
+		VCN *update_from);
 
 extern int ntfs_compressed_close(ntfs_attr *na, runlist_element *brl,
-				s64 offs, VCN *update_from);
+		s64 offs, VCN *update_from);
 
 #endif /* defined _NTFS_COMPRESS_H */
 

--- a/include/device_io.h
+++ b/include/device_io.h
@@ -29,8 +29,8 @@
 #ifndef NO_NTFS_DEVICE_DEFAULT_IO_OPS
 
 #if defined(linux) || defined(__uClinux__) || defined(__sun) \
-		|| defined(__APPLE__) || defined(__DARWIN__)
-  /* Make sure the presence of <windows.h> means compiling for Windows */
+	|| defined(__APPLE__) || defined(__DARWIN__)
+/* Make sure the presence of <windows.h> means compiling for Windows */
 #undef HAVE_WINDOWS_H
 #endif
 

--- a/include/dir.h
+++ b/include/dir.h
@@ -65,7 +65,7 @@ extern INDEX_ENTRY * __ntfs_inode_lookup_by_name(ntfs_inode *dir_ni,
 		const ntfschar *uname, const int uname_len);
 extern u64 ntfs_inode_lookup_by_mbsname(ntfs_inode *dir_ni, const char *name);
 extern void ntfs_inode_update_mbsname(ntfs_inode *dir_ni, const char *name,
-				u64 inum);
+		u64 inum);
 
 extern ntfs_inode *ntfs_pathname_to_inode(ntfs_volume *vol, ntfs_inode *parent,
 		const char *pathname);
@@ -115,9 +115,9 @@ ntfs_inode *ntfs_dir_parent_inode(ntfs_inode *ni);
 u32 ntfs_interix_types(ntfs_inode *ni);
 
 int ntfs_get_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
-			char *value, size_t size);
+		char *value, size_t size);
 int ntfs_set_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
-			const char *value, size_t size,	int flags);
+		const char *value, size_t size,	int flags);
 int ntfs_remove_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni);
 int ntfs_dir_link_cnt(ntfs_inode *ni);
 

--- a/include/efs.h
+++ b/include/efs.h
@@ -24,7 +24,7 @@
 int ntfs_get_efs_info(ntfs_inode *ni, char *value, size_t size);
 
 int ntfs_set_efs_info(ntfs_inode *ni,
-			const char *value, size_t size,	int flags);
+		const char *value, size_t size,	int flags);
 int ntfs_efs_fixup_attribute(ntfs_attr_search_ctx *ctx, ntfs_attr *na);
 
 #endif /* EFS_H */

--- a/include/endians.h
+++ b/include/endians.h
@@ -62,22 +62,22 @@
 #		define __LITTLE_ENDIAN LITTLE_ENDIAN
 #		define __BIG_ENDIAN BIG_ENDIAN
 #	elif defined(__BYTE_ORDER__) && defined(__LITTLE_ENDIAN__) && \
-			defined(__BIG_ENDIAN__)
+	defined(__BIG_ENDIAN__)
 #		define __BYTE_ORDER __BYTE_ORDER__
 #		define __LITTLE_ENDIAN __LITTLE_ENDIAN__
 #		define __BIG_ENDIAN __BIG_ENDIAN__
 #	elif defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-			defined(__ORDER_BIG_ENDIAN__)
+	defined(__ORDER_BIG_ENDIAN__)
 #		define __BYTE_ORDER __BYTE_ORDER__
 #		define __LITTLE_ENDIAN __ORDER_LITTLE_ENDIAN__
 #		define __BIG_ENDIAN __ORDER_BIG_ENDIAN__
 #	elif (defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN)) || \
-			defined(WORDS_LITTLEENDIAN)
+	defined(WORDS_LITTLEENDIAN)
 #		define __BYTE_ORDER 1
 #		define __LITTLE_ENDIAN 1
 #		define __BIG_ENDIAN 0
 #	elif (!defined(_LITTLE_ENDIAN) && defined(_BIG_ENDIAN)) || \
-			defined(WORDS_BIGENDIAN)
+	defined(WORDS_BIGENDIAN)
 #		define __BYTE_ORDER 0
 #		define __LITTLE_ENDIAN 1
 #		define __BIG_ENDIAN 0
@@ -87,24 +87,24 @@
 #endif
 
 #define __ntfs_bswap_constant_16(x)		\
-	  (u16)((((u16)(x) & 0xff00) >> 8) |	\
-		(((u16)(x) & 0x00ff) << 8))
+	(u16)((((u16)(x) & 0xff00) >> 8) |	\
+			(((u16)(x) & 0x00ff) << 8))
 
 #define __ntfs_bswap_constant_32(x)			\
-	  (u32)((((u32)(x) & 0xff000000u) >> 24) |	\
-		(((u32)(x) & 0x00ff0000u) >>  8) |	\
-		(((u32)(x) & 0x0000ff00u) <<  8) |	\
-		(((u32)(x) & 0x000000ffu) << 24))
+	(u32)((((u32)(x) & 0xff000000u) >> 24) |	\
+			(((u32)(x) & 0x00ff0000u) >>  8) |	\
+			(((u32)(x) & 0x0000ff00u) <<  8) |	\
+			(((u32)(x) & 0x000000ffu) << 24))
 
 #define __ntfs_bswap_constant_64(x)				\
-	  (u64)((((u64)(x) & 0xff00000000000000ull) >> 56) |	\
-		(((u64)(x) & 0x00ff000000000000ull) >> 40) |	\
-		(((u64)(x) & 0x0000ff0000000000ull) >> 24) |	\
-		(((u64)(x) & 0x000000ff00000000ull) >>  8) |	\
-		(((u64)(x) & 0x00000000ff000000ull) <<  8) |	\
-		(((u64)(x) & 0x0000000000ff0000ull) << 24) |	\
-		(((u64)(x) & 0x000000000000ff00ull) << 40) |	\
-		(((u64)(x) & 0x00000000000000ffull) << 56))
+	(u64)((((u64)(x) & 0xff00000000000000ull) >> 56) |	\
+			(((u64)(x) & 0x00ff000000000000ull) >> 40) |	\
+			(((u64)(x) & 0x0000ff0000000000ull) >> 24) |	\
+			(((u64)(x) & 0x000000ff00000000ull) >>  8) |	\
+			(((u64)(x) & 0x00000000ff000000ull) <<  8) |	\
+			(((u64)(x) & 0x0000000000ff0000ull) << 24) |	\
+			(((u64)(x) & 0x000000000000ff00ull) << 40) |	\
+			(((u64)(x) & 0x00000000000000ffull) << 56))
 
 #ifdef HAVE_BYTESWAP_H
 #	include <byteswap.h>

--- a/include/fsck.h
+++ b/include/fsck.h
@@ -12,7 +12,7 @@
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-	/* Do not #include <sys/mount.h> here : conflicts with <linux/fs.h> */
+/* Do not #include <sys/mount.h> here : conflicts with <linux/fs.h> */
 #ifdef HAVE_MNTENT_H
 #include <mntent.h>
 #endif
@@ -42,7 +42,7 @@ int ntfs_fsck_set_lcnbmp_range(ntfs_volume *vol, s64 lcn, s64 length, u8 bit);
 runlist *ntfs_fsck_check_and_set_lcnbmp(ntfs_volume *vol, ntfs_attr *na, int rl_idx,
 		u8 set_bit, runlist *dup_rl);
 runlist_element *ntfs_rl_append(runlist_element *dst, int dsize,
-				       runlist_element *src, int ssize, int loc);
+		runlist_element *src, int ssize, int loc);
 int ntfs_fsck_repair_cluster_dup(ntfs_attr *na, runlist *dup_rl);
 void ntfs_fsck_fill_unused_lcnbmp(ntfs_volume *vol, s64 last_idx, u8 *buf);
 

--- a/include/index.h
+++ b/include/index.h
@@ -31,13 +31,13 @@
  *  ... code requiring gcc 2.8 or later ...
  *  #endif
  *  Note - they won't work for gcc1 or glibc1, since the _MINOR macros
- *  were not defined then. 
+ *  were not defined then.
  */
 
 #ifndef __GNUC_PREREQ
 # if defined __GNUC__ && defined __GNUC_MINOR__
 #  define __GNUC_PREREQ(maj, min) \
-        ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+	((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
 # else
 #  define __GNUC_PREREQ(maj, min) 0
 # endif
@@ -47,7 +47,7 @@
 #ifndef __attribute_warn_unused_result__
 # if __GNUC_PREREQ (3,4)
 #  define __attribute_warn_unused_result__ \
-    __attribute__ ((__warn_unused_result__))
+	__attribute__ ((__warn_unused_result__))
 # else
 #  define __attribute_warn_unused_result__ /* empty */
 # endif
@@ -64,7 +64,7 @@
 #define  MAX_PARENT_VCN		64
 
 typedef int (*COLLATE)(ntfs_volume *vol, const void *data1, int len1,
-					 const void *data2, int len2);
+		const void *data2, int len2);
 
 /**
  * struct ntfs_index_context -
@@ -135,15 +135,15 @@ typedef struct {
 } ntfs_index_context;
 
 extern ntfs_index_context *ntfs_index_ctx_get(ntfs_inode *ni,
-						ntfschar *name, u32 name_len);
+		ntfschar *name, u32 name_len);
 extern void ntfs_index_ctx_put(ntfs_index_context *ictx);
 extern void ntfs_index_ctx_reinit(ntfs_index_context *ictx);
 
 extern int ntfs_index_block_inconsistent(ntfs_volume *vol, ntfs_attr *ia_na,
 		INDEX_BLOCK *ib, u32 block_size, u64 inum, VCN vcn);
 extern int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
-			COLLATION_RULES collation_rule, u64 inum,
-			ntfs_index_context *ictx);
+		COLLATION_RULES collation_rule, u64 inum,
+		ntfs_index_context *ictx);
 extern int ntfs_index_lookup(const void *key, const int key_len,
 		ntfs_index_context *ictx) __attribute_warn_unused_result__;
 
@@ -159,9 +159,9 @@ extern INDEX_ROOT *ntfs_index_root_get(ntfs_inode *ni, ATTR_RECORD *attr);
 
 extern VCN ntfs_ie_get_vcn(INDEX_ENTRY *ie);
 INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
-			ntfs_index_context *ictx);
+		ntfs_index_context *ictx);
 INDEX_ENTRY *ntfs_index_walk_up(INDEX_ENTRY *ie,
-			ntfs_index_context *ictx);
+		ntfs_index_context *ictx);
 
 extern void ntfs_index_entry_mark_dirty(ntfs_index_context *ictx);
 
@@ -178,7 +178,7 @@ int ntfs_ib_write(ntfs_index_context *icx, INDEX_BLOCK *ib);
 int ntfsck_update_index_entry(ntfs_index_context *ictx);
 int ntfs_ibm_modify(ntfs_index_context *icx, VCN vcn, int set);
 INDEX_ROOT *ntfs_ir_lookup(ntfs_inode *ni, ntfschar *name,
-				  u32 name_len, ntfs_attr_search_ctx **ctx);
+		u32 name_len, ntfs_attr_search_ctx **ctx);
 INDEX_ROOT *ntfs_ir_lookup2(ntfs_inode *ni, ntfschar *name, u32 len);
 s64 ntfs_ib_vcn_to_pos(ntfs_index_context *icx, VCN vcn);
 

--- a/include/inode.h
+++ b/include/inode.h
@@ -46,9 +46,9 @@ typedef enum {
 	/* The NI_AttrList* tests only make sense for base inodes. */
 	NI_AttrList,		/* 1: Mft record contains an attribute list. */
 	NI_AttrListDirty,	/* 1: Attribute list needs to be written to the
-				      mft record and then to disk. */
+						   mft record and then to disk. */
 	NI_FileNameDirty,	/* 1: FILE_NAME attributes need to be updated
-				      in the index. */
+						   in the index. */
 	NI_v3_Extensions,	/* 1: JPA v3.x extensions present. */
 	NI_TimesSet,		/* 1: Use times which were set */
 	NI_KnownSize,		/* 1: Set if sizes are meaningful */
@@ -59,9 +59,9 @@ typedef enum {
 #define clear_nino_flag(ni, flag)	  clear_bit(NI_##flag, (ni)->state)
 
 #define test_and_set_nino_flag(ni, flag)	\
-				   test_and_set_bit(NI_##flag, (ni)->state)
+	test_and_set_bit(NI_##flag, (ni)->state)
 #define test_and_clear_nino_flag(ni, flag)	\
-				 test_and_clear_bit(NI_##flag, (ni)->state)
+	test_and_clear_bit(NI_##flag, (ni)->state)
 
 #define NInoDirty(ni)				  test_nino_flag(ni, Dirty)
 #define NInoSetDirty(ni)			   set_nino_flag(ni, Dirty)
@@ -79,9 +79,9 @@ typedef enum {
 #define clear_nino_al_flag(ni, flag)	clear_nino_flag(ni, AttrList##flag)
 
 #define test_and_set_nino_al_flag(ni, flag)	\
-				 test_and_set_nino_flag(ni, AttrList##flag)
+	test_and_set_nino_flag(ni, AttrList##flag)
 #define test_and_clear_nino_al_flag(ni, flag)	\
-			       test_and_clear_nino_flag(ni, AttrList##flag)
+	test_and_clear_nino_flag(ni, AttrList##flag)
 
 #define NInoAttrListDirty(ni)			    test_nino_al_flag(ni, Dirty)
 #define NInoAttrListSetDirty(ni)		     set_nino_al_flag(ni, Dirty)
@@ -93,9 +93,9 @@ typedef enum {
 #define NInoFileNameSetDirty(ni)               set_nino_flag(ni, FileNameDirty)
 #define NInoFileNameClearDirty(ni)           clear_nino_flag(ni, FileNameDirty)
 #define NInoFileNameTestAndSetDirty(ni)		\
-				      test_and_set_nino_flag(ni, FileNameDirty)
+	test_and_set_nino_flag(ni, FileNameDirty)
 #define NInoFileNameTestAndClearDirty(ni)	\
-				    test_and_clear_nino_flag(ni, FileNameDirty)
+	test_and_clear_nino_flag(ni, FileNameDirty)
 
 /**
  * struct _ntfs_inode - The NTFS in-memory inode structure.
@@ -108,9 +108,9 @@ struct _ntfs_inode {
 	MFT_RECORD *mrec;	/* The actual mft record of the inode. */
 	ntfs_volume *vol;	/* Pointer to the ntfs volume of this inode. */
 	unsigned long state;	/* NTFS specific flags describing this inode.
-				   See ntfs_inode_state_bits above. */
+							   See ntfs_inode_state_bits above. */
 	FILE_ATTR_FLAGS flags;	/* Flags describing the file.
-				   (Copy from STANDARD_INFORMATION) */
+							   (Copy from STANDARD_INFORMATION) */
 	/*
 	 * Attribute list support (for use by the attribute lookup functions).
 	 * Setup during ntfs_open_inode() for all inodes with attribute lists.
@@ -120,15 +120,15 @@ struct _ntfs_inode {
 	u8 *attr_list;		/* Attribute list value itself. */
 	/* Below fields are always valid. */
 	s32 nr_extents;		/* For a base mft record, the number of
-				   attached extent inodes (0 if none), for
-				   extent records this is -1. */
+						   attached extent inodes (0 if none), for
+						   extent records this is -1. */
 	union {		/* This union is only used if nr_extents != 0. */
 		ntfs_inode **extent_nis;/* For nr_extents > 0, array of the
-					   ntfs inodes of the extent mft
-					   records belonging to this base
-					   inode which have been loaded. */
+								   ntfs inodes of the extent mft
+								   records belonging to this base
+								   inode which have been loaded. */
 		ntfs_inode *base_ni;	/* For nr_extents == -1, the ntfs
-					   inode of the base mft record. */
+								   inode of the base mft record. */
 	};
 
 	/* Below fields are valid only for base inode. */
@@ -141,13 +141,13 @@ struct _ntfs_inode {
 	 * flag KnownSize is set.
 	 */
 	s64 data_size;		/* Data size of unnamed DATA attribute
-				   (or INDEX_ROOT for directories) */
+						   (or INDEX_ROOT for directories) */
 	s64 allocated_size;	/* Allocated size stored in the filename
-				   index. (NOTE: Equal to allocated size of
-				   the unnamed data attribute for normal or
-				   encrypted files and to compressed size
-				   of the unnamed data attribute for sparse or
-				   compressed files.) */
+						   index. (NOTE: Equal to allocated size of
+						   the unnamed data attribute for normal or
+						   encrypted files and to compressed size
+						   of the unnamed data attribute for sparse or
+						   compressed files.) */
 
 	/*
 	 * These four fields are copy of relevant fields from
@@ -158,8 +158,8 @@ struct _ntfs_inode {
 	ntfs_time last_data_change_time;
 	ntfs_time last_mft_change_time;
 	ntfs_time last_access_time;
-				/* NTFS 3.x extensions added by JPA */
-				/* only if NI_v3_Extensions is set in state */
+	/* NTFS 3.x extensions added by JPA */
+	/* only if NI_v3_Extensions is set in state */
 	le32 owner_id;
 	le32 security_id;
 	le64 quota_charged;
@@ -219,7 +219,7 @@ extern int ntfs_inode_badclus_bad(u64 mft_no, ATTR_RECORD *a);
 extern int ntfs_inode_get_times(ntfs_inode *ni, char *value, size_t size);
 
 extern int ntfs_inode_set_times(ntfs_inode *ni, const char *value,
-			size_t size, int flags);
+		size_t size, int flags);
 
 /* debugging */
 #define debug_double_inode(num, type)

--- a/include/ioctl.h
+++ b/include/ioctl.h
@@ -30,6 +30,6 @@
  * some commands (e.g. FITRIM) do not fit in a signed 32 bit field.
  */
 int ntfs_ioctl(ntfs_inode *ni, unsigned long cmd, void *arg,
-                        unsigned int flags, void *data);
+		unsigned int flags, void *data);
 
 #endif /* IOCTL_H */

--- a/include/layout.h
+++ b/include/layout.h
@@ -47,21 +47,21 @@
  * struct BIOS_PARAMETER_BLOCK - BIOS parameter block (bpb) structure.
  */
 typedef struct {
-	le16 bytes_per_sector;		/* Size of a sector in bytes. */
-	u8  sectors_per_cluster;	/* Size of a cluster in sectors. */
-	le16 reserved_sectors;		/* zero */
-	u8  fats;			/* zero */
+	le16 bytes_per_sector;	/* Size of a sector in bytes. */
+	u8 sectors_per_cluster;	/* Size of a cluster in sectors. */
+	le16 reserved_sectors;	/* zero */
+	u8 fats;				/* zero */
 	le16 root_entries;		/* zero */
 	le16 sectors;			/* zero */
-	u8  media_type;			/* 0xf8 = hard disk */
-	le16 sectors_per_fat;		/* zero */
-/*0x0d*/le16 sectors_per_track;		/* Required to boot Windows. */
-/*0x0f*/le16 heads;			/* Required to boot Windows. */
-/*0x11*/le32 hidden_sectors;		/* Offset to the start of the partition
-					   relative to the disk in sectors.
-					   Required to boot Windows. */
-/*0x15*/le32 large_sectors;		/* zero */
-/* sizeof() = 25 (0x19) bytes */
+	u8 media_type;			/* 0xf8 = hard disk */
+	le16 sectors_per_fat;	/* zero */
+	le16 sectors_per_track;	/* (0x0d) Required to boot Windows. */
+	le16 heads;				/* (0x0f) Required to boot Windows. */
+	le32 hidden_sectors;	/* (0x11) Offset to the start of the partition
+							   relative to the disk in sectors.
+							   Required to boot Windows. */
+	le32 large_sectors;		/* (0x15) zero */
+	/* sizeof() = 25 (0x19) bytes */
 } __attribute__((__packed__)) BIOS_PARAMETER_BLOCK;
 
 /**
@@ -70,16 +70,16 @@ typedef struct {
 typedef struct {
 	u8  jump[3];			/* Irrelevant (jump to boot up code).*/
 	le64 oem_id;			/* Magic "NTFS    ". */
-/*0x0b*/BIOS_PARAMETER_BLOCK bpb;	/* See BIOS_PARAMETER_BLOCK. */
-	u8 physical_drive;		/* 0x00 floppy, 0x80 hard disk */
-	u8 current_head;		/* zero */
-	u8 extended_boot_signature; 	/* 0x80 */
-	u8 reserved2;			/* zero */
-/*0x28*/sle64 number_of_sectors;		/* Number of sectors in volume. Gives
-					   maximum volume size of 2^63 sectors.
-					   Assuming standard sector size of 512
-					   bytes, the maximum byte size is
-					   approx. 4.7x10^21 bytes. (-; */
+	BIOS_PARAMETER_BLOCK bpb;	/* (0x0b) See BIOS_PARAMETER_BLOCK. */
+	u8 physical_drive;			/* 0x00 floppy, 0x80 hard disk */
+	u8 current_head;			/* zero */
+	u8 extended_boot_signature;	/* (0x80) */
+	u8 reserved2;				/* zero */
+	sle64 number_of_sectors;	/* (0x28) Number of sectors in volume. Gives
+								   maximum volume size of 2^63 sectors.
+								   Assuming standard sector size of 512
+								   bytes, the maximum byte size is
+								   approx. 4.7x10^21 bytes. (-; */
 	sle64 mft_lcn;			/* Cluster location of mft data. */
 	sle64 mftmirr_lcn;		/* Cluster location of copy of mft. */
 	s8  clusters_per_mft_record;	/* Mft record size in clusters. */
@@ -88,10 +88,10 @@ typedef struct {
 	u8  reserved1[3];		/* zero */
 	le64 volume_serial_number;	/* Irrelevant (serial number). */
 	le32 checksum;			/* Boot sector checksum. */
-/*0x54*/u8  bootstrap[426];		/* Irrelevant (boot up code). */
+	u8  bootstrap[426];		/* (0x54) Irrelevant (boot up code). */
 	le16 end_of_sector_marker;	/* End of bootsector magic. Always is
-					   0xaa55 in little endian. */
-/* sizeof() = 512 (0x200) bytes */
+								   0xaa55 in little endian. */
+	/* sizeof() = 512 (0x200) bytes */
 } __attribute__((__packed__)) NTFS_BOOT_SECTOR;
 
 /**
@@ -115,7 +115,7 @@ typedef enum {
 
 	/* Found in all ntfs record containing records. */
 	magic_BAAD = const_cpu_to_le32(0x44414142), /* Failed multi sector
-						       transfer was detected. */
+												   transfer was detected. */
 
 	/*
 	 * Found in $LogFile/$DATA when a page is full or 0xff bytes and is
@@ -123,8 +123,8 @@ typedef enum {
 	 * it.
 	 */
 	magic_empty = const_cpu_to_le32(0xffffffff),/* Record is empty and has
-						       to be initialized before
-						       it can be used. */
+												   to be initialized before
+												   it can be used. */
 } NTFS_RECORD_TYPES;
 
 /*
@@ -190,13 +190,13 @@ typedef enum {
  */
 typedef struct {
 	NTFS_RECORD_TYPES magic;/* A four-byte magic identifying the
-				   record type and/or status. */
+							   record type and/or status. */
 	le16 usa_ofs;		/* Offset to the Update Sequence Array (usa)
-				   from the start of the ntfs record. */
+						   from the start of the ntfs record. */
 	le16 usa_count;		/* Number of le16 sized entries in the usa
-				   including the Update Sequence Number (usn),
-				   thus the number of fixups is the usa_count
-				   minus 1. */
+						   including the Update Sequence Number (usn),
+						   thus the number of fixups is the usa_count
+						   minus 1. */
 } __attribute__((__packed__)) NTFS_RECORD;
 
 /**
@@ -209,41 +209,41 @@ typedef struct {
  */
 typedef enum {
 	FILE_MFT	= 0,	/* Master file table (mft). Data attribute
-				   contains the entries and bitmap attribute
-				   records which ones are in use (bit==1). */
+						   contains the entries and bitmap attribute
+						   records which ones are in use (bit==1). */
 	FILE_MFTMirr	= 1,	/* Mft mirror: copy of first four mft records
-				   in data attribute. If cluster size > 4kiB,
-				   copy of first N mft records, with
-					N = cluster_size / mft_record_size. */
+							   in data attribute. If cluster size > 4kiB,
+							   copy of first N mft records, with
+							   N = cluster_size / mft_record_size. */
 	FILE_LogFile	= 2,	/* Journalling log in data attribute. */
 	FILE_Volume	= 3,	/* Volume name attribute and volume information
-				   attribute (flags and ntfs version). Windows
-				   refers to this file as volume DASD (Direct
-				   Access Storage Device). */
+						   attribute (flags and ntfs version). Windows
+						   refers to this file as volume DASD (Direct
+						   Access Storage Device). */
 	FILE_AttrDef	= 4,	/* Array of attribute definitions in data
-				   attribute. */
+							   attribute. */
 	FILE_root	= 5,	/* Root directory. */
 	FILE_Bitmap	= 6,	/* Allocation bitmap of all clusters (lcns) in
-				   data attribute. */
+						   data attribute. */
 	FILE_Boot	= 7,	/* Boot sector (always at cluster 0) in data
-				   attribute. */
+						   attribute. */
 	FILE_BadClus	= 8,	/* Contains all bad clusters in the non-resident
-				   data attribute. */
+							   data attribute. */
 	FILE_Secure	= 9,	/* Shared security descriptors in data attribute
-				   and two indexes into the descriptors.
-				   Appeared in Windows 2000. Before that, this
-				   file was named $Quota but was unused. */
+						   and two indexes into the descriptors.
+						   Appeared in Windows 2000. Before that, this
+						   file was named $Quota but was unused. */
 	FILE_UpCase	= 10,	/* Uppercase equivalents of all 65536 Unicode
-				   characters in data attribute. */
+						   characters in data attribute. */
 	FILE_Extend	= 11,	/* Directory containing other system files (eg.
-				   $ObjId, $Quota, $Reparse and $UsnJrnl). This
-				   is new to NTFS3.0. */
+						   $ObjId, $Quota, $Reparse and $UsnJrnl). This
+						   is new to NTFS3.0. */
 	FILE_reserved12	= 12,	/* Reserved for future use (records 12-15). */
 	FILE_reserved13	= 13,
 	FILE_reserved14	= 14,
 	FILE_mft_data	= 15,	/* Reserved for first extent of $MFT:$DATA */
 	FILE_first_user	= 16,	/* First user file, used as test limit for
-				   whether to allow opening a file or not. */
+							   whether to allow opening a file or not. */
 } NTFS_SYSTEM_FILES;
 
 /**
@@ -268,7 +268,7 @@ typedef enum {
 	MFT_RECORD_IS_4			= const_cpu_to_le16(0x0004),
 	MFT_RECORD_IS_VIEW_INDEX	= const_cpu_to_le16(0x0008),
 	MFT_REC_SPACE_FILLER		= 0xffff, /* Just to make flags
-						     16-bit. */
+											 16-bit. */
 } __attribute__((__packed__)) MFT_RECORD_FLAGS;
 
 /*
@@ -322,9 +322,9 @@ typedef u64 MFT_REF;
 typedef le64 leMFT_REF;   /* a little-endian MFT_MREF */
 
 #define MK_MREF(m, s)	((MFT_REF)(((MFT_REF)(s) << 48) |		\
-					((MFT_REF)(m) & MFT_REF_MASK_CPU)))
+			((MFT_REF)(m) & MFT_REF_MASK_CPU)))
 #define MK_LE_MREF(m, s) const_cpu_to_le64(((MFT_REF)(((MFT_REF)(s) << 48) | \
-					((MFT_REF)(m) & MFT_REF_MASK_CPU))))
+				((MFT_REF)(m) & MFT_REF_MASK_CPU))))
 
 #define MREF(x)		((u64)((x) & MFT_REF_MASK_CPU))
 #define MSEQNO(x)	((u16)(((x) >> 48) & 0xffff))
@@ -351,67 +351,66 @@ typedef struct {
 	le16 usa_ofs;		/* See NTFS_RECORD definition above. */
 	le16 usa_count;		/* See NTFS_RECORD definition above. */
 
-/*  8*/	leLSN lsn;		/* $LogFile sequence number for this record.
-				   Changed every time the record is modified. */
-/* 16*/	le16 sequence_number;	/* Number of times this mft record has been
-				   reused. (See description for MFT_REF
-				   above.) NOTE: The increment (skipping zero)
-				   is done when the file is deleted. NOTE: If
-				   this is zero it is left zero. */
-/* 18*/	le16 link_count;		/* Number of hard links, i.e. the number of
-				   directory entries referencing this record.
-				   NOTE: Only used in mft base records.
-				   NOTE: When deleting a directory entry we
-				   check the link_count and if it is 1 we
-				   delete the file. Otherwise we delete the
-				   FILE_NAME_ATTR being referenced by the
-				   directory entry from the mft record and
-				   decrement the link_count.
-				   FIXME: Careful with Win32 + DOS names! */
-/* 20*/	le16 attrs_offset;	/* Byte offset to the first attribute in this
-				   mft record from the start of the mft record.
-				   NOTE: Must be aligned to 8-byte boundary. */
-/* 22*/	MFT_RECORD_FLAGS flags;	/* Bit array of MFT_RECORD_FLAGS. When a file
-				   is deleted, the MFT_RECORD_IN_USE flag is
-				   set to zero. */
-/* 24*/	le32 bytes_in_use;	/* Number of bytes used in this mft record.
-				   NOTE: Must be aligned to 8-byte boundary. */
-/* 28*/	le32 bytes_allocated;	/* Number of bytes allocated for this mft
-				   record. This should be equal to the mft
-				   record size. */
-/* 32*/	leMFT_REF base_mft_record;
-				/* This is zero for base mft records.
-				   When it is not zero it is a mft reference
-				   pointing to the base mft record to which
-				   this record belongs (this is then used to
-				   locate the attribute list attribute present
-				   in the base record which describes this
-				   extension record and hence might need
-				   modification when the extension record
-				   itself is modified, also locating the
-				   attribute list also means finding the other
-				   potential extents, belonging to the non-base
-				   mft record). */
-/* 40*/	le16 next_attr_instance; /* The instance number that will be
-				   assigned to the next attribute added to this
-				   mft record. NOTE: Incremented each time
-				   after it is used. NOTE: Every time the mft
-				   record is reused this number is set to zero.
-				   NOTE: The first instance number is always 0.
-				 */
-/* The below fields are specific to NTFS 3.1+ (Windows XP and above): */
-/* 42*/ le16 reserved;		/* Reserved/alignment. */
-/* 44*/ le32 mft_record_number;	/* Number of this mft record. */
-/* sizeof() = 48 bytes */
-/*
- * When (re)using the mft record, we place the update sequence array at this
- * offset, i.e. before we start with the attributes. This also makes sense,
- * otherwise we could run into problems with the update sequence array
- * containing in itself the last two bytes of a sector which would mean that
- * multi sector transfer protection wouldn't work. As you can't protect data
- * by overwriting it since you then can't get it back...
- * When reading we obviously use the data from the ntfs record header.
- */
+	leLSN lsn;		/* (8) $LogFile sequence number for this record.
+					Changed every time the record is modified. */
+	le16 sequence_number;	/* (16) Number of times this mft record has been
+					reused. (See description for MFT_REF
+					above.) NOTE: The increment (skipping zero)
+					is done when the file is deleted. NOTE: If
+					this is zero it is left zero. */
+	le16 link_count;	/* (18) Number of hard links, i.e. the number of
+					directory entries referencing this record.
+					NOTE: Only used in mft base records.
+					NOTE: When deleting a directory entry we
+					check the link_count and if it is 1 we
+					delete the file. Otherwise we delete the
+					FILE_NAME_ATTR being referenced by the
+					directory entry from the mft record and
+					decrement the link_count.
+					FIXME: Careful with Win32 + DOS names! */
+	le16 attrs_offset;	/* (20) Byte offset to the first attribute in this
+					mft record from the start of the mft record.
+					NOTE: Must be aligned to 8-byte boundary. */
+	MFT_RECORD_FLAGS flags;	/* (22) Bit array of MFT_RECORD_FLAGS. When a file
+					is deleted, the MFT_RECORD_IN_USE flag is
+									   set to zero. */
+	le32 bytes_in_use;	/* (24) Number of bytes used in this mft record.
+					NOTE: Must be aligned to 8-byte boundary. */
+	le32 bytes_allocated;	/* (28) Number of bytes allocated for this mft
+					record. This should be equal to the mft
+					record size. */
+	leMFT_REF base_mft_record;	/* (32) */
+	/* This is zero for base mft records.
+	   When it is not zero it is a mft reference
+	   pointing to the base mft record to which
+	   this record belongs (this is then used to
+	   locate the attribute list attribute present
+	   in the base record which describes this
+	   extension record and hence might need
+	   modification when the extension record
+	   itself is modified, also locating the
+	   attribute list also means finding the other
+	   potential extents, belonging to the non-base
+	   mft record). */
+	le16 next_attr_instance;/* (40) The instance number that will be
+					assigned to the next attribute added to this
+					mft record. NOTE: Incremented each time
+					after it is used. NOTE: Every time the mft
+					record is reused this number is set to zero.
+					NOTE: The first instance number is always 0. */
+	/* The below fields are specific to NTFS 3.1+ (Windows XP and above): */
+	le16 reserved;		/* (42) Reserved/alignment. */
+	le32 mft_record_number;	/* (44) Number of this mft record. */
+	/* sizeof() = 48 bytes */
+	/*
+	 * When (re)using the mft record, we place the update sequence array at this
+	 * offset, i.e. before we start with the attributes. This also makes sense,
+	 * otherwise we could run into problems with the update sequence array
+	 * containing in itself the last two bytes of a sector which would mean that
+	 * multi sector transfer protection wouldn't work. As you can't protect data
+	 * by overwriting it since you then can't get it back...
+	 * When reading we obviously use the data from the ntfs record header.
+	 */
 } __attribute__((__packed__)) MFT_RECORD;
 
 /**
@@ -426,64 +425,63 @@ typedef struct {
 	le16 usa_ofs;		/* See NTFS_RECORD definition above. */
 	le16 usa_count;		/* See NTFS_RECORD definition above. */
 
-/*  8*/	leLSN lsn;		/* $LogFile sequence number for this record.
-				   Changed every time the record is modified. */
-/* 16*/	le16 sequence_number;	/* Number of times this mft record has been
-				   reused. (See description for MFT_REF
-				   above.) NOTE: The increment (skipping zero)
-				   is done when the file is deleted. NOTE: If
-				   this is zero it is left zero. */
-/* 18*/	le16 link_count;		/* Number of hard links, i.e. the number of
-				   directory entries referencing this record.
-				   NOTE: Only used in mft base records.
-				   NOTE: When deleting a directory entry we
-				   check the link_count and if it is 1 we
-				   delete the file. Otherwise we delete the
-				   FILE_NAME_ATTR being referenced by the
-				   directory entry from the mft record and
-				   decrement the link_count.
-				   FIXME: Careful with Win32 + DOS names! */
-/* 20*/	le16 attrs_offset;	/* Byte offset to the first attribute in this
-				   mft record from the start of the mft record.
-				   NOTE: Must be aligned to 8-byte boundary. */
-/* 22*/	MFT_RECORD_FLAGS flags;	/* Bit array of MFT_RECORD_FLAGS. When a file
-				   is deleted, the MFT_RECORD_IN_USE flag is
-				   set to zero. */
-/* 24*/	le32 bytes_in_use;	/* Number of bytes used in this mft record.
-				   NOTE: Must be aligned to 8-byte boundary. */
-/* 28*/	le32 bytes_allocated;	/* Number of bytes allocated for this mft
-				   record. This should be equal to the mft
-				   record size. */
-/* 32*/	leMFT_REF base_mft_record;
-				/* This is zero for base mft records.
-				   When it is not zero it is a mft reference
-				   pointing to the base mft record to which
-				   this record belongs (this is then used to
-				   locate the attribute list attribute present
-				   in the base record which describes this
-				   extension record and hence might need
-				   modification when the extension record
-				   itself is modified, also locating the
-				   attribute list also means finding the other
-				   potential extents, belonging to the non-base
-				   mft record). */
-/* 40*/	le16 next_attr_instance; /* The instance number that will be
-				   assigned to the next attribute added to this
-				   mft record. NOTE: Incremented each time
-				   after it is used. NOTE: Every time the mft
-				   record is reused this number is set to zero.
-				   NOTE: The first instance number is always 0.
-				 */
-/* sizeof() = 42 bytes */
-/*
- * When (re)using the mft record, we place the update sequence array at this
- * offset, i.e. before we start with the attributes. This also makes sense,
- * otherwise we could run into problems with the update sequence array
- * containing in itself the last two bytes of a sector which would mean that
- * multi sector transfer protection wouldn't work. As you can't protect data
- * by overwriting it since you then can't get it back...
- * When reading we obviously use the data from the ntfs record header.
- */
+	leLSN lsn;		/* ( 8) $LogFile sequence number for this record.
+					Changed every time the record is modified. */
+	le16 sequence_number;	/* (16) Number of times this mft record has been
+					reused. (See description for MFT_REF
+					above.) NOTE: The increment (skipping zero)
+					is done when the file is deleted. NOTE: If
+					this is zero it is left zero. */
+	le16 link_count;	/* (18) Number of hard links, i.e. the number of
+					directory entries referencing this record.
+					NOTE: Only used in mft base records.
+					NOTE: When deleting a directory entry we
+					check the link_count and if it is 1 we
+					delete the file. Otherwise we delete the
+					FILE_NAME_ATTR being referenced by the
+					directory entry from the mft record and
+					decrement the link_count.
+					FIXME: Careful with Win32 + DOS names! */
+	le16 attrs_offset;	/* (20) Byte offset to the first attribute in this
+					mft record from the start of the mft record.
+					NOTE: Must be aligned to 8-byte boundary. */
+	MFT_RECORD_FLAGS flags;	/* (22) Bit array of MFT_RECORD_FLAGS. When a file
+					is deleted, the MFT_RECORD_IN_USE flag is
+					set to zero. */
+	le32 bytes_in_use;	/* (24) Number of bytes used in this mft record.
+					NOTE: Must be aligned to 8-byte boundary. */
+	le32 bytes_allocated;	/* (28) Number of bytes allocated for this mft
+					record. This should be equal to the mft
+					record size. */
+	leMFT_REF base_mft_record;	/* (32) */
+	/* This is zero for base mft records.
+	   When it is not zero it is a mft reference
+	   pointing to the base mft record to which
+	   this record belongs (this is then used to
+	   locate the attribute list attribute present
+	   in the base record which describes this
+	   extension record and hence might need
+	   modification when the extension record
+	   itself is modified, also locating the
+	   attribute list also means finding the other
+	   potential extents, belonging to the non-base
+	   mft record). */
+	le16 next_attr_instance; /* (40) The instance number that will be
+					assigned to the next attribute added to this
+					mft record. NOTE: Incremented each time
+					after it is used. NOTE: Every time the mft
+					record is reused this number is set to zero.
+					NOTE: The first instance number is always 0.  */
+	/* sizeof() = 42 bytes */
+	/*
+	 * When (re)using the mft record, we place the update sequence array at this
+	 * offset, i.e. before we start with the attributes. This also makes sense,
+	 * otherwise we could run into problems with the update sequence array
+	 * containing in itself the last two bytes of a sector which would mean that
+	 * multi sector transfer protection wouldn't work. As you can't protect data
+	 * by overwriting it since you then can't get it back...
+	 * When reading we obviously use the data from the ntfs record header.
+	 */
 } __attribute__((__packed__)) MFT_RECORD_OLD;
 
 /**
@@ -577,29 +575,29 @@ typedef enum {
  */
 typedef enum {
 	ATTR_DEF_INDEXABLE	= const_cpu_to_le32(0x02), /* Attribute can be
-					indexed. */
+						      indexed. */
 	ATTR_DEF_MULTIPLE	= const_cpu_to_le32(0x04), /* Attribute type
-					can be present multiple times in the
-					mft records of an inode. */
+						      can be present multiple times in the
+						      mft records of an inode. */
 	ATTR_DEF_NOT_ZERO	= const_cpu_to_le32(0x08), /* Attribute value
-					must contain at least one non-zero
-					byte. */
+						      must contain at least one non-zero
+						      byte. */
 	ATTR_DEF_INDEXED_UNIQUE	= const_cpu_to_le32(0x10), /* Attribute must be
-					indexed and the attribute value must be
-					unique for the attribute type in all of
-					the mft records of an inode. */
+							      indexed and the attribute value must be
+							      unique for the attribute type in all of
+							      the mft records of an inode. */
 	ATTR_DEF_NAMED_UNIQUE	= const_cpu_to_le32(0x20), /* Attribute must be
-					named and the name must be unique for
-					the attribute type in all of the mft
-					records of an inode. */
+							      named and the name must be unique for
+							      the attribute type in all of the mft
+							      records of an inode. */
 	ATTR_DEF_RESIDENT	= const_cpu_to_le32(0x40), /* Attribute must be
-					resident. */
+						      resident. */
 	ATTR_DEF_ALWAYS_LOG	= const_cpu_to_le32(0x80), /* Always log
-					modifications to this attribute,
-					regardless of whether it is resident or
-					non-resident.  Without this, only log
-					modifications if the attribute is
-					resident. */
+						      modifications to this attribute,
+						      regardless of whether it is resident or
+						      non-resident.  Without this, only log
+						      modifications if the attribute is
+						      resident. */
 } ATTR_DEF_FLAGS;
 
 /**
@@ -615,16 +613,16 @@ typedef enum {
  */
 typedef struct {
 /*hex ofs*/
-/*  0*/	ntfschar name[0x40];		/* Unicode name of the attribute. Zero
-					   terminated. */
-/* 80*/	ATTR_TYPES type;		/* Type of the attribute. */
-/* 84*/	le32 display_rule;		/* Default display rule.
-					   FIXME: What does it mean? (AIA) */
-/* 88*/ COLLATION_RULES collation_rule;	/* Default collation rule. */
-/* 8c*/	ATTR_DEF_FLAGS flags;		/* Flags describing the attribute. */
-/* 90*/	sle64 min_size;			/* Optional minimum attribute size. */
-/* 98*/	sle64 max_size;			/* Maximum size of attribute. */
-/* sizeof() = 0xa0 or 160 bytes */
+	ntfschar name[0x40];	/* (0x00) Unicode name of the attribute. Zero
+								   terminated. */
+	ATTR_TYPES type;		/* (0x80) Type of the attribute. */
+	le32 display_rule;		/* (0x84) Default display rule.
+								FIXME: What does it mean? (AIA) */
+	COLLATION_RULES collation_rule;	/* (0x88) Default collation rule. */
+	ATTR_DEF_FLAGS flags;	/* (0x8c) Flags describing the attribute. */
+	sle64 min_size;			/* (0x90) Optional minimum attribute size. */
+	sle64 max_size;			/* (0x98) Maximum size of attribute. */
+	/* sizeof() = 0xa0 or 160 bytes */
 } __attribute__((__packed__)) ATTR_DEF;
 
 /**
@@ -633,8 +631,8 @@ typedef struct {
 typedef enum {
 	ATTR_IS_COMPRESSED	= const_cpu_to_le16(0x0001),
 	ATTR_COMPRESSION_MASK	= const_cpu_to_le16(0x00ff),  /* Compression
-						method mask. Also, first
-						illegal value. */
+								 method mask. Also, first
+								 illegal value. */
 	ATTR_IS_ENCRYPTED	= const_cpu_to_le16(0x4000),
 	ATTR_IS_SPARSE		= const_cpu_to_le16(0x8000),
 } __attribute__((__packed__)) ATTR_FLAGS;
@@ -711,8 +709,8 @@ typedef enum {
  */
 typedef enum {
 	RESIDENT_ATTR_IS_INDEXED = 0x01, /* Attribute is referenced in an index
-					    (has implications for deleting and
-					    modifying the attribute). */
+										(has implications for deleting and
+										modifying the attribute). */
 } __attribute__((__packed__)) RESIDENT_ATTR_FLAGS;
 
 /**
@@ -722,15 +720,15 @@ typedef enum {
  */
 typedef struct {
 /*Ofs*/
-/*  0*/	ATTR_TYPES type;	/* The (32-bit) type of the attribute. */
-/*  4*/	le32 length;		/* Byte size of the resident part of the
+	ATTR_TYPES type;	/* ( 0) The (32-bit) type of the attribute. */
+	le32 length;		/* ( 4) Byte size of the resident part of the
 				   attribute (aligned to 8-byte boundary).
 				   Used to get to the next attribute. */
-/*  8*/	u8 non_resident;	/* If 0, attribute is resident.
+	u8 non_resident;	/* ( 8) If 0, attribute is resident.
 				   If 1, attribute is non-resident. */
-/*  9*/	u8 name_length;		/* Unicode character size of name of attribute.
+	u8 name_length;		/* ( 9) Unicode character size of name of attribute.
 				   0 if unnamed. */
-/* 10*/	le16 name_offset;	/* If name_length != 0, the byte offset to the
+	le16 name_offset;	/* (10) If name_length != 0, the byte offset to the
 				   beginning of the name from the attribute
 				   record. Note that the name is stored as a
 				   Unicode string. When creating, place offset
@@ -739,85 +737,85 @@ typedef struct {
 				   array, resident and non-resident attributes
 				   respectively, aligning to an 8-byte
 				   boundary. */
-/* 12*/	ATTR_FLAGS flags;	/* Flags describing the attribute. */
-/* 14*/	le16 instance;		/* The instance of this attribute record. This
+	ATTR_FLAGS flags;	/* (12) Flags describing the attribute. */
+	le16 instance;		/* (14) The instance of this attribute record. This
 				   number is unique within this mft record (see
 				   MFT_RECORD/next_attr_instance notes
 				   above for more details). */
-/* 16*/	union {
+	union {		/* (16) */
 		/* Resident attributes. */
 		struct {
-/* 16 */		le32 value_length; /* Byte size of attribute value. */
-/* 20 */		le16 value_offset; /* Byte offset of the attribute
-					       value from the start of the
-					       attribute record. When creating,
-					       align to 8-byte boundary if we
-					       have a name present as this might
-					       not have a length of a multiple
-					       of 8-bytes. */
-/* 22 */		RESIDENT_ATTR_FLAGS resident_flags; /* See above. */
-/* 23 */		s8 reservedR;	    /* Reserved/alignment to 8-byte
+			le32 value_length; /* (16) Byte size of attribute value. */
+			le16 value_offset; /* (20) Byte offset of the attribute
+					      value from the start of the
+					      attribute record. When creating,
+					      align to 8-byte boundary if we
+					      have a name present as this might
+					      not have a length of a multiple
+					      of 8-bytes. */
+			RESIDENT_ATTR_FLAGS resident_flags; /* (22) See above. */
+			s8 reservedR;	    /* (23) Reserved/alignment to 8-byte
 					       boundary. */
-/* 24 */		void *resident_end[0]; /* Use offsetof(ATTR_RECORD,
+			void *resident_end[0]; /* (24) Use offsetof(ATTR_RECORD,
 						  resident_end) to get size of
 						  a resident attribute. */
 		} __attribute__((__packed__));
 		/* Non-resident attributes. */
 		struct {
-/* 16*/			leVCN lowest_vcn;	/* Lowest valid virtual cluster number
-				for this portion of the attribute value or
-				0 if this is the only extent (usually the
-				case). - Only when an attribute list is used
-				does lowest_vcn != 0 ever occur. */
-/* 24*/			leVCN highest_vcn; /* Highest valid vcn of this extent of
-				the attribute value. - Usually there is only one
-				portion, so this usually equals the attribute
-				value size in clusters minus 1. Can be -1 for
-				zero length files. Can be 0 for "single extent"
-				attributes. */
-/* 32*/			le16 mapping_pairs_offset; /* Byte offset from the
-				beginning of the structure to the mapping pairs
-				array which contains the mappings between the
-				vcns and the logical cluster numbers (lcns).
-				When creating, place this at the end of this
-				record header aligned to 8-byte boundary. */
-/* 34*/			u8 compression_unit; /* The compression unit expressed
-				as the log to the base 2 of the number of
-				clusters in a compression unit. 0 means not
-				compressed. (This effectively limits the
-				compression unit size to be a power of two
-				clusters.) WinNT4 only uses a value of 4. */
-/* 35*/			u8 reserved1[5];	/* Align to 8-byte boundary. */
-/* The sizes below are only used when lowest_vcn is zero, as otherwise it would
-   be difficult to keep them up-to-date.*/
-/* 40*/			sle64 allocated_size;	/* Byte size of disk space
-				allocated to hold the attribute value. Always
-				is a multiple of the cluster size. When a file
-				is compressed, this field is a multiple of the
-				compression block size (2^compression_unit) and
-				it represents the logically allocated space
-				rather than the actual on disk usage. For this
-				use the compressed_size (see below). */
-/* 48*/			sle64 data_size;	/* Byte size of the attribute
-				value. Can be larger than allocated_size if
-				attribute value is compressed or sparse. */
-/* 56*/			sle64 initialized_size;	/* Byte size of initialized
-				portion of the attribute value. Usually equals
-				data_size. */
-/* 64 */		void *non_resident_end[0]; /* Use offsetof(ATTR_RECORD,
+			leVCN lowest_vcn;	/* (16) Lowest valid virtual cluster number
+						   for this portion of the attribute value or
+						   0 if this is the only extent (usually the
+						   case). - Only when an attribute list is used
+						   does lowest_vcn != 0 ever occur. */
+			leVCN highest_vcn;	/* (24) Highest valid vcn of this extent of
+					      the attribute value. - Usually there is only one
+					      portion, so this usually equals the attribute
+					      value size in clusters minus 1. Can be -1 for
+					      zero length files. Can be 0 for "single extent"
+					      attributes. */
+			le16 mapping_pairs_offset;	/* (32) Byte offset from the
+						      beginning of the structure to the mapping pairs
+						      array which contains the mappings between the
+						      vcns and the logical cluster numbers (lcns).
+						      When creating, place this at the end of this
+						      record header aligned to 8-byte boundary. */
+			u8 compression_unit;	/* (34) The compression unit expressed
+						as the log to the base 2 of the number of
+						clusters in a compression unit. 0 means not
+						compressed. (This effectively limits the
+						compression unit size to be a power of two
+						clusters.) WinNT4 only uses a value of 4. */
+			u8 reserved1[5];	/* (35) Align to 8-byte boundary. */
+			/* The sizes below are only used when lowest_vcn is zero, as otherwise it would
+			   be difficult to keep them up-to-date.*/
+			sle64 allocated_size;	/* (40) Byte size of disk space
+						   allocated to hold the attribute value. Always
+						   is a multiple of the cluster size. When a file
+						   is compressed, this field is a multiple of the
+						   compression block size (2^compression_unit) and
+						   it represents the logically allocated space
+						   rather than the actual on disk usage. For this
+						   use the compressed_size (see below). */
+			sle64 data_size;	/* (48) Byte size of the attribute
+						   value. Can be larger than allocated_size if
+						   attribute value is compressed or sparse. */
+			sle64 initialized_size;	/* (56) Byte size of initialized
+						   portion of the attribute value. Usually equals
+						   data_size. */
+			void *non_resident_end[0]; /* (64) Use offsetof(ATTR_RECORD,
 						      non_resident_end) to get
 						      size of a non resident
 						      attribute. */
-/* sizeof(uncompressed attr) = 64*/
-/* 64*/			sle64 compressed_size;	/* Byte size of the attribute
-				value after compression. Only present when
-				compressed. Always is a multiple of the
-				cluster size. Represents the actual amount of
-				disk space being used on the disk. */
-/* 72 */		void *compressed_end[0];
-				/* Use offsetof(ATTR_RECORD, compressed_end) to
-				   get size of a compressed attribute. */
-/* sizeof(compressed attr) = 72*/
+			/* sizeof(uncompressed attr) = 64*/
+			sle64 compressed_size;	/* (64) Byte size of the attribute
+						   value after compression. Only present when
+						   compressed. Always is a multiple of the
+						   cluster size. Represents the actual amount of
+						   disk space being used on the disk. */
+			void *compressed_end[0];	/* (72) */
+			/* Use offsetof(ATTR_RECORD, compressed_end) to
+			   get size of a compressed attribute. */
+			/* sizeof(compressed attr) = 72*/
 		} __attribute__((__packed__));
 	} __attribute__((__packed__));
 } __attribute__((__packed__)) ATTR_RECORD;
@@ -852,7 +850,7 @@ typedef enum {
 	FILE_ATTR_OFFLINE		= const_cpu_to_le32(0x00001000),
 	FILE_ATTR_NOT_CONTENT_INDEXED	= const_cpu_to_le32(0x00002000),
 	FILE_ATTR_ENCRYPTED		= const_cpu_to_le32(0x00004000),
-		/* Supposed to mean no data locally, possibly repurposed */
+	/* Supposed to mean no data locally, possibly repurposed */
 	FILE_ATTRIBUTE_RECALL_ON_OPEN	= const_cpu_to_le32(0x00040000),
 
 	FILE_ATTR_VALID_FLAGS		= const_cpu_to_le32(0x00047fb7),
@@ -872,15 +870,15 @@ typedef enum {
 	 * This is a copy of the MFT_RECORD_IS_DIRECTORY bit from the mft
 	 * record, telling us whether this is a directory or not, i.e. whether
 	 * it has an index root attribute named "$I30" or not.
-	 * 
-	 * This flag is only present in the FILE_NAME attribute (in the 
+	 *
+	 * This flag is only present in the FILE_NAME attribute (in the
 	 * file_attributes field).
 	 */
 	FILE_ATTR_I30_INDEX_PRESENT	= const_cpu_to_le32(0x10000000),
-	
+
 	/**
 	 * FILE_ATTR_VIEW_INDEX_PRESENT - Does have a non-directory index?
-	 * 
+	 *
 	 * This is a copy of the MFT_RECORD_IS_VIEW_INDEX bit from the mft
 	 * record, telling us whether this file has a view index present (eg.
 	 * object id index, quota index, one of the security indexes and the
@@ -911,13 +909,13 @@ typedef enum {
  */
 typedef struct {
 /*Ofs*/
-/*  0*/	sle64 creation_time;		/* Time file was created. Updated when
-					   a filename is changed(?). */
-/*  8*/	sle64 last_data_change_time;	/* Time the data attribute was last
+	sle64 creation_time;	/* ( 0) Time file was created. Updated when
+				   a filename is changed(?). */
+	sle64 last_data_change_time;	/* ( 8) Time the data attribute was last
 					   modified. */
-/* 16*/	sle64 last_mft_change_time;	/* Time this mft record was last
+	sle64 last_mft_change_time;	/* (16) Time this mft record was last
 					   modified. */
-/* 24*/	sle64 last_access_time;		/* Approximate time when the file was
+	sle64 last_access_time;		/* (24) Approximate time when the file was
 					   last accessed (obviously this is not
 					   updated on read-only volumes). In
 					   Windows this is only updated when
@@ -925,70 +923,70 @@ typedef struct {
 					   passed since the last update. Also,
 					   last access times updates can be
 					   disabled altogether for speed. */
-/* 32*/	FILE_ATTR_FLAGS file_attributes; /* Flags describing the file. */
-/* 36*/	union {
-		/* NTFS 1.2 (and previous, presumably) */
-		struct {
-		/* 36 */ u8 reserved12[12];	/* Reserved/alignment to 8-byte
+	FILE_ATTR_FLAGS file_attributes; /* (32) Flags describing the file. */
+	union {	/* (36) */
+	    /* NTFS 1.2 (and previous, presumably) */
+	    struct {
+		u8 reserved12[12];	/* (36) Reserved/alignment to 8-byte
 						   boundary. */
-		/* 48 */ void *v1_end[0];	/* Marker for offsetof(). */
-		} __attribute__((__packed__));
-/* sizeof() = 48 bytes */
-		/* NTFS 3.0 */
-		struct {
-/*
- * If a volume has been upgraded from a previous NTFS version, then these
- * fields are present only if the file has been accessed since the upgrade.
- * Recognize the difference by comparing the length of the resident attribute
- * value. If it is 48, then the following fields are missing. If it is 72 then
- * the fields are present. Maybe just check like this:
- *	if (resident.ValueLength < sizeof(STANDARD_INFORMATION)) {
- *		Assume NTFS 1.2- format.
- *		If (volume version is 3.0+)
- *			Upgrade attribute to NTFS 3.0 format.
- *		else
- *			Use NTFS 1.2- format for access.
- *	} else
- *		Use NTFS 3.0 format for access.
- * Only problem is that it might be legal to set the length of the value to
- * arbitrarily large values thus spoiling this check. - But chkdsk probably
- * views that as a corruption, assuming that it behaves like this for all
- * attributes.
- */
-		/* 36*/	le32 maximum_versions;	/* Maximum allowed versions for
-				file. Zero if version numbering is disabled. */
-		/* 40*/	le32 version_number;	/* This file's version (if any).
-				Set to zero if maximum_versions is zero. */
-		/* 44*/	le32 class_id;		/* Class id from bidirectional
-				class id index (?). */
-		/* 48*/	le32 owner_id;		/* Owner_id of the user owning
-				the file. Translate via $Q index in FILE_Extend
-				/$Quota to the quota control entry for the user
-				owning the file. Zero if quotas are disabled. */
-		/* 52*/	le32 security_id;	/* Security_id for the file.
-				Translate via $SII index and $SDS data stream
-				in FILE_Secure to the security descriptor. */
-		/* 56*/	le64 quota_charged;	/* Byte size of the charge to
-				the quota for all streams of the file. Note: Is
-				zero if quotas are disabled. */
-		/* 64*/	le64 usn;		/* Last update sequence number
-				of the file. This is a direct index into the
-				change (aka usn) journal file. It is zero if
-				the usn journal is disabled.
-				NOTE: To disable the journal need to delete
-				the journal file itself and to then walk the
-				whole mft and set all Usn entries in all mft
-				records to zero! (This can take a while!)
-				The journal is FILE_Extend/$UsnJrnl. Win2k
-				will recreate the journal and initiate
-				logging if necessary when mounting the
-				partition. This, in contrast to disabling the
-				journal is a very fast process, so the user
-				won't even notice it. */
-		/* 72*/ void *v3_end[0]; /* Marker for offsetof(). */
-		} __attribute__((__packed__));
+		void *v1_end[0];	/* (48) Marker for offsetof(). */
+	    } __attribute__((__packed__));
+	    /* sizeof() = 48 bytes */
+	    /* NTFS 3.0 */
+	    struct {
+		/*
+		 * If a volume has been upgraded from a previous NTFS version, then these
+		 * fields are present only if the file has been accessed since the upgrade.
+		 * Recognize the difference by comparing the length of the resident attribute
+		 * value. If it is 48, then the following fields are missing. If it is 72 then
+		 * the fields are present. Maybe just check like this:
+		 *	if (resident.ValueLength < sizeof(STANDARD_INFORMATION)) {
+		 *		Assume NTFS 1.2- format.
+		 *		If (volume version is 3.0+)
+		 *			Upgrade attribute to NTFS 3.0 format.
+		 *		else
+		 *			Use NTFS 1.2- format for access.
+		 *	} else
+		 *		Use NTFS 3.0 format for access.
+		 * Only problem is that it might be legal to set the length of the value to
+		 * arbitrarily large values thus spoiling this check. - But chkdsk probably
+		 * views that as a corruption, assuming that it behaves like this for all
+		 * attributes.
+		 */
+		le32 maximum_versions;	/* (36) Maximum allowed versions for
+					   file. Zero if version numbering is disabled. */
+		le32 version_number;	/* (40) This file's version (if any).
+					   Set to zero if maximum_versions is zero. */
+		le32 class_id;		/* (44) Class id from bidirectional
+					   class id index (?). */
+		le32 owner_id;		/* (48) Owner_id of the user owning
+					   the file. Translate via $Q index in FILE_Extend
+					   /$Quota to the quota control entry for the user
+					   owning the file. Zero if quotas are disabled. */
+		le32 security_id;	/* (52) Security_id for the file.
+					   Translate via $SII index and $SDS data stream
+					   in FILE_Secure to the security descriptor. */
+		le64 quota_charged;	/* (56) Byte size of the charge to
+					   the quota for all streams of the file. Note: Is
+					   zero if quotas are disabled. */
+		le64 usn;		/* (64) Last update sequence number
+					   of the file. This is a direct index into the
+					   change (aka usn) journal file. It is zero if
+					   the usn journal is disabled.
+					    NOTE: To disable the journal need to delete
+					    the journal file itself and to then walk the
+					    whole mft and set all Usn entries in all mft
+					    records to zero! (This can take a while!)
+					    The journal is FILE_Extend/$UsnJrnl. Win2k
+					    will recreate the journal and initiate
+					    logging if necessary when mounting the
+					    partition. This, in contrast to disabling the
+					    journal is a very fast process, so the user
+					    won't even notice it. */
+		void *v3_end[0]; /* (72) Marker for offsetof(). */
+	    } __attribute__((__packed__));
 	} __attribute__((__packed__));
-/* sizeof() = 72 bytes (NTFS 3.0) */
+	/* sizeof() = 72 bytes (NTFS 3.0) */
 } __attribute__((__packed__)) STANDARD_INFORMATION;
 
 /**
@@ -1022,14 +1020,14 @@ typedef struct {
  */
 typedef struct {
 /*Ofs*/
-/*  0*/	ATTR_TYPES type;	/* Type of referenced attribute. */
-/*  4*/	le16 length;		/* Byte size of this entry. */
-/*  6*/	u8 name_length;		/* Size in Unicode chars of the name of the
-				   attribute or 0 if unnamed. */
-/*  7*/	u8 name_offset;		/* Byte offset to beginning of attribute name
-				   (always set this to where the name would
-				   start even if unnamed). */
-/*  8*/	leVCN lowest_vcn;	/* Lowest virtual cluster number of this portion
+	ATTR_TYPES type;	/* ( 0) Type of referenced attribute. */
+	le16 length;	/* ( 4) Byte size of this entry. */
+	u8 name_length;	/* ( 6) Size in Unicode chars of the name of the
+			   attribute or 0 if unnamed. */
+	u8 name_offset;	/* ( 7) Byte offset to beginning of attribute name
+			   (always set this to where the name would
+			   start even if unnamed). */
+	leVCN lowest_vcn;	/* ( 8) Lowest virtual cluster number of this portion
 				   of the attribute value. This is usually 0. It
 				   is non-zero for the case where one attribute
 				   does not fit into one mft record and thus
@@ -1041,15 +1039,15 @@ typedef struct {
 				   value! The windows driver uses cmp, followed
 				   by jg when comparing this, thus it treats it
 				   as signed. */
-/* 16*/	leMFT_REF mft_reference;/* The reference of the mft record holding
-				   the ATTR_RECORD for this portion of the
-				   attribute value. */
-/* 24*/	le16 instance;		/* If lowest_vcn = 0, the instance of the
+	leMFT_REF mft_reference;	/* (16) The reference of the mft record holding
+					   the ATTR_RECORD for this portion of the
+					   attribute value. */
+	le16 instance;		/* (24) If lowest_vcn = 0, the instance of the
 				   attribute being referenced; otherwise 0. */
-/* 26*/	ntfschar name[0];	/* Use when creating only. When reading use
+	ntfschar name[0];	/* (26) Use when creating only. When reading use
 				   name_offset to determine the location of the
 				   name. */
-/* sizeof() = 26 + (attribute_name_length * 2) bytes */
+	/* sizeof() = 26 + (attribute_name_length * 2) bytes */
 } __attribute__((__packed__)) ATTR_LIST_ENTRY;
 
 /*
@@ -1063,30 +1061,30 @@ typedef struct {
  */
 typedef enum {
 	FILE_NAME_POSIX			= 0x00,
-		/* This is the largest namespace. It is case sensitive and
-		   allows all Unicode characters except for: '\0' and '/'.
-		   Beware that in WinNT/2k files which eg have the same name
-		   except for their case will not be distinguished by the
-		   standard utilities and thus a "del filename" will delete
-		   both "filename" and "fileName" without warning. */
+	/* This is the largest namespace. It is case sensitive and
+	   allows all Unicode characters except for: '\0' and '/'.
+	   Beware that in WinNT/2k files which eg have the same name
+	   except for their case will not be distinguished by the
+	   standard utilities and thus a "del filename" will delete
+	   both "filename" and "fileName" without warning. */
 	FILE_NAME_WIN32			= 0x01,
-		/* The standard WinNT/2k NTFS long filenames. Case insensitive.
-		   All Unicode chars except: '\0', '"', '*', '/', ':', '<',
-		   '>', '?', '\' and '|'.  Trailing dots and spaces are allowed,
-		   even though on Windows a filename with such a suffix can only
-		   be created and accessed using a WinNT-style path, i.e.
-		   \\?\-prefixed.  (If a regular path is used, Windows will
-		   strip the trailing dots and spaces, which makes such
-		   filenames incompatible with most Windows software.) */
+	/* The standard WinNT/2k NTFS long filenames. Case insensitive.
+	   All Unicode chars except: '\0', '"', '*', '/', ':', '<',
+	   '>', '?', '\' and '|'.  Trailing dots and spaces are allowed,
+	   even though on Windows a filename with such a suffix can only
+	   be created and accessed using a WinNT-style path, i.e.
+	   \\?\-prefixed.  (If a regular path is used, Windows will
+	   strip the trailing dots and spaces, which makes such
+	   filenames incompatible with most Windows software.) */
 	FILE_NAME_DOS			= 0x02,
-		/* The standard DOS filenames (8.3 format). Uppercase only.
-		   All 8-bit characters greater space, except: '"', '*', '+',
-		   ',', '/', ':', ';', '<', '=', '>', '?' and '\'.  Trailing
-		   dots and spaces are forbidden. */
+	/* The standard DOS filenames (8.3 format). Uppercase only.
+	   All 8-bit characters greater space, except: '"', '*', '+',
+	   ',', '/', ':', ';', '<', '=', '>', '?' and '\'.  Trailing
+	   dots and spaces are forbidden. */
 	FILE_NAME_WIN32_AND_DOS		= 0x03,
-		/* 3 means that both the Win32 and the DOS filenames are
-		   identical and hence have been saved in this single filename
-		   record. */
+	/* 3 means that both the Win32 and the DOS filenames are
+	   identical and hence have been saved in this single filename
+	   record. */
 } __attribute__((__packed__)) FILE_NAME_TYPE_FLAGS;
 
 /**
@@ -1104,16 +1102,16 @@ typedef enum {
  */
 typedef struct {
 /*hex ofs*/
-/*  0*/	leMFT_REF parent_directory;	/* Directory this filename is
+	leMFT_REF parent_directory;	/* (0x00) Directory this filename is
 					   referenced from. */
-/*  8*/	sle64 creation_time;		/* Time file was created. */
-/* 10*/	sle64 last_data_change_time;	/* Time the data attribute was last
+	sle64 creation_time;		/* (0x08) Time file was created. */
+	sle64 last_data_change_time;	/* (0x10) Time the data attribute was last
 					   modified. */
-/* 18*/	sle64 last_mft_change_time;	/* Time this mft record was last
+	sle64 last_mft_change_time;	/* (0x18) Time this mft record was last
 					   modified. */
-/* 20*/	sle64 last_access_time;		/* Last time this mft record was
+	sle64 last_access_time;		/* (0x20) Last time this mft record was
 					   accessed. */
-/* 28*/	sle64 allocated_size;		/* Byte size of on-disk allocated space
+	sle64 allocated_size;		/* (0x28) Byte size of on-disk allocated space
 					   for the data attribute.  So for
 					   normal $DATA, this is the
 					   allocated_size from the unnamed
@@ -1122,25 +1120,25 @@ typedef struct {
 					   compressed_size from the unnamed
 					   $DATA attribute.  NOTE: This is a
 					   multiple of the cluster size. */
-/* 30*/	sle64 data_size;			/* Byte size of actual data in data
-					   attribute. */
-/* 38*/	FILE_ATTR_FLAGS file_attributes;	/* Flags describing the file. */
-/* 3c*/	union {
-	/* 3c*/	struct {
-		/* 3c*/	le16 packed_ea_size;	/* Size of the buffer needed to
+	sle64 data_size;			/* (0x30) Byte size of actual data in data
+										   attribute. */
+	FILE_ATTR_FLAGS file_attributes;	/* (0x38) Flags describing the file. */
+	union {		/* (0x3c) */
+		struct {	/* (0x3c) */
+			le16 packed_ea_size;	/* (0x3c) Size of the buffer needed to
 						   pack the extended attributes
 						   (EAs), if such are present.*/
-		/* 3e*/	le16 reserved;		/* Reserved for alignment. */
+			le16 reserved;		/* (0x3e) Reserved for alignment. */
 		} __attribute__((__packed__));
-	/* 3c*/	le32 reparse_point_tag;		/* Type of reparse point,
+		le32 reparse_point_tag;		/* (0x3c) Type of reparse point,
 						   present only in reparse
 						   points and only if there are
 						   no EAs. */
 	} __attribute__((__packed__));
-/* 40*/	u8 file_name_length;			/* Length of file name in
+	u8 file_name_length;			/* (0x40) Length of file name in
 						   (Unicode) characters. */
-/* 41*/	FILE_NAME_TYPE_FLAGS file_name_type;	/* Namespace of the file name.*/
-/* 42*/	ntfschar file_name[0];			/* File name in Unicode. */
+	FILE_NAME_TYPE_FLAGS file_name_type;	/* (0x41) Namespace of the file name.*/
+	ntfschar file_name[0];			/* (0x42) File name in Unicode. */
 } __attribute__((__packed__)) FILE_NAME_ATTR;
 
 /**
@@ -1196,8 +1194,7 @@ typedef struct {
  * NOTE: Always resident.
  */
 typedef struct {
-	GUID object_id;				/* Unique id assigned to the
-						   file.*/
+	GUID object_id;		/* Unique id assigned to the file.*/
 	/* The following fields are optional. The attribute value size is 16
 	   bytes, i.e. sizeof(GUID), if these are not present at all. Note,
 	   the entries can be present but one or more (or all) can be zero
@@ -1408,7 +1405,7 @@ typedef enum {
 	SID_REVISION			=  1,	/* Current revision level. */
 	SID_MAX_SUB_AUTHORITIES		= 15,	/* Maximum number of those. */
 	SID_RECOMMENDED_SUB_AUTHORITIES	=  1,	/* Will change to around 6 in
-						   a future revision. */
+											   a future revision. */
 } SID_CONSTANTS;
 
 /**
@@ -1663,14 +1660,14 @@ typedef struct {
  */
 typedef struct {
 /*  0	ACE_HEADER; -- Unfolded here as gcc doesn't like unnamed structs. */
-	ACE_TYPES type;		/* Type of the ACE. */
+	ACE_TYPES type;		/* ( 0) Type of the ACE. */
 	ACE_FLAGS flags;	/* Flags describing the ACE. */
 	le16 size;		/* Size in bytes of the ACE. */
 
-/*  4*/	ACCESS_MASK mask;	/* Access mask associated with the ACE. */
-/*  8*/	SID sid;		/* The SID associated with the ACE. */
+	ACCESS_MASK mask;	/* ( 4) Access mask associated with the ACE. */
+	SID sid;		/* ( 8) The SID associated with the ACE. */
 } __attribute__((__packed__)) ACCESS_ALLOWED_ACE, ACCESS_DENIED_ACE,
-			       SYSTEM_AUDIT_ACE, SYSTEM_ALARM_ACE;
+	SYSTEM_AUDIT_ACE, SYSTEM_ALARM_ACE;
 
 /**
  * enum OBJECT_ACE_FLAGS - The object ACE flags (32-bit).
@@ -1685,19 +1682,19 @@ typedef enum {
  */
 typedef struct {
 /*  0	ACE_HEADER; -- Unfolded here as gcc doesn't like unnamed structs. */
-	ACE_TYPES type;		/* Type of the ACE. */
+	ACE_TYPES type;		/* ( 0) Type of the ACE. */
 	ACE_FLAGS flags;	/* Flags describing the ACE. */
 	le16 size;		/* Size in bytes of the ACE. */
 
-/*  4*/	ACCESS_MASK mask;	/* Access mask associated with the ACE. */
-/*  8*/	OBJECT_ACE_FLAGS object_flags;	/* Flags describing the object ACE. */
-/* 12*/	GUID object_type;
-/* 28*/	GUID inherited_object_type;
-/* 44*/	SID sid;		/* The SID associated with the ACE. */
+	ACCESS_MASK mask;	/* ( 4) Access mask associated with the ACE. */
+	OBJECT_ACE_FLAGS object_flags;	/* ( 8) Flags describing the object ACE. */
+	GUID object_type;	/* (12) */
+	GUID inherited_object_type;	/* (28) */
+	SID sid;		/* (44) The SID associated with the ACE. */
 } __attribute__((__packed__)) ACCESS_ALLOWED_OBJECT_ACE,
-			       ACCESS_DENIED_OBJECT_ACE,
-			       SYSTEM_AUDIT_OBJECT_ACE,
-			       SYSTEM_ALARM_OBJECT_ACE;
+	ACCESS_DENIED_OBJECT_ACE,
+	SYSTEM_AUDIT_OBJECT_ACE,
+	SYSTEM_ALARM_OBJECT_ACE;
 
 /**
  * struct ACL - An ACL is an access-control list (ACL).
@@ -1714,7 +1711,7 @@ typedef struct {
 			   header, the ACEs and the remaining free space. */
 	le16 ace_count;	/* Number of ACEs in the ACL. */
 	le16 alignment2;
-/* sizeof() = 8 bytes */
+	/* sizeof() = 8 bytes */
 } __attribute__((__packed__)) ACL;
 
 /**
@@ -1810,7 +1807,7 @@ typedef struct {
 	u8 revision;	/* Revision level of the security descriptor. */
 	u8 alignment;
 	SECURITY_DESCRIPTOR_CONTROL control; /* Flags qualifying the type of
-			   the descriptor as well as the following fields. */
+						the descriptor as well as the following fields. */
 	le32 owner;	/* Byte offset to a SID representing an object's
 			   owner. If this is NULL, no owner SID is present in
 			   the descriptor. */
@@ -1825,7 +1822,7 @@ typedef struct {
 			   SE_DACL_PRESENT is set in the control field. If
 			   SE_DACL_PRESENT is set but dacl is NULL, a NULL ACL
 			   (unconditionally granting access) is specified. */
-/* sizeof() = 0x14 bytes */
+	/* sizeof() = 0x14 bytes */
 } __attribute__((__packed__)) SECURITY_DESCRIPTOR_RELATIVE;
 
 /**
@@ -1842,7 +1839,7 @@ typedef struct {
 	u8 revision;	/* Revision level of the security descriptor. */
 	u8 alignment;
 	SECURITY_DESCRIPTOR_CONTROL control;	/* Flags qualifying the type of
-			   the descriptor as well as the following fields. */
+						   the descriptor as well as the following fields. */
 	SID *owner;	/* Points to a SID representing an object's owner. If
 			   this is NULL, no owner SID is present in the
 			   descriptor. */
@@ -1947,7 +1944,7 @@ typedef struct {
 	le64 offset;	   /* Byte offset of this entry in the $SDS stream. */
 	le32 length;	   /* Size in bytes of this entry in $SDS stream. */
 	le32 reserved_II;   /* Padding - always unicode "II" or zero. This field
-			      isn't counted in INDEX_ENTRY's data_length. */
+			       isn't counted in INDEX_ENTRY's data_length. */
 } __attribute__((__packed__)) SDH_INDEX_DATA;
 
 /**
@@ -1969,13 +1966,13 @@ typedef SECURITY_DESCRIPTOR_HEADER SII_INDEX_DATA;
  * $SDS data stream and the second copy will be at offset 0x451d0.
  */
 typedef struct {
-/*  0	SECURITY_DESCRIPTOR_HEADER; -- Unfolded here as gcc doesn't like
-				       unnamed structs. */
+	/*  0	SECURITY_DESCRIPTOR_HEADER; -- Unfolded here as gcc doesn't like
+		unnamed structs. */
 	le32 hash;	   /* Hash of the security descriptor. */
 	le32 security_id;   /* The security_id assigned to the descriptor. */
 	le64 offset;	   /* Byte offset of this entry in the $SDS stream. */
 	le32 length;	   /* Size in bytes of this entry in $SDS stream. */
-/* 20*/	SECURITY_DESCRIPTOR_RELATIVE sid; /* The self-relative security
+	SECURITY_DESCRIPTOR_RELATIVE sid; /* (20) The self-relative security
 					     descriptor. */
 } __attribute__((__packed__)) SDS_ENTRY;
 
@@ -2084,24 +2081,24 @@ typedef enum {
  * start of the index root or index allocation structures themselves.
  */
 typedef struct {
-/*  0*/	le32 entries_offset;	/* Byte offset from the INDEX_HEADER to first
+	le32 entries_offset;	/* ( 0) Byte offset from the INDEX_HEADER to first
 				   INDEX_ENTRY, aligned to 8-byte boundary.  */
-/*  4*/	le32 index_length;	/* Data size in byte of the INDEX_ENTRY's,
+	le32 index_length;	/* ( 4) Data size in byte of the INDEX_ENTRY's,
 				   including the INDEX_HEADER, aligned to 8. */
-/*  8*/	le32 allocated_size;	/* Allocated byte size of this index (block),
+	le32 allocated_size;	/* ( 8) Allocated byte size of this index (block),
 				   multiple of 8 bytes. See more below.      */
-	/* 
+	/*
 	   For the index root attribute, the above two numbers are always
 	   equal, as the attribute is resident and it is resized as needed.
-	   
-	   For the index allocation attribute, the attribute is not resident 
-	   and the allocated_size is equal to the index_block_size specified 
-	   by the corresponding INDEX_ROOT attribute minus the INDEX_BLOCK 
+
+	   For the index allocation attribute, the attribute is not resident
+	   and the allocated_size is equal to the index_block_size specified
+	   by the corresponding INDEX_ROOT attribute minus the INDEX_BLOCK
 	   size not counting the INDEX_HEADER part (i.e. minus -24).
-	 */
-/* 12*/	INDEX_HEADER_FLAGS ih_flags;	/* Bit field of INDEX_HEADER_FLAGS.  */
-/* 13*/	u8 reserved[3];			/* Reserved/align to 8-byte boundary.*/
-/* sizeof() == 16 */
+	   */
+	INDEX_HEADER_FLAGS ih_flags;	/* (12) Bit field of INDEX_HEADER_FLAGS.  */
+	u8 reserved[3];			/* (13) Reserved/align to 8-byte boundary.*/
+	/* sizeof() == 16 */
 } __attribute__((__packed__)) INDEX_HEADER;
 
 /*
@@ -2131,23 +2128,23 @@ typedef struct {
  * directories do not contain entries for themselves, though.
  */
 typedef struct {
-/*  0*/	ATTR_TYPES type;		/* Type of the indexed attribute. Is
+	ATTR_TYPES type;		/* ( 0) Type of the indexed attribute. Is
 					   $FILE_NAME for directories, zero
 					   for view indexes. No other values
 					   allowed. */
-/*  4*/	COLLATION_RULES collation_rule;	/* Collation rule used to sort the
+	COLLATION_RULES collation_rule;	/* ( 4) Collation rule used to sort the
 					   index entries. If type is $FILE_NAME,
 					   this must be COLLATION_FILE_NAME. */
-/*  8*/	le32 index_block_size;		/* Size of index block in bytes (in
+	le32 index_block_size;		/* ( 8) Size of index block in bytes (in
 					   the index allocation attribute). */
-/* 12*/	s8 clusters_per_index_block;	/* Size of index block in clusters (in
+	s8 clusters_per_index_block;	/* (12) Size of index block in clusters (in
 					   the index allocation attribute), when
 					   an index block is >= than a cluster,
 					   otherwise sectors per index block. */
-/* 13*/	u8 reserved[3];			/* Reserved/align to 8-byte boundary. */
-/* 16*/	INDEX_HEADER index;		/* Index header describing the
+	u8 reserved[3];			/* (13) Reserved/align to 8-byte boundary. */
+	INDEX_HEADER index;		/* (16) Index header describing the
 					   following index entries. */
-/* sizeof()= 32 bytes */
+	/* sizeof()= 32 bytes */
 } __attribute__((__packed__)) INDEX_ROOT;
 
 /*
@@ -2172,25 +2169,25 @@ typedef struct {
  * index entries (INDEX_ENTRY structures), as described by the INDEX_HEADER.
  */
 typedef struct {
-/*  0	NTFS_RECORD; -- Unfolded here as gcc doesn't like unnamed structs. */
+	/*  0	NTFS_RECORD; -- Unfolded here as gcc doesn't like unnamed structs. */
 	NTFS_RECORD_TYPES magic;/* Magic is "INDX". */
 	le16 usa_ofs;		/* See NTFS_RECORD definition. */
 	le16 usa_count;		/* See NTFS_RECORD definition. */
 
-/*  8*/	leLSN lsn;		/* $LogFile sequence number of the last
+	leLSN lsn;		/* ( 8) $LogFile sequence number of the last
 				   modification of this index block. */
-/* 16*/	leVCN index_block_vcn;	/* Virtual cluster number of the index block. */
-/* 24*/	INDEX_HEADER index;	/* Describes the following index entries. */
-/* sizeof()= 40 (0x28) bytes */
-/*
- * When creating the index block, we place the update sequence array at this
- * offset, i.e. before we start with the index entries. This also makes sense,
- * otherwise we could run into problems with the update sequence array
- * containing in itself the last two bytes of a sector which would mean that
- * multi sector transfer protection wouldn't work. As you can't protect data
- * by overwriting it since you then can't get it back...
- * When reading use the data from the ntfs record header.
- */
+	leVCN index_block_vcn;	/* (16) Virtual cluster number of the index block. */
+	INDEX_HEADER index;	/* (24) Describes the following index entries. */
+	/* sizeof()= 40 (0x28) bytes */
+	/*
+	 * When creating the index block, we place the update sequence array at this
+	 * offset, i.e. before we start with the index entries. This also makes sense,
+	 * otherwise we could run into problems with the update sequence array
+	 * containing in itself the last two bytes of a sector which would mean that
+	 * multi sector transfer protection wouldn't work. As you can't protect data
+	 * by overwriting it since you then can't get it back...
+	 * When reading use the data from the ntfs record header.
+	 */
 } __attribute__((__packed__)) INDEX_BLOCK;
 
 typedef INDEX_BLOCK INDEX_ALLOCATION;
@@ -2222,7 +2219,7 @@ typedef enum {
 	QUOTA_FLAG_ID_DELETED		= const_cpu_to_le32(0x00000004),
 
 	QUOTA_FLAG_USER_MASK		= const_cpu_to_le32(0x00000007),
-		/* Bit mask for user quota flags. */
+	/* Bit mask for user quota flags. */
 
 	/* These flags are only present in the quota defaults index entry,
 	   i.e. in the entry where owner_id = QUOTA_DEFAULTS_ID. */
@@ -2262,12 +2259,12 @@ typedef enum {
 typedef struct {
 	le32 version;		/* Currently equals 2. */
 	QUOTA_FLAGS flags;	/* Flags describing this quota entry. */
-	le64 bytes_used;		/* How many bytes of the quota are in use. */
+	le64 bytes_used;	/* How many bytes of the quota are in use. */
 	sle64 change_time;	/* Last time this quota entry was changed. */
-	sle64 threshold;		/* Soft quota (-1 if not limited). */
+	sle64 threshold;	/* Soft quota (-1 if not limited). */
 	sle64 limit;		/* Hard quota (-1 if not limited). */
 	sle64 exceeded_time;	/* How long the soft quota has been exceeded. */
-/* The below field is NOT present for the quota defaults entry. */
+	/* The below field is NOT present for the quota defaults entry. */
 	SID sid;		/* The SID of the user/object associated with
 				   this quota entry. If this field is missing
 				   then the INDEX_ENTRY is padded to a multiple
@@ -2302,25 +2299,25 @@ typedef enum {
  */
 typedef enum {
 	INDEX_ENTRY_NODE = const_cpu_to_le16(1), /* This entry contains a
-					sub-node, i.e. a reference to an index
-					block in form of a virtual cluster
-					number (see below). */
+						    sub-node, i.e. a reference to an index
+						    block in form of a virtual cluster
+						    number (see below). */
 	INDEX_ENTRY_END  = const_cpu_to_le16(2), /* This signifies the last
-					entry in an index block. The index
-					entry does not represent a file but it
-					can point to a sub-node. */
+						    entry in an index block. The index
+						    entry does not represent a file but it
+						    can point to a sub-node. */
 	INDEX_ENTRY_SPACE_FILLER = 0xffff, /* Just to force 16-bit width. */
 } __attribute__((__packed__)) INDEX_ENTRY_FLAGS;
 
 /**
  * struct INDEX_ENTRY_HEADER - This the index entry header (see below).
- * 
+ *
  *         ==========================================================
  *         !!!!!  SEE DESCRIPTION OF THE FIELDS AT INDEX_ENTRY  !!!!!
  *         ==========================================================
  */
 typedef struct {
-/*  0*/	union {
+	union {	/* ( 0) */
 		leMFT_REF indexed_file;
 		struct {
 			le16 data_offset;
@@ -2328,11 +2325,11 @@ typedef struct {
 			le32 reservedV;
 		} __attribute__((__packed__));
 	} __attribute__((__packed__));
-/*  8*/	le16 length;
-/* 10*/	le16 key_length;
-/* 12*/	INDEX_ENTRY_FLAGS flags;
-/* 14*/	le16 reserved;
-/* sizeof() = 16 bytes */
+	le16 length;		/* ( 8) */
+	le16 key_length;	/* (10) */
+	INDEX_ENTRY_FLAGS flags;/* (12) */
+	le16 reserved;		/* (14) */
+	/* sizeof() = 16 bytes */
 } __attribute__((__packed__)) INDEX_ENTRY_HEADER;
 
 /**
@@ -2345,7 +2342,7 @@ typedef struct {
  * NOTE: Before NTFS 3.0 only filename attributes were indexed.
  */
 typedef struct {
-/*  0	INDEX_ENTRY_HEADER; -- Unfolded here as gcc dislikes unnamed structs. */
+	/*  0	INDEX_ENTRY_HEADER; -- Unfolded here as gcc dislikes unnamed structs. */
 	union {		/* Only valid when INDEX_ENTRY_END is not set. */
 		leMFT_REF indexed_file;		/* The mft reference of the file
 						   described by this index
@@ -2359,16 +2356,16 @@ typedef struct {
 			le32 reservedV;		/* Reserved (zero). */
 		} __attribute__((__packed__));
 	} __attribute__((__packed__));
-/*  8*/ le16 length;		 /* Byte size of this index entry, multiple of
+	le16 length;		 /* ( 8) Byte size of this index entry, multiple of
 				    8-bytes. Size includes INDEX_ENTRY_HEADER
 				    and the optional subnode VCN. See below. */
-/* 10*/ le16 key_length;		 /* Byte size of the key value, which is in the
+	le16 key_length;	 /* (10) Byte size of the key value, which is in the
 				    index entry. It follows field reserved. Not
 				    multiple of 8-bytes. */
-/* 12*/	INDEX_ENTRY_FLAGS ie_flags; /* Bit field of INDEX_ENTRY_* flags. */
-/* 14*/	le16 reserved;		 /* Reserved/align to 8-byte boundary. */
-/*	End of INDEX_ENTRY_HEADER */
-/* 16*/	union {		/* The key of the indexed attribute. NOTE: Only present
+	INDEX_ENTRY_FLAGS ie_flags; /* (12) Bit field of INDEX_ENTRY_* flags. */
+	le16 reserved;		 /* (14) Reserved/align to 8-byte boundary. */
+	/*	End of INDEX_ENTRY_HEADER */
+	union {		/* (16) The key of the indexed attribute. NOTE: Only present
 			   if INDEX_ENTRY_END bit in flags is not set. NOTE: On
 			   NTFS versions before 3.0 the only valid key is the
 			   FILE_NAME_ATTR. On NTFS 3.0+ the following
@@ -2389,17 +2386,17 @@ typedef struct {
 					   the index. */
 	} __attribute__((__packed__)) key;
 	/* The (optional) index data is inserted here when creating.
-	leVCN vcn;	   If INDEX_ENTRY_NODE bit in ie_flags is set, the last
-			   eight bytes of this index entry contain the virtual
-			   cluster number of the index block that holds the
-			   entries immediately preceding the current entry. 
-	
-			   If the key_length is zero, then the vcn immediately
-			   follows the INDEX_ENTRY_HEADER. 
-	
-			   The address of the vcn of "ie" INDEX_ENTRY is given by 
-			   (char*)ie + le16_to_cpu(ie->length) - sizeof(VCN)
-	*/
+	   leVCN vcn;	   If INDEX_ENTRY_NODE bit in ie_flags is set, the last
+	   eight bytes of this index entry contain the virtual
+	   cluster number of the index block that holds the
+	   entries immediately preceding the current entry.
+
+	   If the key_length is zero, then the vcn immediately
+	   follows the INDEX_ENTRY_HEADER.
+
+	   The address of the vcn of "ie" INDEX_ENTRY is given by
+	   (char*)ie + le16_to_cpu(ie->length) - sizeof(VCN)
+	   */
 } __attribute__((__packed__)) INDEX_ENTRY;
 
 /**
@@ -2595,23 +2592,23 @@ typedef struct {
  * The header of the Logged utility stream (0x100) attribute named "$EFS".
  */
 typedef struct {
-/*  0*/	le32 length;		/* Length of EFS attribute in bytes. */
+	le32 length;		/* ( 0) Length of EFS attribute in bytes. */
 	le32 state;		/* Always 0? */
 	le32 version;		/* Efs version.  Always 2? */
 	le32 crypto_api_version;	/* Always 0? */
-/* 16*/	u8 unknown4[16];	/* MD5 hash of decrypted FEK?  This field is
+	u8 unknown4[16];	/* (16) MD5 hash of decrypted FEK?  This field is
 				   created with a call to UuidCreate() so is
 				   unlikely to be an MD5 hash and is more
 				   likely to be GUID of this encrytped file
 				   or something like that. */
-/* 32*/	u8 unknown5[16];	/* MD5 hash of DDFs? */
-/* 48*/	u8 unknown6[16];	/* MD5 hash of DRFs? */
-/* 64*/	le32 offset_to_ddf_array;/* Offset in bytes to the array of data
-				   decryption fields (DDF), see below.  Zero if
-				   no DDFs are present. */
+	u8 unknown5[16];	/* (32) MD5 hash of DDFs? */
+	u8 unknown6[16];	/* (48) MD5 hash of DRFs? */
+	le32 offset_to_ddf_array;/* (64) Offset in bytes to the array of data
+				    decryption fields (DDF), see below.  Zero if
+				    no DDFs are present. */
 	le32 offset_to_drf_array;/* Offset in bytes to the array of data
-				   recovery fields (DRF), see below.  Zero if
-				   no DRFs are present. */
+				    recovery fields (DRF), see below.  Zero if
+				    no DRFs are present. */
 	le32 reserved;		/* Reserved. */
 } __attribute__((__packed__)) EFS_ATTR_HEADER;
 
@@ -2627,52 +2624,52 @@ typedef struct {
  * struct EFS_DF_HEADER -
  */
 typedef struct {
-/*  0*/	le32 df_length;		/* Length of this data decryption/recovery
+	le32 df_length;		/* ( 0) Length of this data decryption/recovery
 				   field in bytes. */
 	le32 cred_header_offset;	/* Offset in bytes to the credential header. */
 	le32 fek_size;		/* Size in bytes of the encrypted file
 				   encryption key (FEK). */
-	le32 fek_offset;		/* Offset in bytes to the FEK from the start of
+	le32 fek_offset;	/* Offset in bytes to the FEK from the start of
 				   the data decryption/recovery field. */
-/* 16*/	le32 unknown1;		/* always 0?  Might be just padding. */
+	le32 unknown1;		/* (16) always 0?  Might be just padding. */
 } __attribute__((__packed__)) EFS_DF_HEADER;
 
 /**
  * struct EFS_DF_CREDENTIAL_HEADER -
  */
 typedef struct {
-/*  0*/	le32 cred_length;	/* Length of this credential in bytes. */
-	le32 sid_offset;		/* Offset in bytes to the user's sid from start
+	le32 cred_length;	/* ( 0) Length of this credential in bytes. */
+	le32 sid_offset;	/* Offset in bytes to the user's sid from start
 				   of this structure.  Zero if no sid is
 				   present. */
-/*  8*/	le32 type;		/* Type of this credential:
-					1 = CryptoAPI container.
-					2 = Unexpected type.
-					3 = Certificate thumbprint.
-					other = Unknown type. */
+	le32 type;		/* ( 8) Type of this credential:
+				   1 = CryptoAPI container.
+				   2 = Unexpected type.
+				   3 = Certificate thumbprint.
+				   other = Unknown type. */
 	union {
 		/* CryptoAPI container. */
 		struct {
-/* 12*/			le32 container_name_offset;	/* Offset in bytes to
-				   the name of the container from start of this
-				   structure (may not be zero). */
-/* 16*/			le32 provider_name_offset;	/* Offset in bytes to
-				   the name of the provider from start of this
-				   structure (may not be zero). */
-			le32 public_key_blob_offset;	/* Offset in bytes to
-				   the public key blob from start of this
-				   structure. */
-/* 24*/			le32 public_key_blob_size;	/* Size in bytes of
-				   public key blob. */
+			le32 container_name_offset;	/* (12) Offset in bytes to
+							   the name of the container from start of this
+							   structure (may not be zero). */
+			le32 provider_name_offset;	/* (16) Offset in bytes to
+							   the name of the provider from start of this
+							   structure (may not be zero). */
+			le32 public_key_blob_offset;	/* (20) Offset in bytes to
+							   the public key blob from start of this
+							   structure. */
+			le32 public_key_blob_size;	/* (24) Size in bytes of
+							   public key blob. */
 		} __attribute__((__packed__));
 		/* Certificate thumbprint. */
 		struct {
-/* 12*/			le32 cert_thumbprint_header_size;	/* Size in
-				   bytes of the header of the certificate
-				   thumbprint. */
-/* 16*/			le32 cert_thumbprint_header_offset;	/* Offset in
-				   bytes to the header of the certificate
-				   thumbprint from start of this structure. */
+			le32 cert_thumbprint_header_size;	/* (12) Size in
+								   bytes of the header of the certificate
+								   thumbprint. */
+			le32 cert_thumbprint_header_offset;	/* (16) Offset in
+								   bytes to the header of the certificate
+								   thumbprint from start of this structure. */
 			le32 unknown1;	/* Always 0?  Might be padding... */
 			le32 unknown2;	/* Always 0?  Might be padding... */
 		} __attribute__((__packed__));
@@ -2685,16 +2682,16 @@ typedef EFS_DF_CREDENTIAL_HEADER EFS_DF_CRED_HEADER;
  * struct EFS_DF_CERTIFICATE_THUMBPRINT_HEADER -
  */
 typedef struct {
-/*  0*/	le32 thumbprint_offset;		/* Offset in bytes to the thumbprint. */
+	le32 thumbprint_offset;		/* ( 0) Offset in bytes to the thumbprint. */
 	le32 thumbprint_size;		/* Size of thumbprint in bytes. */
-/*  8*/	le32 container_name_offset;	/* Offset in bytes to the name of the
+	le32 container_name_offset;	/* ( 8) Offset in bytes to the name of the
 					   container from start of this
 					   structure or 0 if no name present. */
 	le32 provider_name_offset;	/* Offset in bytes to the name of the
 					   cryptographic provider from start of
 					   this structure or 0 if no name
 					   present. */
-/* 16*/	le32 user_name_offset;		/* Offset in bytes to the user name
+	le32 user_name_offset;		/* (16) Offset in bytes to the user name
 					   from start of this structure or 0 if
 					   no user name present.  (This is also
 					   known as lpDisplayInformation.) */

--- a/include/logfile.h
+++ b/include/logfile.h
@@ -63,39 +63,39 @@
  * Begins the restart area.
  */
 typedef struct {
-/*Ofs*/
-/*  0	NTFS_RECORD; -- Unfolded here as gcc doesn't like unnamed structs. */
-/*  0*/	NTFS_RECORD_TYPES magic;/* The magic is "RSTR". */
-/*  4*/	le16 usa_ofs;		/* See NTFS_RECORD definition in layout.h.
+	/*Ofs*/
+	/*  0	NTFS_RECORD; -- Unfolded here as gcc doesn't like unnamed structs. */
+	NTFS_RECORD_TYPES magic;/* ( 0) The magic is "RSTR". */
+	le16 usa_ofs;		/* ( 4) See NTFS_RECORD definition in layout.h.
 				   When creating, set this to be immediately
 				   after this header structure (without any
 				   alignment). */
-/*  6*/	le16 usa_count;		/* See NTFS_RECORD definition in layout.h. */
+	le16 usa_count;		/* ( 6) See NTFS_RECORD definition in layout.h. */
 
-/*  8*/	leLSN chkdsk_lsn;	/* The last log file sequence number found by
+	leLSN chkdsk_lsn;	/* ( 8) The last log file sequence number found by
 				   chkdsk.  Only used when the magic is changed
 				   to "CHKD".  Otherwise this is zero. */
-/* 16*/	le32 system_page_size;	/* Byte size of system pages when the log file
+	le32 system_page_size;	/* (16) Byte size of system pages when the log file
 				   was created, has to be >= 512 and a power of
 				   2.  Use this to calculate the required size
 				   of the usa (usa_count) and add it to usa_ofs.
 				   Then verify that the result is less than the
 				   value of the restart_area_offset. */
-/* 20*/	le32 log_page_size;	/* Byte size of log file pages, has to be >=
+	le32 log_page_size;	/* (20) Byte size of log file pages, has to be >=
 				   512 and a power of 2.  The default is 4096
 				   and is used when the system page size is
 				   between 4096 and 8192.  Otherwise this is
 				   set to the system page size instead. */
-/* 24*/	le16 restart_area_offset;/* Byte offset from the start of this header to
-				   the RESTART_AREA.  Value has to be aligned
-				   to 8-byte boundary.  When creating, set this
-				   to be after the usa. */
-/* 26*/	sle16 minor_ver;	/* Log file minor version.  Only check if major
+	le16 restart_area_offset;/* (24) Byte offset from the start of this header to
+				    the RESTART_AREA.  Value has to be aligned
+				    to 8-byte boundary.  When creating, set this
+				    to be after the usa. */
+	sle16 minor_ver;	/* (26) Log file minor version.  Only check if major
 				   version is 1. */
-/* 28*/	sle16 major_ver;	/* Log file major version.  We only support
+	sle16 major_ver;	/* (28) Log file major version.  We only support
 				   version 1.1. */
-/* 30*/	le16 usn;
-/* sizeof() = 32 (0x20) bytes */
+	le16 usn;		/* (30) */
+	/* sizeof() = 32 (0x20) bytes */
 } __attribute__((__packed__)) RESTART_PAGE_HEADER;
 
 /*
@@ -125,17 +125,17 @@ typedef le16 RESTART_AREA_FLAGS;
  * See notes at restart_area_offset above.
  */
 typedef struct {
-/*Ofs*/
-/*  0*/	leLSN current_lsn;	/* The current, i.e. last LSN inside the log
+	/*Ofs*/
+	leLSN current_lsn;	/* ( 0) The current, i.e. last LSN inside the log
 				   when the restart area was last written.
 				   This happens often but what is the interval?
 				   Is it just fixed time or is it every time a
 				   check point is written or something else?
 				   On create set to 0. */
-/*  8*/	le16 log_clients;	/* Number of log client records in the array of
+	le16 log_clients;	/* ( 8) Number of log client records in the array of
 				   log client records which follows this
 				   restart area.  Must be 1.  */
-/* 10*/	le16 client_free_list;	/* The index of the first free log client record
+	le16 client_free_list;	/* (10) The index of the first free log client record
 				   in the array of log client records.
 				   LOGFILE_NO_CLIENT means that there are no
 				   free log client records in the array.
@@ -151,7 +151,7 @@ typedef struct {
 				   and presumably later, the logfile is always
 				   open, even on clean shutdown so this should
 				   always be LOGFILE_NO_CLIENT. */
-/* 12*/	le16 client_in_use_list;/* The index of the first in-use log client
+	le16 client_in_use_list;/* (12) The index of the first in-use log client
 				   record in the array of log client records.
 				   LOGFILE_NO_CLIENT means that there are no
 				   in-use log client records in the array.  If
@@ -168,59 +168,59 @@ typedef struct {
 				   presumably later, the logfile is always
 				   open, even on clean shutdown so this should
 				   always be 0. */
-/* 14*/	RESTART_AREA_FLAGS flags;/* Flags modifying LFS behaviour.  On Win2k
-				   and presumably earlier this is always 0.  On
-				   WinXP and presumably later, if the logfile
-				   was shutdown cleanly, the second bit,
-				   RESTART_VOLUME_IS_CLEAN, is set.  This bit
-				   is cleared when the volume is mounted by
-				   WinXP and set when the volume is dismounted,
-				   thus if the logfile is dirty, this bit is
-				   clear.  Thus we don't need to check the
-				   Windows version to determine if the logfile
-				   is clean.  Instead if the logfile is closed,
-				   we know it must be clean.  If it is open and
-				   this bit is set, we also know it must be
-				   clean.  If on the other hand the logfile is
-				   open and this bit is clear, we can be almost
-				   certain that the logfile is dirty. */
-/* 16*/	le32 seq_number_bits;	/* How many bits to use for the sequence
+	RESTART_AREA_FLAGS flags;/* (14) Flags modifying LFS behaviour.  On Win2k
+				    and presumably earlier this is always 0.  On
+				    WinXP and presumably later, if the logfile
+				    was shutdown cleanly, the second bit,
+				    RESTART_VOLUME_IS_CLEAN, is set.  This bit
+				    is cleared when the volume is mounted by
+				    WinXP and set when the volume is dismounted,
+				    thus if the logfile is dirty, this bit is
+				    clear.  Thus we don't need to check the
+				    Windows version to determine if the logfile
+				    is clean.  Instead if the logfile is closed,
+				    we know it must be clean.  If it is open and
+				    this bit is set, we also know it must be
+				    clean.  If on the other hand the logfile is
+				    open and this bit is clear, we can be almost
+				    certain that the logfile is dirty. */
+	le32 seq_number_bits;	/* (16) How many bits to use for the sequence
 				   number.  This is calculated as 67 - the
 				   number of bits required to store the logfile
 				   size in bytes and this can be used in with
 				   the specified file_size as a consistency
 				   check. */
-/* 20*/	le16 restart_area_length;/* Length of the restart area including the
-				   client array.  Following checks required if
-				   version matches.  Otherwise, skip them.
-				   restart_area_offset + restart_area_length
-				   has to be <= system_page_size.  Also,
-				   restart_area_length has to be >=
-				   client_array_offset + (log_clients *
-				   sizeof(log client record)). */
-/* 22*/	le16 client_array_offset;/* Offset from the start of this record to
-				   the first log client record if versions are
-				   matched.  When creating, set this to be
-				   after this restart area structure, aligned
-				   to 8-bytes boundary.  If the versions do not
-				   match, this is ignored and the offset is
-				   assumed to be (sizeof(RESTART_AREA) + 7) &
-				   ~7, i.e. rounded up to first 8-byte
-				   boundary.  Either way, client_array_offset
-				   has to be aligned to an 8-byte boundary.
-				   Also, restart_area_offset +
-				   client_array_offset has to be <= 510.
-				   Finally, client_array_offset + (log_clients
-				   * sizeof(log client record)) has to be <=
-				   system_page_size.  On Win2k and presumably
-				   earlier, this is 0x30, i.e. immediately
-				   following this record.  On WinXP and
-				   presumably later, this is 0x40, i.e. there
-				   are 16 extra bytes between this record and
-				   the client array.  This probably means that
-				   the RESTART_AREA record is actually bigger
-				   in WinXP and later. */
-/* 24*/	sle64 file_size;	/* Usable byte size of the log file.  If the
+	le16 restart_area_length;/* (20) Length of the restart area including the
+				    client array.  Following checks required if
+				    version matches.  Otherwise, skip them.
+				    restart_area_offset + restart_area_length
+				    has to be <= system_page_size.  Also,
+				    restart_area_length has to be >=
+				    client_array_offset + (log_clients *
+				    sizeof(log client record)). */
+	le16 client_array_offset;/* (22) Offset from the start of this record to
+				    the first log client record if versions are
+				    matched.  When creating, set this to be
+				    after this restart area structure, aligned
+				    to 8-bytes boundary.  If the versions do not
+				    match, this is ignored and the offset is
+				    assumed to be (sizeof(RESTART_AREA) + 7) &
+				    ~7, i.e. rounded up to first 8-byte
+				    boundary.  Either way, client_array_offset
+				    has to be aligned to an 8-byte boundary.
+				    Also, restart_area_offset +
+				    client_array_offset has to be <= 510.
+				    Finally, client_array_offset + (log_clients
+				    * sizeof(log client record)) has to be <=
+				    system_page_size.  On Win2k and presumably
+				    earlier, this is 0x30, i.e. immediately
+				    following this record.  On WinXP and
+				    presumably later, this is 0x40, i.e. there
+				    are 16 extra bytes between this record and
+				    the client array.  This probably means that
+				    the RESTART_AREA record is actually bigger
+				    in WinXP and later. */
+	sle64 file_size;	/* (24) Usable byte size of the log file.  If the
 				   restart_area_offset + the offset of the
 				   file_size are > 510 then corruption has
 				   occurred.  This is the very first check when
@@ -233,29 +233,29 @@ typedef struct {
 				   then it has to be at least big enough to
 				   store the two restart pages and 48 (0x30)
 				   log record pages. */
-/* 32*/	le32 last_lsn_data_length;/* Length of data of last LSN, not including
-				   the log record header.  On create set to
-				   0. */
-/* 36*/	le16 log_record_header_length;/* Byte size of the log record header.
-				   If the version matches then check that the
-				   value of log_record_header_length is a
-				   multiple of 8, i.e.
-				   (log_record_header_length + 7) & ~7 ==
-				   log_record_header_length.  When creating set
-				   it to sizeof(LOG_RECORD_HEADER), aligned to
-				   8 bytes. */
-/* 38*/	le16 log_page_data_offset;/* Offset to the start of data in a log record
-				   page.  Must be a multiple of 8.  On create
-				   set it to immediately after the update
-				   sequence array of the log record page. */
-/* 40*/	le32 restart_log_open_count;/* A counter that gets incremented every
-				   time the logfile is restarted which happens
-				   at mount time when the logfile is opened.
-				   When creating set to a random value.  Win2k
-				   sets it to the low 32 bits of the current
-				   system time in NTFS format (see time.h). */
-/* 44*/	le32 reserved;		/* Reserved/alignment to 8-byte boundary. */
-/* sizeof() = 48 (0x30) bytes */
+	le32 last_lsn_data_length;/* (32) Length of data of last LSN, not including
+				     the log record header.  On create set to
+				     0. */
+	le16 log_record_header_length;/* (36) Byte size of the log record header.
+					 If the version matches then check that the
+					 value of log_record_header_length is a
+					 multiple of 8, i.e.
+					 (log_record_header_length + 7) & ~7 ==
+					 log_record_header_length.  When creating set
+					 it to sizeof(LOG_RECORD_HEADER), aligned to
+					 8 bytes. */
+	le16 log_page_data_offset;/* (38) Offset to the start of data in a log record
+				     page.  Must be a multiple of 8.  On create
+				     set it to immediately after the update
+				     sequence array of the log record page. */
+	le32 restart_log_open_count;/* (40) A counter that gets incremented every
+				       time the logfile is restarted which happens
+				       at mount time when the logfile is opened.
+				       When creating set to a random value.  Win2k
+				       sets it to the low 32 bits of the current
+				       system time in NTFS format (see time.h). */
+	le32 reserved;		/* (44) Reserved/alignment to 8-byte boundary. */
+	/* sizeof() = 48 (0x30) bytes */
 } __attribute__((__packed__)) RESTART_AREA;
 
 /**
@@ -265,38 +265,38 @@ typedef struct {
  * RESTART_AREA to the client_array_offset value found in it.
  */
 typedef struct {
-/*Ofs*/
-/*  0*/	leLSN oldest_lsn;	/* Oldest LSN needed by this client.  On create
+	/*Ofs*/
+	leLSN oldest_lsn;	/* ( 0) Oldest LSN needed by this client.  On create
 				   set to 0. */
-/*  8*/	leLSN client_restart_lsn;/* LSN at which this client needs to restart
-				   the volume, i.e. the current position within
-				   the log file.  At present, if clean this
-				   should = current_lsn in restart area but it
-				   probably also = current_lsn when dirty most
-				   of the time.  At create set to 0. */
-/* 16*/	le16 prev_client;	/* The offset to the previous log client record
+	leLSN client_restart_lsn;/* ( 8) LSN at which this client needs to restart
+				    the volume, i.e. the current position within
+				    the log file.  At present, if clean this
+				    should = current_lsn in restart area but it
+				    probably also = current_lsn when dirty most
+				    of the time.  At create set to 0. */
+	le16 prev_client;	/* (16) The offset to the previous log client record
 				   in the array of log client records.
 				   LOGFILE_NO_CLIENT means there is no previous
 				   client record, i.e. this is the first one.
 				   This is always LOGFILE_NO_CLIENT. */
-/* 18*/	le16 next_client;	/* The offset to the next log client record in
+	le16 next_client;	/* (18) The offset to the next log client record in
 				   the array of log client records.
 				   LOGFILE_NO_CLIENT means there are no next
 				   client records, i.e. this is the last one.
 				   This is always LOGFILE_NO_CLIENT. */
-/* 20*/	le16 seq_number;	/* On Win2k and presumably earlier, this is set
+	le16 seq_number;	/* (20) On Win2k and presumably earlier, this is set
 				   to zero every time the logfile is restarted
 				   and it is incremented when the logfile is
 				   closed at dismount time.  Thus it is 0 when
 				   dirty and 1 when clean.  On WinXP and
 				   presumably later, this is always 0. */
-/* 22*/	u8 reserved[6];		/* Reserved/alignment. */
-/* 28*/	le32 client_name_length;/* Length of client name in bytes.  Should
+	u8 reserved[6];		/* (22) Reserved/alignment. */
+	le32 client_name_length;/* (28) Length of client name in bytes.  Should
 				   always be 8. */
-/* 32*/	ntfschar client_name[64];/* Name of the client in Unicode.  Should
-				   always be "NTFS" with the remaining bytes
-				   set to 0. */
-/* sizeof() = 160 (0xa0) bytes */
+	ntfschar client_name[64];/* (32) Name of the client in Unicode.  Should
+				    always be "NTFS" with the remaining bytes
+				    set to 0. */
+	/* sizeof() = 160 (0xa0) bytes */
 } __attribute__((__packed__)) LOG_CLIENT_RECORD;
 
 /**
@@ -308,7 +308,7 @@ typedef struct {
  * this specified anywhere?).
  */
 typedef struct {
-/*  0	NTFS_RECORD; -- Unfolded here as gcc doesn't like unnamed structs. */
+	/*  0	NTFS_RECORD; -- Unfolded here as gcc doesn't like unnamed structs. */
 	NTFS_RECORD_TYPES magic;/* Usually the magic is "RCRD". */
 	le16 usa_ofs;		/* See NTFS_RECORD definition in layout.h.
 				   When creating, set this to be immediately
@@ -337,12 +337,12 @@ typedef struct {
  */
 typedef enum {
 	LOG_RECORD_MULTI_PAGE = const_cpu_to_le16(0x0001),	/* ??? */
-		/* The flags below were introduced in Windows 10 */
+	/* The flags below were introduced in Windows 10 */
 	LOG_RECORD_DELETING =	const_cpu_to_le16(0x0002),
 	LOG_RECORD_ADDING =	const_cpu_to_le16(0x0004),
 	LOG_RECORD_SIZE_PLACE_HOLDER = 0xffff,
-		/* This has nothing to do with the log record. It is only so
-		   gcc knows to make the flags 16-bit. */
+	/* This has nothing to do with the log record. It is only so
+	   gcc knows to make the flags 16-bit. */
 } __attribute__((__packed__)) LOG_RECORD_FLAGS;
 
 /**
@@ -365,7 +365,7 @@ enum {
 typedef le32 LOG_RECORD_TYPE;
 
 /*
- *	ATTRIBUTE_FLAGS : flags describing the kind of NTFS record 
+ *	ATTRIBUTE_FLAGS : flags describing the kind of NTFS record
  *	is being updated.
  *	These flags were introduced in Vista, only two flags are known?
  */
@@ -394,7 +394,7 @@ typedef struct {
 	le32 transaction_id;
 	LOG_RECORD_FLAGS log_record_flags;
 	le16 reserved_or_alignment[3];
-/* Now are at ofs 0x30 into struct. */
+	/* Now are at ofs 0x30 into struct. */
 	le16 redo_operation;
 	le16 undo_operation;
 	le16 redo_offset;
@@ -405,16 +405,16 @@ typedef struct {
 			le16 undo_length;
 			le16 target_attribute;
 			le16 lcns_to_follow;   /* Number of lcn_list entries
-					      following this entry. */
-/* Now at ofs 0x40. */
+						  following this entry. */
+			/* Now at ofs 0x40. */
 			le16 record_offset;
 			le16 attribute_offset;
 			le16 cluster_index;
 			ATTRIBUTE_FLAGS attribute_flags;
 			leVCN target_vcn;
-/* Now at ofs 0x50. */
+			/* Now at ofs 0x50. */
 			leLCN lcn_list[0]; /* Only present if lcns_to_follow
-						is not 0. */
+					      is not 0. */
 		} __attribute__((__packed__));
 		struct {
 			leLSN transaction_lsn;

--- a/include/logging.h
+++ b/include/logging.h
@@ -35,11 +35,11 @@
 
 /* Function prototype for the logging handlers */
 typedef int (ntfs_log_handler)(const char *function, const char *file, int line,
-	u32 level, void *data, const char *format, va_list args);
+		u32 level, void *data, const char *format, va_list args);
 
 /* Set the logging handler from one of the functions, below. */
 void ntfs_log_set_handler(ntfs_log_handler *handler 
-			  __attribute__((format(printf, 6, 0))));
+		__attribute__((format(printf, 6, 0))));
 
 /* Logging handlers */
 ntfs_log_handler ntfs_log_handler_syslog  __attribute__((format(printf, 6, 0)));
@@ -63,7 +63,7 @@ u32 ntfs_log_get_flags(void);
 BOOL ntfs_log_parse_option(const char *option);
 
 int ntfs_log_redirect(const char *function, const char *file, int line,
-	u32 level, void *data, const char *format, ...)
+		u32 level, void *data, const char *format, ...)
 	__attribute__((format(printf, 6, 7)));
 
 /* Logging levels - Determine what gets logged */
@@ -115,7 +115,7 @@ int ntfs_log_redirect(const char *function, const char *file, int line,
 #endif /* DEBUG */
 
 void ntfs_log_early_error(const char *format, ...)
-                __attribute__((format(printf, 1, 2)));
+	__attribute__((format(printf, 1, 2)));
 
 #endif /* _LOGGING_H_ */
 

--- a/include/mft.h
+++ b/include/mft.h
@@ -50,8 +50,8 @@ extern int ntfs_mft_records_read(const ntfs_volume *vol, const MFT_REF mref,
 static __inline__ int ntfs_mft_record_read(const ntfs_volume *vol,
 		const MFT_REF mref, MFT_RECORD *b)
 {
-	int ret; 
-	
+	int ret;
+
 	ntfs_log_enter("Entering for inode %lld\n", (long long)MREF(mref));
 	ret = ntfs_mft_records_read(vol, mref, 1, b);
 	ntfs_log_leave("\n");
@@ -85,8 +85,8 @@ extern int ntfs_mft_records_write(const ntfs_volume *vol, const MFT_REF mref,
 static __inline__ int ntfs_mft_record_write(const ntfs_volume *vol,
 		const MFT_REF mref, MFT_RECORD *b)
 {
-	int ret; 
-	
+	int ret;
+
 	ntfs_log_enter("Entering for inode %lld\n", (long long)MREF(mref));
 	ret = ntfs_mft_records_write(vol, mref, 1, b);
 	ntfs_log_leave("\n");

--- a/include/mst.h
+++ b/include/mst.h
@@ -29,7 +29,7 @@
 
 extern int ntfs_mst_post_read_fixup(NTFS_RECORD *b, const u32 size);
 extern int ntfs_mst_post_read_fixup_warn(NTFS_RECORD *b, const u32 size,
-					BOOL warn);
+		BOOL warn);
 extern int ntfs_mst_pre_write_fixup(NTFS_RECORD *b, const u32 size);
 extern void ntfs_mst_post_write_fixup(NTFS_RECORD *b);
 

--- a/include/ntfstime.h
+++ b/include/ntfstime.h
@@ -74,7 +74,7 @@ static __inline__ struct timespec ntfs2timespec(ntfs_time ntfstime)
 	spec.tv_sec = (cputime - (NTFS_TIME_OFFSET)) / 10000000;
 	spec.tv_nsec = (cputime - (NTFS_TIME_OFFSET)
 			- (s64)spec.tv_sec*10000000)*100;
-		/* force zero nsec for overflowing dates */
+	/* force zero nsec for overflowing dates */
 	if ((spec.tv_nsec < 0) || (spec.tv_nsec > 999999999))
 		spec.tv_nsec = 0;
 	return (spec);
@@ -101,7 +101,7 @@ static __inline__ ntfs_time timespec2ntfs(struct timespec spec)
 	s64 units;
 
 	units = (s64)spec.tv_sec * 10000000
-				+ NTFS_TIME_OFFSET + spec.tv_nsec/100;
+		+ NTFS_TIME_OFFSET + spec.tv_nsec/100;
 	return (cpu_to_sle64(units));
 }
 

--- a/include/object_id.h
+++ b/include/object_id.h
@@ -27,7 +27,7 @@
 int ntfs_get_ntfs_object_id(ntfs_inode *ni, char *value, size_t size);
 
 int ntfs_set_ntfs_object_id(ntfs_inode *ni, const char *value,
-			size_t size, int flags);
+		size_t size, int flags);
 int ntfs_remove_ntfs_object_id(ntfs_inode *ni);
 
 int ntfs_delete_object_id_index(ntfs_inode *ni);

--- a/include/param.h
+++ b/include/param.h
@@ -31,7 +31,7 @@
 #define FORCE_FORMAT_v1x 0	/* Insert security data as in NTFS v1.x */
 #define OWNERFROMACL 1		/* Get the owner from ACL (not Windows owner) */
 
-		/* default security sub-authorities */
+/* default security sub-authorities */
 enum {
 	DEFSECAUTH1 = -1153374643, /* 3141592653 */
 	DEFSECAUTH2 = 589793238,
@@ -43,18 +43,18 @@ enum {
  *		Parameters for formatting
  */
 
-		/* Up to Windows 10, the cluster size was limited to 64K */
+/* Up to Windows 10, the cluster size was limited to 64K */
 #define NTFS_MAX_CLUSTER_SIZE 2097152 /* Windows 10 Creators allows 2MB */
 
 /*
  *		Parameters for compression
  */
 
-	/* default option for compression */
+/* default option for compression */
 #define DEFAULT_COMPRESSION 1
-	/* (log2 of) number of clusters in a compression block for new files */
+/* (log2 of) number of clusters in a compression block for new files */
 #define STANDARD_COMPRESSION_UNIT 4
-	/* maximum cluster size for allowing compression for new files */
+/* maximum cluster size for allowing compression for new files */
 #define MAX_COMPRESSION_CLUSTER_SIZE 4096
 
 /*
@@ -80,14 +80,14 @@ enum {
  *		Parameters for runlists
  */
 
-	/* only update the final extent of a runlist when appending data */
+/* only update the final extent of a runlist when appending data */
 #define PARTIAL_RUNLIST_UPDATING 1
 
 /*
  *		Parameters for upper-case table
  */
 
-	/* Create upper-case tables as defined by Windows 6.1 (Win7) */
+/* Create upper-case tables as defined by Windows 6.1 (Win7) */
 #define UPCASE_MAJOR 6
 #define UPCASE_MINOR 1
 

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -37,16 +37,16 @@
 struct fuse_file_info;
 struct stat;
 
-	/*
-	 *	The plugin operations currently defined.
-	 * These functions should return a non-negative value when they
-	 * succeed, or a negative errno value when they fail.
-	 * They must not close or free their arguments.
-	 * The file system must be left in a consistent state after
-	 * each individual call.
-	 * If an operation is not defined, an EOPNOTSUPP error is
-	 * returned to caller.
-	 */
+/*
+ *	The plugin operations currently defined.
+ * These functions should return a non-negative value when they
+ * succeed, or a negative errno value when they fail.
+ * They must not close or free their arguments.
+ * The file system must be left in a consistent state after
+ * each individual call.
+ * If an operation is not defined, an EOPNOTSUPP error is
+ * returned to caller.
+ */
 typedef struct plugin_operations {
 	/*
 	 *	Set the attributes st_size, st_blocks and st_mode

--- a/include/reparse.h
+++ b/include/reparse.h
@@ -30,20 +30,20 @@ BOOL ntfs_possible_symlink(ntfs_inode *ni);
 
 int ntfs_get_ntfs_reparse_data(ntfs_inode *ni, char *value, size_t size);
 
-char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, 
-			int count, const char *mnt_point, BOOL isdir);
+char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction,
+		int count, const char *mnt_point, BOOL isdir);
 
 REPARSE_POINT *ntfs_get_reparse_point(ntfs_inode *ni);
 
 int ntfs_reparse_check_wsl(ntfs_inode *ni, const REPARSE_POINT *reparse);
 
 int ntfs_reparse_set_wsl_symlink(ntfs_inode *ni,
-			const ntfschar *target, int target_len);
+		const ntfschar *target, int target_len);
 
 int ntfs_reparse_set_wsl_not_symlink(ntfs_inode *ni, mode_t mode);
 
 int ntfs_set_ntfs_reparse_data(ntfs_inode *ni, const char *value,
-			size_t size, int flags);
+		size_t size, int flags);
 int ntfs_remove_ntfs_reparse_data(ntfs_inode *ni);
 
 int ntfs_delete_reparse_index(ntfs_inode *ni);

--- a/include/runlist.h
+++ b/include/runlist.h
@@ -50,10 +50,10 @@ struct _runlist_element {/* In memory vcn to lcn mapping structure element. */
 };
 
 extern runlist_element *ntfs_rl_extend(ntfs_attr *na, runlist_element *rl,
-			int more_entries);
+		int more_entries);
 
 extern runlist_element *ntfs_rl_replace(runlist_element *dst, int dsize,
-				       runlist_element *src, int ssize, int loc);
+		runlist_element *src, int ssize, int loc);
 
 extern LCN ntfs_rl_vcn_to_lcn(const runlist_element *rl, const VCN vcn);
 
@@ -89,8 +89,8 @@ extern int ntfs_rl_sparse(runlist *rl);
 extern s64 ntfs_rl_get_compressed_size(ntfs_volume *vol, runlist *rl);
 
 extern runlist_element *ntfs_rl_punch_hole(runlist_element *dst_rl, int dst_cnt,
-				    VCN start_vcn, s64 len,
-				    runlist_element **punch_rl);
+		VCN start_vcn, s64 len,
+		runlist_element **punch_rl);
 extern runlist *ntfs_copy_rl_clusters(ntfs_volume *vol, runlist *new_rl, int new_cnt,
 		runlist *orig_rl, int orig_cnt);
 

--- a/include/security.h
+++ b/include/security.h
@@ -1,5 +1,5 @@
 /*
- * security.h - Exports for handling security/ACLs in NTFS.  
+ * security.h - Exports for handling security/ACLs in NTFS.
  *              Originated from the Linux-NTFS project.
  *
  * Copyright (c) 2004      Anton Altaparmakov
@@ -75,7 +75,7 @@ struct CACHED_PERMISSIONS_LEGACY {
 	void *variable;
 	size_t varsize;
 	union ALIGNMENT payload[0];
-		/* above fields must match "struct CACHED_GENERIC" */
+	/* above fields must match "struct CACHED_GENERIC" */
 	u64 mft_no;
 	struct CACHED_PERMISSIONS perm;
 } ;
@@ -90,7 +90,7 @@ struct CACHED_SECURID {
 	void *variable;
 	size_t varsize;
 	union ALIGNMENT payload[0];
-		/* above fields must match "struct CACHED_GENERIC" */
+	/* above fields must match "struct CACHED_GENERIC" */
 	uid_t uid;
 	gid_t gid;
 	unsigned int dmode;
@@ -104,7 +104,7 @@ struct CACHED_SECURID {
 
 struct CACHED_PERMISSIONS_HEADER {
 	unsigned int last;
-			/* statistics for permissions */
+	/* statistics for permissions */
 	unsigned long p_writes;
 	unsigned long p_reads;
 	unsigned long p_hits;
@@ -146,20 +146,20 @@ struct SECURITY_CONTEXT {
 	gid_t gid; /* gid of user requesting (not the mounter) */
 	pid_t tid; /* thread id of thread requesting */
 	mode_t umask; /* umask of requesting thread */
-	} ;
+} ;
 
 #if POSIXACLS
 
 /*
  *		       Posix ACL structures
  */
-  
+
 struct POSIX_ACE {
 	u16 tag;
 	u16 perms;
-	s32 id;   
+	s32 id;
 } __attribute__((__packed__));
-        
+
 struct POSIX_ACL {
 	u8 version;
 	u8 flags;
@@ -176,12 +176,12 @@ struct POSIX_SECURITY {
 	u16 filler;
 	struct POSIX_ACL acl;
 } ;
-        
+
 /*
  *		Posix tags, cpu-endian 16 bits
  */
-   
-enum {  
+
+enum {
 	POSIX_ACL_USER_OBJ =	1,
 	POSIX_ACL_USER =	2,
 	POSIX_ACL_GROUP_OBJ =	4,
@@ -192,12 +192,12 @@ enum {
 } ;
 
 #define POSIX_ACL_EXTENSIONS (POSIX_ACL_USER | POSIX_ACL_GROUP | POSIX_ACL_MASK)
-        
+
 /*
  *		Posix permissions, cpu-endian 16 bits
  */
-   
-enum {  
+
+enum {
 	POSIX_PERM_X =		1,
 	POSIX_PERM_W =		2,
 	POSIX_PERM_R =		4,
@@ -218,7 +218,7 @@ extern void ntfs_generate_guid(GUID *guid);
 extern int ntfs_sd_add_everyone(ntfs_inode *ni);
 
 extern le32 ntfs_security_hash(const SECURITY_DESCRIPTOR_RELATIVE *sd, 
-			       const u32 len);
+		const u32 len);
 
 int ntfs_build_mapping(struct SECURITY_CONTEXT *scx, const char *usermap_path,
 		BOOL allowdef);
@@ -266,23 +266,23 @@ int ntfs_set_inherited_posix(struct SECURITY_CONTEXT *scx,
 		ntfs_inode *ni, uid_t uid, gid_t gid,
 		ntfs_inode *dir_ni, mode_t mode);
 int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *name, char *value, size_t size);
+		const char *name, char *value, size_t size);
 int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *name, const char *value, size_t size,
-			int flags);
+		const char *name, const char *value, size_t size,
+		int flags);
 int ntfs_remove_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *name);
+		const char *name);
 #endif
 
 int ntfs_get_ntfs_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			char *value, size_t size);
+		char *value, size_t size);
 int ntfs_set_ntfs_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *value, size_t size, int flags); 
+		const char *value, size_t size, int flags); 
 
 int ntfs_get_ntfs_attrib(ntfs_inode *ni, char *value, size_t size);
 int ntfs_set_ntfs_attrib(ntfs_inode *ni,
-			const char *value, size_t size,	int flags);
-			
+		const char *value, size_t size,	int flags);
+
 
 /*
  *		Security API for direct access to security descriptors
@@ -310,8 +310,8 @@ enum {	OWNER_SECURITY_INFORMATION = 1,
 } ;
 
 int ntfs_get_file_security(struct SECURITY_API *scapi,
-                const char *path, u32 selection,  
-                char *buf, u32 buflen, u32 *psize);
+		const char *path, u32 selection,  
+		char *buf, u32 buflen, u32 *psize);
 int ntfs_set_file_security(struct SECURITY_API *scapi,
 		const char *path, u32 selection, const char *attr);
 int ntfs_get_file_attributes(struct SECURITY_API *scapi,
@@ -327,7 +327,7 @@ INDEX_ENTRY *ntfs_read_sii(struct SECURITY_API *scapi,
 INDEX_ENTRY *ntfs_read_sdh(struct SECURITY_API *scapi,
 		INDEX_ENTRY *entry);
 struct SECURITY_API *ntfs_initialize_file_security(const char *device,
-                                unsigned long flags);
+		unsigned long flags);
 BOOL ntfs_leave_file_security(struct SECURITY_API *scx);
 
 int ntfs_get_usid(struct SECURITY_API *scapi, uid_t uid, char *buf);

--- a/include/unistr.h
+++ b/include/unistr.h
@@ -70,10 +70,10 @@ extern void ntfs_ucsfree(ntfschar *ucs);
 
 extern BOOL ntfs_forbidden_chars(const ntfschar *name, int len, BOOL strict);
 extern BOOL ntfs_forbidden_names(ntfs_volume *vol,
-				const ntfschar *name, int len, BOOL strict);
+		const ntfschar *name, int len, BOOL strict);
 extern BOOL ntfs_collapsible_chars(ntfs_volume *vol,
-				const ntfschar *shortname, int shortlen,
-				const ntfschar *longname, int longlen);
+		const ntfschar *shortname, int shortlen,
+		const ntfschar *longname, int longlen);
 
 extern int ntfs_set_char_encoding(const char *locale);
 

--- a/include/volume.h
+++ b/include/volume.h
@@ -36,7 +36,7 @@
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
-	/* Do not #include <sys/mount.h> here : conflicts with <linux/fs.h> */
+/* Do not #include <sys/mount.h> here : conflicts with <linux/fs.h> */
 #ifdef HAVE_MNTENT_H
 #include <mntent.h>
 #endif
@@ -86,8 +86,8 @@ extern int parse_errors;
 	do { \
 		ntfs_log_info("Parse #%d: " FORMAT, parse_count++, ##ARGS); \
 		if (fsck_errors) \
-			ntfs_log_info(" (left:%d, errors:%d, fixed:%d)", \
-				fsck_errors - fsck_fixes, fsck_errors, fsck_fixes); \
+		ntfs_log_info(" (left:%d, errors:%d, fixed:%d)", \
+			fsck_errors - fsck_fixes, fsck_errors, fsck_fixes); \
 		ntfs_log_info("\n"); \
 	} while (0)
 
@@ -95,10 +95,10 @@ extern int parse_errors;
 #define fsck_end_step() \
 	do { \
 		if ((fsck_errors - fsck_fixes) != parse_errors) \
-			parse_errors = (fsck_errors - fsck_fixes); \
+		parse_errors = (fsck_errors - fsck_fixes); \
 		if (parse_errors) \
-			ntfs_log_info("Parse #%d Errors remains: %d\n", \
-					parse_count - 1, parse_errors); \
+		ntfs_log_info("Parse #%d Errors remains: %d\n", \
+			parse_count - 1, parse_errors); \
 	} while (0)
 
 /**
@@ -119,7 +119,7 @@ enum {
 
 	NTFS_MNT_MAY_RDONLY             = 0x02000000, /* Allow fallback to ro */
 	NTFS_MNT_FORENSIC               = 0x04000000, /* No modification during
-	                                               * mount. */
+						       * mount. */
 	NTFS_MNT_EXCLUSIVE              = 0x08000000,
 	NTFS_MNT_RECOVER                = 0x10000000,
 	NTFS_MNT_IGNORE_HIBERFILE       = 0x20000000,
@@ -347,9 +347,9 @@ struct _ntfs_volume {
 	s32 attrdef_len;	/* Size of the attribute definition table in
 				   bytes. */
 
-	s64 free_clusters; 	/* Track the number of free clusters which
+	s64 free_clusters;	/* Track the number of free clusters which
 				   greatly improves statfs() performance */
-	s64 free_mft_records; 	/* Same for free mft records (see above) */
+	s64 free_mft_records;	/* Same for free mft records (see above) */
 	BOOL efs_raw;		/* volume is mounted for raw access to
 				   efs-encrypted files */
 	ntfs_volume_special_files special_files; /* Implementation of special files */

--- a/include/xattrs.h
+++ b/include/xattrs.h
@@ -59,7 +59,7 @@ enum SYSTEMXATTRS {
 	XATTR_NTFS_CRTIME,
 	XATTR_NTFS_CRTIME_BE,
 	XATTR_NTFS_EA,
-	XATTR_POSIX_ACC, 
+	XATTR_POSIX_ACC,
 	XATTR_POSIX_DEF
 } ;
 
@@ -72,26 +72,26 @@ struct XATTRMAPPING {
 #ifdef XATTR_MAPPINGS
 
 struct XATTRMAPPING *ntfs_xattr_build_mapping(ntfs_volume *vol,
-			const char *path);
+	const char *path);
 void ntfs_xattr_free_mapping(struct XATTRMAPPING*);
 
 #endif /* XATTR_MAPPINGS */
 
 enum SYSTEMXATTRS ntfs_xattr_system_type(const char *name,
-			ntfs_volume *vol);
+	ntfs_volume *vol);
 
 struct SECURITY_CONTEXT;
 
 int ntfs_xattr_system_getxattr(struct SECURITY_CONTEXT *scx,
-			enum SYSTEMXATTRS attr,
-			ntfs_inode *ni, ntfs_inode *dir_ni,
-			char *value, size_t size);
+	enum SYSTEMXATTRS attr,
+	ntfs_inode *ni, ntfs_inode *dir_ni,
+	char *value, size_t size);
 int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
-			enum SYSTEMXATTRS attr,
-			ntfs_inode *ni, ntfs_inode *dir_ni,
-			const char *value, size_t size, int flags);
+	enum SYSTEMXATTRS attr,
+	ntfs_inode *ni, ntfs_inode *dir_ni,
+	const char *value, size_t size, int flags);
 int ntfs_xattr_system_removexattr(struct SECURITY_CONTEXT *scx,
-			enum SYSTEMXATTRS attr,
-			ntfs_inode *ni, ntfs_inode *dir_ni);
+	enum SYSTEMXATTRS attr,
+	ntfs_inode *ni, ntfs_inode *dir_ni);
 
 #endif /* _NTFS_XATTRS_H_ */

--- a/libntfs/acls.c
+++ b/libntfs/acls.c
@@ -64,11 +64,11 @@
  */
 
 static const char nullsidbytes[] = {
-		1,		/* revision */
-		1,		/* auth count */
-		0, 0, 0, 0, 0, 0,	/* base */
-		0, 0, 0, 0 	/* 1st level */
-	};
+	1,			/* revision */
+	1,			/* auth count */
+	0, 0, 0, 0, 0, 0,	/* base */
+	0, 0, 0, 0		/* 1st level */
+};
 
 static const SID *nullsid = (const SID*)nullsidbytes;
 
@@ -77,10 +77,10 @@ static const SID *nullsid = (const SID*)nullsidbytes;
  */
 
 static const char worldsidbytes[] = {
-		1,		/* revision */
-		1,		/* auth count */
-		0, 0, 0, 0, 0, 1,	/* base */
-		0, 0, 0, 0	/* 1st level */
+	1,			/* revision */
+	1,			/* auth count */
+	0, 0, 0, 0, 0, 1,	/* base */
+	0, 0, 0, 0		/* 1st level */
 } ;
 
 const SID *worldsid = (const SID*)worldsidbytes;
@@ -90,10 +90,10 @@ const SID *worldsid = (const SID*)worldsidbytes;
  */
 
 static const char authsidbytes[] = {
-		1,		/* revision */
-		1,		/* auth count */
-		0, 0, 0, 0, 0, 5,	/* base */
-		11, 0, 0, 0	/* 1st level */
+	1,			/* revision */
+	1,			/* auth count */
+	0, 0, 0, 0, 0, 5,	/* base */
+	11, 0, 0, 0		/* 1st level */
 };
 
 static const SID *authsid = (const SID*)authsidbytes;
@@ -103,11 +103,11 @@ static const SID *authsid = (const SID*)authsidbytes;
  */
 
 static const char adminsidbytes[] = {
-		1,		/* revision */
-		2,		/* auth count */
-		0, 0, 0, 0, 0, 5,	/* base */
-		32, 0, 0, 0,	/* 1st level */
-		32, 2, 0, 0	/* 2nd level */
+	1,			/* revision */
+	2,			/* auth count */
+	0, 0, 0, 0, 0, 5,	/* base */
+	32, 0, 0, 0,		/* 1st level */
+	32, 2, 0, 0		/* 2nd level */
 };
 
 const SID *adminsid = (const SID*)adminsidbytes;
@@ -117,11 +117,11 @@ const SID *adminsid = (const SID*)adminsidbytes;
  */
 
 static const char systemsidbytes[] = {
-		1,		/* revision */
-		1,		/* auth count */
-		0, 0, 0, 0, 0, 5,	/* base */
-		18, 0, 0, 0 	/* 1st level */
-	};
+	1,			/* revision */
+	1,			/* auth count */
+	0, 0, 0, 0, 0, 5,	/* base */
+	18, 0, 0, 0		/* 1st level */
+};
 
 static const SID *systemsid = (const SID*)systemsidbytes;
 
@@ -131,10 +131,10 @@ static const SID *systemsid = (const SID*)systemsidbytes;
  */
 
 static const char ownersidbytes[] = {
-		1,		/* revision */
-		1,		/* auth count */
-		0, 0, 0, 0, 0, 3,	/* base */
-		0, 0, 0, 0	/* 1st level */
+	1,			/* revision */
+	1,			/* auth count */
+	0, 0, 0, 0, 0, 3,	/* base */
+	0, 0, 0, 0		/* 1st level */
 } ;
 
 static const SID *ownersid = (const SID*)ownersidbytes;
@@ -145,10 +145,10 @@ static const SID *ownersid = (const SID*)ownersidbytes;
  */
 
 static const char groupsidbytes[] = {
-		1,		/* revision */
-		1,		/* auth count */
-		0, 0, 0, 0, 0, 3,	/* base */
-		1, 0, 0, 0	/* 1st level */
+	1,			/* revision */
+	1,			/* auth count */
+	0, 0, 0, 0, 0, 3,	/* base */
+	1, 0, 0, 0		/* 1st level */
 } ;
 
 static const SID *groupsid = (const SID*)groupsidbytes;
@@ -172,7 +172,7 @@ BOOL ntfs_same_sid(const SID *first, const SID *second)
 
 	size = ntfs_sid_size(first);
 	return ((ntfs_sid_size(second) == size)
-		&& !memcmp(first, second, size));
+			&& !memcmp(first, second, size));
 }
 
 /*
@@ -187,33 +187,33 @@ BOOL ntfs_same_sid(const SID *first, const SID *second)
 static int is_world_sid(const SID * usid)
 {
 	return (
-	     /* check whether S-1-1-0 : world */
-	       ((usid->sub_authority_count == 1)
-	    && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
-	    && (usid->identifier_authority.low_part ==  const_cpu_to_be32(1))
-	    && (usid->sub_authority[0] == const_cpu_to_le32(0)))
+	/* check whether S-1-1-0 : world */
+		((usid->sub_authority_count == 1)
+	  && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
+	  && (usid->identifier_authority.low_part ==  const_cpu_to_be32(1))
+	  && (usid->sub_authority[0] == const_cpu_to_le32(0)))
 
-	     /* check whether S-1-5-32-545 : local user */
-	  ||   ((usid->sub_authority_count == 2)
-	    && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
-	    && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
-	    && (usid->sub_authority[0] == const_cpu_to_le32(32))
-	    && (usid->sub_authority[1] == const_cpu_to_le32(545)))
+	/* check whether S-1-5-32-545 : local user */
+	||  ((usid->sub_authority_count == 2)
+	  && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
+	  && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
+	  && (usid->sub_authority[0] == const_cpu_to_le32(32))
+	  && (usid->sub_authority[1] == const_cpu_to_le32(545)))
 
-	     /* check whether S-1-5-11 : authenticated user */
-	  ||   ((usid->sub_authority_count == 1)
-	    && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
-	    && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
-	    && (usid->sub_authority[0] == const_cpu_to_le32(11)))
+	/* check whether S-1-5-11 : authenticated user */
+	||  ((usid->sub_authority_count == 1)
+	  && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
+	  && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
+	  && (usid->sub_authority[0] == const_cpu_to_le32(11)))
 
 #if !POSIXACLS
-	     /* check whether S-1-5-4 : interactive user */
-	  ||   ((usid->sub_authority_count == 1)
-	    && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
-	    && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
-	    && (usid->sub_authority[0] == const_cpu_to_le32(4)))
+	/* check whether S-1-5-4 : interactive user */
+	||  ((usid->sub_authority_count == 1)
+	  && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
+	  && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
+	  && (usid->sub_authority[0] == const_cpu_to_le32(4)))
 #endif /* !POSIXACLS */
-		);
+	);
 }
 
 /*
@@ -225,9 +225,9 @@ static int is_world_sid(const SID * usid)
 BOOL ntfs_is_user_sid(const SID *usid)
 {
 	return ((usid->sub_authority_count == 5)
-	    && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
-	    && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
-	    && (usid->sub_authority[0] ==  const_cpu_to_le32(21)));
+		&& (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
+		&& (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
+		&& (usid->sub_authority[0] ==  const_cpu_to_le32(21)));
 }
 
 /*
@@ -241,12 +241,12 @@ BOOL ntfs_is_user_sid(const SID *usid)
 
 static BOOL ntfs_known_group_sid(const SID *usid)
 {
-			/* count == 1 excludes S-1-5-5-X-Y (logon) */
+	/* count == 1 excludes S-1-5-5-X-Y (logon) */
 	return ((usid->sub_authority_count == 1)
-	    && (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
-	    && (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
-	    && (le32_to_cpu(usid->sub_authority[0]) >=  1)
-	    && (le32_to_cpu(usid->sub_authority[0]) <=  6));
+		&& (usid->identifier_authority.high_part ==  const_cpu_to_be16(0))
+		&& (usid->identifier_authority.low_part ==  const_cpu_to_be32(5))
+		&& (le32_to_cpu(usid->sub_authority[0]) >=  1)
+		&& (le32_to_cpu(usid->sub_authority[0]) <=  6));
 }
 
 /*
@@ -269,28 +269,28 @@ unsigned int ntfs_attr_size(const char *attr)
 	unsigned int attrsz;
 
 	phead = (const SECURITY_DESCRIPTOR_RELATIVE*)attr;
-		/*
-		 * First check group, which is the last field in all descriptors
-		 * we build, and in most descriptors built by Windows
-		 */
+	/*
+	 * First check group, which is the last field in all descriptors
+	 * we build, and in most descriptors built by Windows
+	 */
 	attrsz = sizeof(SECURITY_DESCRIPTOR_RELATIVE);
 	offgroup = le32_to_cpu(phead->group);
 	if (offgroup >= attrsz) {
-			/* find end of GSID */
+		/* find end of GSID */
 		psid = (const SID*)&attr[offgroup];
 		endsid = offgroup + ntfs_sid_size(psid);
 		if (endsid > attrsz) attrsz = endsid;
 	}
 	offowner = le32_to_cpu(phead->owner);
 	if (offowner >= attrsz) {
-			/* find end of USID */
+		/* find end of USID */
 		psid = (const SID*)&attr[offowner];
 		endsid = offowner + ntfs_sid_size(psid);
 		attrsz = endsid;
 	}
 	offsacl = le32_to_cpu(phead->sacl);
 	if (offsacl >= attrsz) {
-			/* find end of SACL */
+		/* find end of SACL */
 		psacl = (const ACL*)&attr[offsacl];
 		endacl = offsacl + le16_to_cpu(psacl->size);
 		if (endacl > attrsz)
@@ -298,7 +298,7 @@ unsigned int ntfs_attr_size(const char *attr)
 	}
 
 
-		/* find end of DACL */
+	/* find end of DACL */
 	offdacl = le32_to_cpu(phead->dacl);
 	if (offdacl >= attrsz) {
 		pdacl = (const ACL*)&attr[offdacl];
@@ -383,7 +383,7 @@ static u32 findimplicit(const SID *xsid, const SID *pattern, int parity)
 				/*
 				 * check whether part of mapping had to be
 				 * recorded in a higher level authority
-			 	 */
+				 */
 				carry = 1;
 				do {
 					leauth = psid->sub_authority[cnt-2];
@@ -391,10 +391,10 @@ static u32 findimplicit(const SID *xsid, const SID *pattern, int parity)
 					psid->sub_authority[cnt-2]
 						= cpu_to_le32(uauth);
 				} while (!ntfs_same_sid(psid,xsid)
-					 && (++carry < 4));
+						&& (++carry < 4));
 				if (carry < 4)
 					xid = (((xlast - rlast) >> 1)
-						& 0x3fffffff) | (carry << 30);
+							& 0x3fffffff) | (carry << 30);
 			}
 		}
 	}
@@ -561,33 +561,33 @@ static BOOL valid_acl(const ACL *pacl, unsigned int end)
 				&((const char*)pacl)[offace];
 			acesz = le16_to_cpu(pace->size);
 			switch (pace->type) {
-			case ACCESS_ALLOWED_ACE_TYPE :
-			case ACCESS_DENIED_ACE_TYPE :
-				wantsz = ntfs_sid_size(&pace->sid) + 8;
-				if (((offace + acesz) > end)
-				    || !ntfs_valid_sid(&pace->sid)
-				    || (wantsz != acesz))
-					ok = FALSE;
-				break;
-			case SYSTEM_AUDIT_ACE_TYPE :
-			case ACCESS_ALLOWED_CALLBACK_ACE_TYPE :
-			case ACCESS_DENIED_CALLBACK_ACE_TYPE :
-			case SYSTEM_AUDIT_CALLBACK_ACE_TYPE :
-			case SYSTEM_MANDATORY_LABEL_ACE_TYPE :
-			case SYSTEM_RESOURCE_ATTRIBUTE_ACE_TYPE :
-			case SYSTEM_SCOPED_POLICY_ID_ACE_TYPE :
-				/* Extra data after the SID */
-				wantsz = ntfs_sid_size(&pace->sid) + 8;
-				if (((offace + acesz) > end)
-				    || !ntfs_valid_sid(&pace->sid)
-				    || (wantsz > acesz))
-					ok = FALSE;
-				break;
-			default :
-				/* SID at a different location */
-				if ((offace + acesz) > end)
-					ok = FALSE;
-				break;
+				case ACCESS_ALLOWED_ACE_TYPE :
+				case ACCESS_DENIED_ACE_TYPE :
+					wantsz = ntfs_sid_size(&pace->sid) + 8;
+					if (((offace + acesz) > end)
+							|| !ntfs_valid_sid(&pace->sid)
+							|| (wantsz != acesz))
+						ok = FALSE;
+					break;
+				case SYSTEM_AUDIT_ACE_TYPE :
+				case ACCESS_ALLOWED_CALLBACK_ACE_TYPE :
+				case ACCESS_DENIED_CALLBACK_ACE_TYPE :
+				case SYSTEM_AUDIT_CALLBACK_ACE_TYPE :
+				case SYSTEM_MANDATORY_LABEL_ACE_TYPE :
+				case SYSTEM_RESOURCE_ATTRIBUTE_ACE_TYPE :
+				case SYSTEM_SCOPED_POLICY_ID_ACE_TYPE :
+					/* Extra data after the SID */
+					wantsz = ntfs_sid_size(&pace->sid) + 8;
+					if (((offace + acesz) > end)
+							|| !ntfs_valid_sid(&pace->sid)
+							|| (wantsz > acesz))
+						ok = FALSE;
+					break;
+				default :
+					/* SID at a different location */
+					if ((offace + acesz) > end)
+						ok = FALSE;
+					break;
 			}
 			offace += acesz;
 		}
@@ -631,12 +631,12 @@ BOOL ntfs_valid_descr(const char *securattr, unsigned int attrsz)
 	pdacl = (const ACL*)&securattr[offdacl];
 	psacl = (const ACL*)&securattr[offsacl];
 
-		/*
-		 * size check occurs before the above pointers are used
-		 *
-		 * "DR Watson" standard directory on WinXP has an
-		 * old revision and no DACL though SE_DACL_PRESENT is set
-		 */
+	/*
+	 * size check occurs before the above pointers are used
+	 *
+	 * "DR Watson" standard directory on WinXP has an
+	 * old revision and no DACL though SE_DACL_PRESENT is set
+	 */
 	if ((attrsz >= sizeof(SECURITY_DESCRIPTOR_RELATIVE))
 		&& (phead->revision == SECURITY_DESCRIPTOR_REVISION)
 		&& (offowner >= sizeof(SECURITY_DESCRIPTOR_RELATIVE))
@@ -645,10 +645,10 @@ BOOL ntfs_valid_descr(const char *securattr, unsigned int attrsz)
 		&& ((offgroup + 2) < attrsz)
 		&& (!offdacl
 			|| ((offdacl >= sizeof(SECURITY_DESCRIPTOR_RELATIVE))
-			    && (offdacl+sizeof(ACL) <= attrsz)))
+				&& (offdacl+sizeof(ACL) <= attrsz)))
 		&& (!offsacl
 			|| ((offsacl >= sizeof(SECURITY_DESCRIPTOR_RELATIVE))
-			    && (offsacl+sizeof(ACL) <= attrsz)))
+				&& (offsacl+sizeof(ACL) <= attrsz)))
 		&& !(phead->owner & const_cpu_to_le32(3))
 		&& !(phead->group & const_cpu_to_le32(3))
 		&& !(phead->dacl & const_cpu_to_le32(3))
@@ -662,19 +662,19 @@ BOOL ntfs_valid_descr(const char *securattr, unsigned int attrsz)
 			 * but "Dr Watson" has SE_DACL_PRESENT though no DACL
 			 */
 		&& (!offdacl
-		    || ((phead->control & SE_DACL_PRESENT)
-			&& ((pdacl->revision == ACL_REVISION)
-			   || (pdacl->revision == ACL_REVISION_DS))))
+			|| ((phead->control & SE_DACL_PRESENT)
+				&& ((pdacl->revision == ACL_REVISION)
+					|| (pdacl->revision == ACL_REVISION_DS))))
 			/* same for SACL */
 		&& (!offsacl
-		    || ((phead->control & SE_SACL_PRESENT)
-			&& ((psacl->revision == ACL_REVISION)
-			    || (psacl->revision == ACL_REVISION_DS))))) {
-			/*
-			 *  Check the DACL and SACL if present
-			 */
+			|| ((phead->control & SE_SACL_PRESENT)
+				&& ((psacl->revision == ACL_REVISION)
+					|| (psacl->revision == ACL_REVISION_DS))))) {
+		/*
+		 *  Check the DACL and SACL if present
+		 */
 		if ((offdacl && !valid_acl(pdacl,attrsz - offdacl))
-		   || (offsacl && !valid_acl(psacl,attrsz - offsacl)))
+				|| (offsacl && !valid_acl(psacl,attrsz - offsacl)))
 			ok = FALSE;
 	} else
 		ok = FALSE;
@@ -689,8 +689,8 @@ BOOL ntfs_valid_descr(const char *securattr, unsigned int attrsz)
  */
 
 int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
-			const SID *usid, const SID *gsid, BOOL fordir,
-			le16 inherited)
+		const SID *usid, const SID *gsid, BOOL fordir,
+		le16 inherited)
 {
 	unsigned int src;
 	unsigned int dst;
@@ -732,13 +732,13 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 		 * for other types (whose SID may be at a different location)
 		 */
 		switch (poldace->type) {
-		case ACCESS_ALLOWED_ACE_TYPE :
-		case ACCESS_DENIED_ACE_TYPE :
-			acceptable = TRUE;
-			break;
-		default :
-			acceptable = FALSE;
-			break;
+			case ACCESS_ALLOWED_ACE_TYPE :
+			case ACCESS_DENIED_ACE_TYPE :
+				acceptable = TRUE;
+				break;
+			default :
+				acceptable = FALSE;
+				break;
 		}
 		/*
 		 * Extract inheritance for access, including inheritance for
@@ -754,45 +754,45 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 		 * "information."
 		 */
 		if ((poldace->flags & selection)
-		    && acceptable
-		    && (!fordir
-			|| (poldace->flags & NO_PROPAGATE_INHERIT_ACE)
-			|| (poldace->mask & (GENERIC_ALL | GENERIC_READ
-					| GENERIC_WRITE | GENERIC_EXECUTE)))
-		    && !ntfs_same_sid(&poldace->sid, ownersid)
-		    && !ntfs_same_sid(&poldace->sid, groupsid)) {
+				&& acceptable
+				&& (!fordir
+					|| (poldace->flags & NO_PROPAGATE_INHERIT_ACE)
+					|| (poldace->mask & (GENERIC_ALL | GENERIC_READ
+							| GENERIC_WRITE | GENERIC_EXECUTE)))
+				&& !ntfs_same_sid(&poldace->sid, ownersid)
+				&& !ntfs_same_sid(&poldace->sid, groupsid)) {
 			pnewace = (ACCESS_ALLOWED_ACE*)
-					((char*)newacl + dst);
+				((char*)newacl + dst);
 			memcpy(pnewace,poldace,acesz);
-				/* reencode GENERIC_ALL */
+			/* reencode GENERIC_ALL */
 			if (pnewace->mask & GENERIC_ALL) {
 				pnewace->mask &= ~GENERIC_ALL;
 				if (fordir)
 					pnewace->mask |= OWNER_RIGHTS
-							| DIR_READ
-							| DIR_WRITE
-							| DIR_EXEC;
+						| DIR_READ
+						| DIR_WRITE
+						| DIR_EXEC;
 				else
-			/*
-			 * The last flag is not defined for a file,
-			 * however Windows sets it, so do the same
-			 */
+					/*
+					 * The last flag is not defined for a file,
+					 * however Windows sets it, so do the same
+					 */
 					pnewace->mask |= OWNER_RIGHTS
-							| FILE_READ
-							| FILE_WRITE
-							| FILE_EXEC
-							| const_cpu_to_le32(0x40);
+						| FILE_READ
+						| FILE_WRITE
+						| FILE_EXEC
+						| const_cpu_to_le32(0x40);
 			}
-				/* reencode GENERIC_READ (+ EXECUTE) */
+			/* reencode GENERIC_READ (+ EXECUTE) */
 			if (pnewace->mask & GENERIC_READ) {
 				if (fordir)
 					pnewace->mask |= OWNER_RIGHTS
-							| DIR_READ
-							| DIR_EXEC;
+						| DIR_READ
+						| DIR_EXEC;
 				else
 					pnewace->mask |= OWNER_RIGHTS
-							| FILE_READ
-							| FILE_EXEC;
+						| FILE_READ
+						| FILE_EXEC;
 				pnewace->mask &= ~(GENERIC_READ
 						| GENERIC_EXECUTE
 						| WRITE_DAC
@@ -800,29 +800,29 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 						| DELETE | FILE_WRITE_EA
 						| FILE_WRITE_ATTRIBUTES);
 			}
-				/* reencode GENERIC_WRITE */
+			/* reencode GENERIC_WRITE */
 			if (pnewace->mask & GENERIC_WRITE) {
 				if (fordir)
 					pnewace->mask |= OWNER_RIGHTS
-							| DIR_WRITE;
+						| DIR_WRITE;
 				else
 					pnewace->mask |= OWNER_RIGHTS
-							| FILE_WRITE;
+						| FILE_WRITE;
 				pnewace->mask &= ~(GENERIC_WRITE
-							| WRITE_DAC
-							| WRITE_OWNER
-							| FILE_DELETE_CHILD);
+						| WRITE_DAC
+						| WRITE_OWNER
+						| FILE_DELETE_CHILD);
 			}
-				/* remove inheritance flags */
+			/* remove inheritance flags */
 			pnewace->flags &= ~(OBJECT_INHERIT_ACE
-						| CONTAINER_INHERIT_ACE
-						| INHERIT_ONLY_ACE);
+					| CONTAINER_INHERIT_ACE
+					| INHERIT_ONLY_ACE);
 			/*
 			 * Group similar ACE for authenticated users
 			 * (should probably be done for other SIDs)
 			 */
 			if ((poldace->type == ACCESS_ALLOWED_ACE_TYPE)
-			    && ntfs_same_sid(&poldace->sid, authsid)) {
+					&& ntfs_same_sid(&poldace->sid, authsid)) {
 				if (pauthace) {
 					pauthace->flags |= pnewace->flags;
 					pauthace->mask |= pnewace->mask;
@@ -840,34 +840,34 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 				newcnt++;
 			}
 		}
-			/*
-			 * Inheritance for access, specific to
-			 * creator-owner (and creator-group)
-			 */
+		/*
+		 * Inheritance for access, specific to
+		 * creator-owner (and creator-group)
+		 */
 		if ((fordir || !inherited
-			|| (poldace->flags
-			   & (CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE)))
-		    && acceptable) {
+					|| (poldace->flags
+						& (CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE)))
+				&& acceptable) {
 			pnewace = (ACCESS_ALLOWED_ACE*)
-					((char*)newacl + dst);
+				((char*)newacl + dst);
 			memcpy(pnewace,poldace,acesz);
-				/*
-				 * Replace generic creator-owner and
-				 * creator-group by owner and group
-				 * (but keep for further inheritance)
-				 */
+			/*
+			 * Replace generic creator-owner and
+			 * creator-group by owner and group
+			 * (but keep for further inheritance)
+			 */
 			if (ntfs_same_sid(&pnewace->sid, ownersid)) {
 				memcpy(&pnewace->sid, usid, usidsz);
 				pnewace->size = cpu_to_le16(usidsz + 8);
-					/* remove inheritance flags */
+				/* remove inheritance flags */
 				pnewace->flags &= ~(OBJECT_INHERIT_ACE
 						| CONTAINER_INHERIT_ACE
 						| INHERIT_ONLY_ACE);
 				if (inherited)
 					pnewace->flags |= INHERITED_ACE;
 				if ((pnewace->type == ACCESS_ALLOWED_ACE_TYPE)
-				    && pownerace
-				    && !(pnewace->flags & ~pownerace->flags)) {
+						&& pownerace
+						&& !(pnewace->flags & ~pownerace->flags)) {
 					pownerace->mask |= pnewace->mask;
 				} else {
 					dst += usidsz + 8;
@@ -877,7 +877,7 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 			if (ntfs_same_sid(&pnewace->sid, groupsid)) {
 				memcpy(&pnewace->sid, gsid, gsidsz);
 				pnewace->size = cpu_to_le16(gsidsz + 8);
-					/* remove inheritance flags */
+				/* remove inheritance flags */
 				pnewace->flags &= ~(OBJECT_INHERIT_ACE
 						| CONTAINER_INHERIT_ACE
 						| INHERIT_ONLY_ACE);
@@ -888,29 +888,29 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 			}
 		}
 
-			/*
-			 * inheritance for further inheritance
-			 *
-			 * Situations leading to output CONTAINER_INHERIT_ACE
-			 * 	or OBJECT_INHERIT_ACE
-			 */
+		/*
+		 * inheritance for further inheritance
+		 *
+		 * Situations leading to output CONTAINER_INHERIT_ACE
+		 *	or OBJECT_INHERIT_ACE
+		 */
 		if (fordir
-		   && (poldace->flags
-			   & (CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE))) {
+				&& (poldace->flags
+					& (CONTAINER_INHERIT_ACE | OBJECT_INHERIT_ACE))) {
 			pnewace = (ACCESS_ALLOWED_ACE*)
-					((char*)newacl + dst);
+				((char*)newacl + dst);
 			memcpy(pnewace,poldace,acesz);
 			if ((poldace->flags & OBJECT_INHERIT_ACE)
-			   && !(poldace->flags & (CONTAINER_INHERIT_ACE
-					| NO_PROPAGATE_INHERIT_ACE)))
+					&& !(poldace->flags & (CONTAINER_INHERIT_ACE
+							| NO_PROPAGATE_INHERIT_ACE)))
 				pnewace->flags |= INHERIT_ONLY_ACE;
 			if (acceptable
-			    && (poldace->flags & CONTAINER_INHERIT_ACE)
-			    && !(poldace->flags & NO_PROPAGATE_INHERIT_ACE)
-			    && !ntfs_same_sid(&poldace->sid, ownersid)
-			    && !ntfs_same_sid(&poldace->sid, groupsid)) {
+					&& (poldace->flags & CONTAINER_INHERIT_ACE)
+					&& !(poldace->flags & NO_PROPAGATE_INHERIT_ACE)
+					&& !ntfs_same_sid(&poldace->sid, ownersid)
+					&& !ntfs_same_sid(&poldace->sid, groupsid)) {
 				if ((poldace->mask & (GENERIC_ALL | GENERIC_READ
-					| GENERIC_WRITE | GENERIC_EXECUTE)))
+								| GENERIC_WRITE | GENERIC_EXECUTE)))
 					pnewace->flags |= INHERIT_ONLY_ACE;
 				else
 					pnewace->flags &= ~INHERIT_ONLY_ACE;
@@ -921,27 +921,27 @@ int ntfs_inherit_acl(const ACL *oldacl, ACL *newacl,
 			 * Prepare grouping similar ACE for authenticated users
 			 */
 			if ((poldace->type == ACCESS_ALLOWED_ACE_TYPE)
-			    && !pauthace
-			    && !(pnewace->flags & INHERIT_ONLY_ACE)
-			    && ntfs_same_sid(&poldace->sid, authsid)) {
+					&& !pauthace
+					&& !(pnewace->flags & INHERIT_ONLY_ACE)
+					&& ntfs_same_sid(&poldace->sid, authsid)) {
 				pauthace = pnewace;
 			}
 			/*
 			 * Prepare grouping similar ACE for owner
 			 */
 			if ((poldace->type == ACCESS_ALLOWED_ACE_TYPE)
-			    && !pownerace
-			    && !(pnewace->flags & INHERIT_ONLY_ACE)
-			    && ntfs_same_sid(&poldace->sid, usid)) {
+					&& !pownerace
+					&& !(pnewace->flags & INHERIT_ONLY_ACE)
+					&& ntfs_same_sid(&poldace->sid, usid)) {
 				pownerace = pnewace;
 			}
 			dst += acesz;
 			newcnt++;
 		}
 	}
-		/*
-		 * Adjust header if something was inherited
-		 */
+	/*
+	 * Adjust header if something was inherited
+	 */
 	if (dst > sizeof(ACL)) {
 		newacl->ace_count = cpu_to_le16(newcnt);
 		newacl->size = cpu_to_le16(dst);
@@ -988,19 +988,19 @@ BOOL ntfs_valid_posix(const struct POSIX_SECURITY *pxdesc)
 	}
 	ok = TRUE;
 	pacl = &pxdesc->acl;
-			/*
-			 * header (strict for now)
-			 */
+	/*
+	 * header (strict for now)
+	 */
 	if ((pacl->version != POSIX_VERSION)
-	    || (pacl->flags != 0)
-	    || (pacl->filler != 0))
+			|| (pacl->flags != 0)
+			|| (pacl->filler != 0))
 		ok = FALSE;
-			/*
-			 * Reject multiple owner, group or other
-			 * but do not require them to be present
-			 * Also check the ACEs are in correct order
-			 * which implies there is no duplicates
-			 */
+	/*
+	 * Reject multiple owner, group or other
+	 * but do not require them to be present
+	 * Also check the ACEs are in correct order
+	 * which implies there is no duplicates
+	 */
 	for (i=0; i<pxdesc->acccnt + pxdesc->defcnt; i++) {
 		if (i >= pxdesc->firstdef)
 			pchk = &checks[1];
@@ -1012,65 +1012,65 @@ BOOL ntfs_valid_posix(const struct POSIX_SECURITY *pxdesc)
 		id = pacl->ace[i].id;
 		if (perms & ~7) ok = FALSE;
 		if ((tag < pchk->previous)
-			|| ((tag == pchk->previous)
-			 && (id <= pchk->previousid)))
-				ok = FALSE;
+				|| ((tag == pchk->previous)
+					&& (id <= pchk->previousid)))
+			ok = FALSE;
 		pchk->previous = tag;
 		pchk->previousid = id;
 		switch (tag) {
-		case POSIX_ACL_USER_OBJ :
-			if (pchk->owners++)
+			case POSIX_ACL_USER_OBJ :
+				if (pchk->owners++)
+					ok = FALSE;
+				if (id != (u32)-1)
+					ok = FALSE;
+				pchk->mode |= perms << 6;
+				break;
+			case POSIX_ACL_GROUP_OBJ :
+				if (pchk->groups++)
+					ok = FALSE;
+				if (id != (u32)-1)
+					ok = FALSE;
+				pchk->mode = (pchk->mode & 07707) | (perms << 3);
+				break;
+			case POSIX_ACL_OTHER :
+				if (pchk->others++)
+					ok = FALSE;
+				if (id != (u32)-1)
+					ok = FALSE;
+				pchk->mode |= perms;
+				break;
+			case POSIX_ACL_USER :
+			case POSIX_ACL_GROUP :
+				if (id == (u32)-1)
+					ok = FALSE;
+				break;
+			case POSIX_ACL_MASK :
+				if (id != (u32)-1)
+					ok = FALSE;
+				pchk->mode = (pchk->mode & 07707) | (perms << 3);
+				break;
+			default :
 				ok = FALSE;
-			if (id != (u32)-1)
-				ok = FALSE;
-			pchk->mode |= perms << 6;
-			break;
-		case POSIX_ACL_GROUP_OBJ :
-			if (pchk->groups++)
-				ok = FALSE;
-			if (id != (u32)-1)
-				ok = FALSE;
-			pchk->mode = (pchk->mode & 07707) | (perms << 3);
-			break;
-		case POSIX_ACL_OTHER :
-			if (pchk->others++)
-				ok = FALSE;
-			if (id != (u32)-1)
-				ok = FALSE;
-			pchk->mode |= perms;
-			break;
-		case POSIX_ACL_USER :
-		case POSIX_ACL_GROUP :
-			if (id == (u32)-1)
-				ok = FALSE;
-			break;
-		case POSIX_ACL_MASK :
-			if (id != (u32)-1)
-				ok = FALSE;
-			pchk->mode = (pchk->mode & 07707) | (perms << 3);
-			break;
-		default :
-			ok = FALSE;
-			break;
+				break;
 		}
 	}
 	if ((pxdesc->acccnt > 0)
-	   && ((checks[0].owners != 1) || (checks[0].groups != 1)
-		|| (checks[0].others != 1)))
+			&& ((checks[0].owners != 1) || (checks[0].groups != 1)
+				|| (checks[0].others != 1)))
 		ok = FALSE;
-		/* do not check owner, group or other are present in */
-		/* the default ACL, Windows does not necessarily set them */
-			/* descriptor */
+	/* do not check owner, group or other are present in */
+	/* the default ACL, Windows does not necessarily set them */
+	/* descriptor */
 	if (pxdesc->defcnt && (pxdesc->acccnt > pxdesc->firstdef))
 		ok = FALSE;
 	if ((pxdesc->acccnt < 0) || (pxdesc->defcnt < 0))
 		ok = FALSE;
-			/* check mode, unless null or no tag set */
+	/* check mode, unless null or no tag set */
 	if (pxdesc->mode
-	    && checks[0].tagsset
-	    && (checks[0].mode != (pxdesc->mode & 0777)))
+			&& checks[0].tagsset
+			&& (checks[0].mode != (pxdesc->mode & 0777)))
 		ok = FALSE;
-			/* check tagsset */
+	/* check tagsset */
 	if (pxdesc->tagsset != checks[0].tagsset)
 		ok = FALSE;
 	return (ok);
@@ -1094,18 +1094,18 @@ static mode_t posix_header(struct POSIX_SECURITY *pxdesc, mode_t basemode)
 		pace = &pxdesc->acl.ace[i];
 		tagsset |= pace->tag;
 		switch(pace->tag) {
-		case POSIX_ACL_USER_OBJ :
-			mode |= (pace->perms & 7) << 6;
-			break;
-		case POSIX_ACL_GROUP_OBJ :
-		case POSIX_ACL_MASK :
-			mode = (mode & 07707) | ((pace->perms & 7) << 3);
-			break;
-		case POSIX_ACL_OTHER :
-			mode |= pace->perms & 7;
-			break;
-		default :
-			break;
+			case POSIX_ACL_USER_OBJ :
+				mode |= (pace->perms & 7) << 6;
+				break;
+			case POSIX_ACL_GROUP_OBJ :
+			case POSIX_ACL_MASK :
+				mode = (mode & 07707) | ((pace->perms & 7) << 3);
+				break;
+			case POSIX_ACL_OTHER :
+				mode |= pace->perms & 7;
+				break;
+			default :
+				break;
 		}
 	}
 	pxdesc->tagsset = tagsset;
@@ -1139,9 +1139,9 @@ void ntfs_sort_posix(struct POSIX_SECURITY *pxdesc)
 	u32 previousid;
 
 
-			/*
-			 * Check sequencing of tag+id in access ACE's
-			 */
+	/*
+	 * Check sequencing of tag+id in access ACE's
+	 */
 	pacl = &pxdesc->acl;
 	do {
 		done = TRUE;
@@ -1152,7 +1152,7 @@ void ntfs_sort_posix(struct POSIX_SECURITY *pxdesc)
 			id = pacl->ace[i].id;
 
 			if ((tag < previous)
-			   || ((tag == previous) && (id < previousid))) {
+					|| ((tag == previous) && (id < previousid))) {
 				done = FALSE;
 				memcpy(&ace,&pacl->ace[i-1],sizeof(struct POSIX_ACE));
 				memcpy(&pacl->ace[i-1],&pacl->ace[i],sizeof(struct POSIX_ACE));
@@ -1163,9 +1163,9 @@ void ntfs_sort_posix(struct POSIX_SECURITY *pxdesc)
 			}
 		}
 	} while (!done);
-				/*
-				 * Same for default ACEs
-				 */
+	/*
+	 * Same for default ACEs
+	 */
 	do {
 		done = TRUE;
 		if ((pxdesc->defcnt) > 1) {
@@ -1177,7 +1177,7 @@ void ntfs_sort_posix(struct POSIX_SECURITY *pxdesc)
 				id = pacl->ace[i].id;
 
 				if ((tag < previous)
-				   || ((tag == previous) && (id < previousid))) {
+						|| ((tag == previous) && (id < previousid))) {
 					done = FALSE;
 					memcpy(&ace,&pacl->ace[i-1],sizeof(struct POSIX_ACE));
 					memcpy(&pacl->ace[i-1],&pacl->ace[i],sizeof(struct POSIX_ACE));
@@ -1210,25 +1210,25 @@ int ntfs_merge_mode_posix(struct POSIX_SECURITY *pxdesc, mode_t mode)
 	for (i=pxdesc->acccnt-1; i>=0; i--) {
 		pace = &pxdesc->acl.ace[i];
 		switch(pace->tag) {
-		case POSIX_ACL_USER_OBJ :
-			pace->perms = (mode >> 6) & 7;
-			todo &= ~POSIX_ACL_USER_OBJ;
-			break;
-		case POSIX_ACL_GROUP_OBJ :
-			if (!maskfound)
+			case POSIX_ACL_USER_OBJ :
+				pace->perms = (mode >> 6) & 7;
+				todo &= ~POSIX_ACL_USER_OBJ;
+				break;
+			case POSIX_ACL_GROUP_OBJ :
+				if (!maskfound)
+					pace->perms = (mode >> 3) & 7;
+				todo &= ~POSIX_ACL_GROUP_OBJ;
+				break;
+			case POSIX_ACL_MASK :
 				pace->perms = (mode >> 3) & 7;
-			todo &= ~POSIX_ACL_GROUP_OBJ;
-			break;
-		case POSIX_ACL_MASK :
-			pace->perms = (mode >> 3) & 7;
-			maskfound = TRUE;
-			break;
-		case POSIX_ACL_OTHER :
-			pace->perms = mode & 7;
-			todo &= ~POSIX_ACL_OTHER;
-			break;
-		default :
-			break;
+				maskfound = TRUE;
+				break;
+			case POSIX_ACL_OTHER :
+				pace->perms = mode & 7;
+				todo &= ~POSIX_ACL_OTHER;
+				break;
+			default :
+				break;
 		}
 	}
 	pxdesc->mode = mode;
@@ -1264,10 +1264,10 @@ struct POSIX_SECURITY *ntfs_replace_acl(const struct POSIX_SECURITY *oldpxdesc,
 			newpxdesc->acccnt = oldpxdesc->acccnt;
 			newpxdesc->defcnt = count;
 			newpxdesc->firstdef = offset;
-					/* copy access ACEs */
+			/* copy access ACEs */
 			for (i=0; i<newpxdesc->acccnt; i++)
 				newpxdesc->acl.ace[i] = oldpxdesc->acl.ace[i];
-					/* copy default ACEs */
+			/* copy default ACEs */
 			for (i=0; i<count; i++)
 				newpxdesc->acl.ace[i + offset] = newacl->ace[i];
 		} else {
@@ -1275,15 +1275,15 @@ struct POSIX_SECURITY *ntfs_replace_acl(const struct POSIX_SECURITY *oldpxdesc,
 			newpxdesc->acccnt = count;
 			newpxdesc->defcnt = oldpxdesc->defcnt;
 			newpxdesc->firstdef = count;
-					/* copy access ACEs */
+			/* copy access ACEs */
 			for (i=0; i<count; i++)
 				newpxdesc->acl.ace[i] = newacl->ace[i];
-					/* copy default ACEs */
+			/* copy default ACEs */
 			oldoffset = oldpxdesc->firstdef;
 			for (i=0; i<newpxdesc->defcnt; i++)
 				newpxdesc->acl.ace[i + offset] = oldpxdesc->acl.ace[i + oldoffset];
 		}
-			/* assume special flags unchanged */
+		/* assume special flags unchanged */
 		posix_header(newpxdesc, oldpxdesc->mode);
 		if (!ntfs_valid_posix(newpxdesc)) {
 			/* do not log, this is an application error */
@@ -1309,7 +1309,7 @@ struct POSIX_SECURITY *ntfs_build_basic_posix(
 	struct POSIX_ACE *pyace;
 
 	pydesc = (struct POSIX_SECURITY*)malloc(
-		sizeof(struct POSIX_SECURITY) + 3*sizeof(struct POSIX_ACE));
+			sizeof(struct POSIX_SECURITY) + 3*sizeof(struct POSIX_ACE));
 	if (pydesc) {
 		pyace = &pydesc->acl.ace[0];
 		pyace->tag = POSIX_ACL_USER_OBJ;
@@ -1325,8 +1325,8 @@ struct POSIX_SECURITY *ntfs_build_basic_posix(
 		pyace->id = -1;
 		pydesc->mode = mode;
 		pydesc->tagsset = POSIX_ACL_USER_OBJ
-				| POSIX_ACL_GROUP_OBJ
-				| POSIX_ACL_OTHER;
+			| POSIX_ACL_GROUP_OBJ
+			| POSIX_ACL_OTHER;
 		pydesc->acccnt = 3;
 		pydesc->defcnt = 0;
 		pydesc->firstdef = 6;
@@ -1366,34 +1366,34 @@ struct POSIX_SECURITY *ntfs_build_inherited_posix(
 	} else
 		count = 3;
 	pydesc = (struct POSIX_SECURITY*)malloc(
-		sizeof(struct POSIX_SECURITY) + count*sizeof(struct POSIX_ACE));
+			sizeof(struct POSIX_SECURITY) + count*sizeof(struct POSIX_ACE));
 	if (pydesc) {
-			/*
-			 * Copy inherited tags and adapt perms
-			 * Use requested mode, ignoring umask
-			 * (not possible with older versions of fuse)
-			 */
+		/*
+		 * Copy inherited tags and adapt perms
+		 * Use requested mode, ignoring umask
+		 * (not possible with older versions of fuse)
+		 */
 		tagsset = 0;
 		defcnt = (pxdesc ? pxdesc->defcnt : 0);
 		for (i=defcnt-1; i>=0; i--) {
 			pyace = &pydesc->acl.ace[i];
 			*pyace = pxdesc->acl.ace[pxdesc->firstdef + i];
 			switch (pyace->tag) {
-			case POSIX_ACL_USER_OBJ :
-				pyace->perms &= (mode >> 6) & 7;
-				break;
-			case POSIX_ACL_GROUP_OBJ :
-				if (!(tagsset & POSIX_ACL_MASK))
+				case POSIX_ACL_USER_OBJ :
+					pyace->perms &= (mode >> 6) & 7;
+					break;
+				case POSIX_ACL_GROUP_OBJ :
+					if (!(tagsset & POSIX_ACL_MASK))
+						pyace->perms &= (mode >> 3) & 7;
+					break;
+				case POSIX_ACL_OTHER :
+					pyace->perms &= mode & 7;
+					break;
+				case POSIX_ACL_MASK :
 					pyace->perms &= (mode >> 3) & 7;
-				break;
-			case POSIX_ACL_OTHER :
-				pyace->perms &= mode & 7;
-				break;
-			case POSIX_ACL_MASK :
-				pyace->perms &= (mode >> 3) & 7;
-				break;
-			default :
-				break;
+					break;
+				default :
+					break;
 			}
 			tagsset |= pyace->tag;
 		}
@@ -1404,9 +1404,9 @@ struct POSIX_SECURITY *ntfs_build_inherited_posix(
 		 * Here we have to use the umask'ed mode
 		 */
 		if (~tagsset & (POSIX_ACL_USER_OBJ
-				 | POSIX_ACL_GROUP_OBJ | POSIX_ACL_OTHER)) {
+					| POSIX_ACL_GROUP_OBJ | POSIX_ACL_OTHER)) {
 			i = defcnt;
-				/* owner was missing */
+			/* owner was missing */
 			if (!(tagsset & POSIX_ACL_USER_OBJ)) {
 				pyace = &pydesc->acl.ace[i];
 				pyace->tag = POSIX_ACL_USER_OBJ;
@@ -1415,7 +1415,7 @@ struct POSIX_SECURITY *ntfs_build_inherited_posix(
 				tagsset |= POSIX_ACL_USER_OBJ;
 				i++;
 			}
-				/* owning group was missing */
+			/* owning group was missing */
 			if (!(tagsset & POSIX_ACL_GROUP_OBJ)) {
 				pyace = &pydesc->acl.ace[i];
 				pyace->tag = POSIX_ACL_GROUP_OBJ;
@@ -1424,7 +1424,7 @@ struct POSIX_SECURITY *ntfs_build_inherited_posix(
 				tagsset |= POSIX_ACL_GROUP_OBJ;
 				i++;
 			}
-				/* other was missing */
+			/* other was missing */
 			if (!(tagsset & POSIX_ACL_OTHER)) {
 				pyace = &pydesc->acl.ace[i];
 				pyace->tag = POSIX_ACL_OTHER;
@@ -1446,12 +1446,12 @@ struct POSIX_SECURITY *ntfs_build_inherited_posix(
 		if (defcnt && isdir) {
 			size = sizeof(struct POSIX_ACE)*defcnt;
 			memcpy(&pydesc->acl.ace[pydesc->firstdef],
-				 &pxdesc->acl.ace[pxdesc->firstdef],size);
+					&pxdesc->acl.ace[pxdesc->firstdef],size);
 			pydesc->defcnt = defcnt;
 		} else {
 			pydesc->defcnt = 0;
 		}
-			/* assume special bits are not inherited */
+		/* assume special bits are not inherited */
 		posix_header(pydesc, mode & 07000);
 		if (!ntfs_valid_posix(pydesc)) {
 			ntfs_log_error("Error building an inherited Posix desc\n");
@@ -1472,21 +1472,21 @@ static int merge_lists_posix(struct POSIX_ACE *targetace,
 	int k;
 
 	k = 0;
-		/*
-		 * No list is exhausted :
-		 *    if same tag+id in both list :
-		 *       ignore ACE from second list
-		 *    else take the one with smaller tag+id
-		 */
+	/*
+	 * No list is exhausted :
+	 *    if same tag+id in both list :
+	 *       ignore ACE from second list
+	 *    else take the one with smaller tag+id
+	 */
 	while ((firstcnt > 0) && (secondcnt > 0))
 		if ((firstace->tag == secondace->tag)
-		    && (firstace->id == secondace->id)) {
+				&& (firstace->id == secondace->id)) {
 			secondace++;
 			secondcnt--;
 		} else
 			if ((firstace->tag < secondace->tag)
-			   || ((firstace->tag == secondace->tag)
-				&& (firstace->id < secondace->id))) {
+					|| ((firstace->tag == secondace->tag)
+						&& (firstace->id < secondace->id))) {
 				targetace->tag = firstace->tag;
 				targetace->id = firstace->id;
 				targetace->perms = firstace->perms;
@@ -1503,9 +1503,9 @@ static int merge_lists_posix(struct POSIX_ACE *targetace,
 				secondcnt--;
 				k++;
 			}
-		/*
-		 * One list is exhausted, copy the other one
-		 */
+	/*
+	 * One list is exhausted, copy the other one
+	 */
 	while (firstcnt > 0) {
 		targetace->tag = firstace->tag;
 		targetace->id = firstace->id;
@@ -1536,7 +1536,7 @@ static int merge_lists_posix(struct POSIX_ACE *targetace,
  */
 
 struct POSIX_SECURITY *ntfs_merge_descr_posix(const struct POSIX_SECURITY *first,
-			const struct POSIX_SECURITY *second)
+		const struct POSIX_SECURITY *second)
 {
 	struct POSIX_SECURITY *pxdesc;
 	struct POSIX_ACE *targetace;
@@ -1547,31 +1547,31 @@ struct POSIX_SECURITY *ntfs_merge_descr_posix(const struct POSIX_SECURITY *first
 
 	size = sizeof(struct POSIX_SECURITY)
 		+ (first->acccnt + first->defcnt
-			+ second->acccnt + second->defcnt)*sizeof(struct POSIX_ACE);
+				+ second->acccnt + second->defcnt)*sizeof(struct POSIX_ACE);
 	pxdesc = (struct POSIX_SECURITY*)malloc(size);
 	if (pxdesc) {
-			/*
-			 * merge access ACEs
-			 */
+		/*
+		 * merge access ACEs
+		 */
 		firstace = first->acl.ace;
 		secondace = second->acl.ace;
 		targetace = pxdesc->acl.ace;
 		k = merge_lists_posix(targetace,firstace,secondace,
-			first->acccnt,second->acccnt);
+				first->acccnt,second->acccnt);
 		pxdesc->acccnt = k;
-			/*
-			 * merge default ACEs
-			 */
+		/*
+		 * merge default ACEs
+		 */
 		pxdesc->firstdef = k;
 		firstace = &first->acl.ace[first->firstdef];
 		secondace = &second->acl.ace[second->firstdef];
 		targetace = &pxdesc->acl.ace[k];
 		k = merge_lists_posix(targetace,firstace,secondace,
-			first->defcnt,second->defcnt);
+				first->defcnt,second->defcnt);
 		pxdesc->defcnt = k;
-			/*
-			 * build header
-			 */
+		/*
+		 * build header
+		 */
 		pxdesc->acl.version = POSIX_VERSION;
 		pxdesc->acl.flags = 0;
 		pxdesc->acl.filler = 0;
@@ -1625,8 +1625,8 @@ static BOOL build_user_denials(ACL *pacl,
 	pos = le16_to_cpu(pacl->size);
 	acecnt = le16_to_cpu(pacl->ace_count);
 	avoidmask = (pset->mask == (POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X))
-			&& ((pset->designates && pset->withmask)
-			   || (!pset->designates && !pset->withmask));
+		&& ((pset->designates && pset->withmask)
+				|| (!pset->designates && !pset->withmask));
 	if (tag == POSIX_ACL_USER_OBJ) {
 		sid = usid;
 		sidsz = ntfs_sid_size(sid);
@@ -1634,7 +1634,7 @@ static BOOL build_user_denials(ACL *pacl,
 	} else {
 		if (pxace->id) {
 			sid = ntfs_find_usid(mapping[MAPUSERS],
-				pxace->id, (SID*)&defsid);
+					pxace->id, (SID*)&defsid);
 			grants = WORLD_RIGHTS;
 		} else {
 			sid = adminsid;
@@ -1790,7 +1790,7 @@ static BOOL build_user_grants(ACL *pacl,
 	} else {
 		if (pxace->id) {
 			sid = ntfs_find_usid(mapping[MAPUSERS],
-				pxace->id, (SID*)&defsid);
+					pxace->id, (SID*)&defsid);
 			if (sid)
 				sidsz = ntfs_sid_size(sid);
 			else
@@ -1836,10 +1836,10 @@ static BOOL build_user_grants(ACL *pacl,
 }
 
 
-			/* a grant ACE for group */
-			/* unless group-obj has the same rights as world */
-			/* but present if group is owner or owner is administrator */
-			/* this ACE will be inserted after denials for group */
+/* a grant ACE for group */
+/* unless group-obj has the same rights as world */
+/* but present if group is owner or owner is administrator */
+/* this ACE will be inserted after denials for group */
 
 static BOOL build_group_denials_grant(ACL *pacl,
 		const SID *gsid, struct MAPPING* const mapping[],
@@ -1869,14 +1869,14 @@ static BOOL build_group_denials_grant(ACL *pacl,
 	acecnt = le16_to_cpu(pacl->ace_count);
 	rootgroup = FALSE;
 	avoidmask = (pset->mask == (POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X))
-			&& ((pset->designates && pset->withmask)
-			   || (!pset->designates && !pset->withmask));
+		&& ((pset->designates && pset->withmask)
+				|| (!pset->designates && !pset->withmask));
 	if (tag == POSIX_ACL_GROUP_OBJ)
 		sid = gsid;
 	else
 		if (pxace->id)
 			sid = ntfs_find_gsid(mapping[MAPGROUPS],
-				pxace->id, (SID*)&defsid);
+					pxace->id, (SID*)&defsid);
 		else {
 			sid = adminsid;
 			rootgroup = TRUE;
@@ -1893,8 +1893,8 @@ static BOOL build_group_denials_grant(ACL *pacl,
 		 * to some user group
 		 */
 		if ((!avoidmask && !rootgroup)
-		    || (pset->rootspecial
-			&& (tag == POSIX_ACL_GROUP_OBJ))) {
+				|| (pset->rootspecial
+					&& (tag == POSIX_ACL_GROUP_OBJ))) {
 			denials = WRITE_OWNER;
 			pdace = (ACCESS_DENIED_ACE*)&((char*)pacl)[pos];
 			if (pset->isdir) {
@@ -1923,11 +1923,11 @@ static BOOL build_group_denials_grant(ACL *pacl,
 	} else
 		rejected = TRUE;
 	if (!rejected
-	    && (pset->adminowns
-		|| pset->groupowns
-		|| avoidmask
-		|| rootgroup
-		|| (perms != pset->othperms))) {
+			&& (pset->adminowns
+				|| pset->groupowns
+				|| avoidmask
+				|| rootgroup
+				|| (perms != pset->othperms))) {
 		grants = WORLD_RIGHTS;
 		if (rootgroup)
 			grants &= ~ROOT_GROUP_UNMARK;
@@ -1953,8 +1953,8 @@ static BOOL build_group_denials_grant(ACL *pacl,
 		denials = const_cpu_to_le32(0);
 		pdace = (ACCESS_DENIED_ACE*)&((char*)pacl)[pos];
 		if (!pset->adminowns
-		    && !pset->groupowns
-		    && !rootgroup) {
+				&& !pset->groupowns
+				&& !rootgroup) {
 			mixperms = pset->othperms;
 			if (tag == POSIX_ACL_GROUP_OBJ)
 				mixperms |= pset->selfgrpperms;
@@ -1985,14 +1985,14 @@ static BOOL build_group_denials_grant(ACL *pacl,
 			}
 		}
 
-			/* now insert grants to group if more than world */
+		/* now insert grants to group if more than world */
 		if (pset->adminowns
-			|| pset->groupowns
-			|| (avoidmask && (pset->designates || pset->withmask))
-			|| (perms & ~pset->othperms)
-			|| (pset->rootspecial
-			   && (tag == POSIX_ACL_GROUP_OBJ))
-			|| (tag == POSIX_ACL_GROUP)) {
+				|| pset->groupowns
+				|| (avoidmask && (pset->designates || pset->withmask))
+				|| (perms & ~pset->othperms)
+				|| (pset->rootspecial
+					&& (tag == POSIX_ACL_GROUP_OBJ))
+				|| (tag == POSIX_ACL_GROUP)) {
 			if (rootgroup)
 				grants &= ~ROOT_GROUP_UNMARK;
 			pgace = (ACCESS_DENIED_ACE*)&((char*)pacl)[pos];
@@ -2100,7 +2100,7 @@ static int buildacls_posix(struct MAPPING* const mapping[],
 		char *secattr, int offs, const struct POSIX_SECURITY *pxdesc,
 		int isdir, const SID *usid, const SID *gsid)
 {
-        struct BUILD_CONTEXT aceset[2], *pset;
+	struct BUILD_CONTEXT aceset[2], *pset;
 	BOOL adminowns;
 	BOOL groupowns;
 	ACL *pacl;
@@ -2130,9 +2130,9 @@ static int buildacls_posix(struct MAPPING* const mapping[],
 	asidsz = ntfs_sid_size(adminsid);
 	ssidsz = ntfs_sid_size(systemsid);
 	mode = pxdesc->mode;
-		/* adminowns and groupowns are used for both lists */
+	/* adminowns and groupowns are used for both lists */
 	adminowns = ntfs_same_sid(usid, adminsid)
-		 || ntfs_same_sid(gsid, adminsid);
+		|| ntfs_same_sid(gsid, adminsid);
 	groupowns = !adminowns && ntfs_same_sid(usid, gsid);
 
 	ok = TRUE;
@@ -2145,14 +2145,14 @@ static int buildacls_posix(struct MAPPING* const mapping[],
 	pacl->ace_count = const_cpu_to_le16(0);
 	pacl->alignment2 = const_cpu_to_le16(0);
 
-		/*
-		 * Determine what is allowed to some group or world
-		 * to prevent designated users or other groups to get
-		 * rights from groups or world
-		 * Do the same if owner and group appear as designated
-		 * user or group
-		 * Also get global mask
-		 */
+	/*
+	 * Determine what is allowed to some group or world
+	 * to prevent designated users or other groups to get
+	 * rights from groups or world
+	 * Do the same if owner and group appear as designated
+	 * user or group
+	 * Also get global mask
+	 */
 	for (k=0; k<2; k++) {
 		pset = &aceset[k];
 		pset->selfuserperms = 0;
@@ -2177,50 +2177,50 @@ static int buildacls_posix(struct MAPPING* const mapping[],
 			pxace = &pxdesc->acl.ace[i];
 		}
 		switch (pxace->tag) {
-		case POSIX_ACL_USER :
-			pset->designates++;
-			if (pxace->id) {
-				sid = ntfs_find_usid(mapping[MAPUSERS],
-					pxace->id, (SID*)&defsid);
-				if (sid && ntfs_same_sid(sid,usid))
-					pset->selfuserperms |= pxace->perms;
-			} else
-				/* root as designated user is processed apart */
-				pset->rootspecial = TRUE;
-			break;
-		case POSIX_ACL_GROUP :
-			pset->designates++;
-			if (pxace->id) {
-				sid = ntfs_find_gsid(mapping[MAPUSERS],
-					pxace->id, (SID*)&defsid);
-				if (sid && ntfs_same_sid(sid,gsid))
-					pset->selfgrpperms |= pxace->perms;
-			} else
-				/* root as designated group is processed apart */
-				pset->rootspecial = TRUE;
-			/* fall through */
-		case POSIX_ACL_GROUP_OBJ :
-			pset->grpperms |= pxace->perms;
-			break;
-		case POSIX_ACL_OTHER :
-			pset->othperms = pxace->perms;
-			break;
-		case POSIX_ACL_MASK :
-			pset->withmask++;
-			pset->mask = pxace->perms;
-		default :
-			break;
+			case POSIX_ACL_USER :
+				pset->designates++;
+				if (pxace->id) {
+					sid = ntfs_find_usid(mapping[MAPUSERS],
+							pxace->id, (SID*)&defsid);
+					if (sid && ntfs_same_sid(sid,usid))
+						pset->selfuserperms |= pxace->perms;
+				} else
+					/* root as designated user is processed apart */
+					pset->rootspecial = TRUE;
+				break;
+			case POSIX_ACL_GROUP :
+				pset->designates++;
+				if (pxace->id) {
+					sid = ntfs_find_gsid(mapping[MAPUSERS],
+							pxace->id, (SID*)&defsid);
+					if (sid && ntfs_same_sid(sid,gsid))
+						pset->selfgrpperms |= pxace->perms;
+				} else
+					/* root as designated group is processed apart */
+					pset->rootspecial = TRUE;
+				/* fall through */
+			case POSIX_ACL_GROUP_OBJ :
+				pset->grpperms |= pxace->perms;
+				break;
+			case POSIX_ACL_OTHER :
+				pset->othperms = pxace->perms;
+				break;
+			case POSIX_ACL_MASK :
+				pset->withmask++;
+				pset->mask = pxace->perms;
+			default :
+				break;
 		}
 	}
 
-if (pxdesc->defcnt && (pxdesc->firstdef != pxdesc->acccnt)) {
-ntfs_log_error("** error : access and default not consecutive\n");
-return (0);
-}
-			/*
-			 * First insert all denials for owner and each
-			 * designated user (with mask if needed)
-			 */
+	if (pxdesc->defcnt && (pxdesc->firstdef != pxdesc->acccnt)) {
+		ntfs_log_error("** error : access and default not consecutive\n");
+		return (0);
+	}
+	/*
+	 * First insert all denials for owner and each
+	 * designated user (with mask if needed)
+	 */
 
 	pacl->ace_count = const_cpu_to_le16(0);
 	pacl->size = const_cpu_to_le16(sizeof(ACL));
@@ -2235,7 +2235,7 @@ return (0);
 				flags = NO_PROPAGATE_INHERIT_ACE;
 			else
 				flags = (isdir ? DIR_INHERITANCE
-					   : FILE_INHERITANCE);
+						: FILE_INHERITANCE);
 			pset = &aceset[0];
 			pxace = &pxdesc->acl.ace[i];
 		}
@@ -2245,23 +2245,23 @@ return (0);
 
 			/* insert denial ACEs for each owner or allowed user */
 
-		case POSIX_ACL_USER :
-		case POSIX_ACL_USER_OBJ :
+			case POSIX_ACL_USER :
+			case POSIX_ACL_USER_OBJ :
 
-			ok = build_user_denials(pacl,
-				usid, mapping, flags, pxace, pset);
-			break;
-		default :
-			break;
+				ok = build_user_denials(pacl,
+						usid, mapping, flags, pxace, pset);
+				break;
+			default :
+				break;
 		}
 	}
 
-		/*
-		 * for directories, insert a world execution denial
-		 * inherited to plain files.
-		 * This is to prevent Windows from granting execution
-		 * of files through inheritance from parent directory
-		 */
+	/*
+	 * for directories, insert a world execution denial
+	 * inherited to plain files.
+	 * This is to prevent Windows from granting execution
+	 * of files through inheritance from parent directory
+	 */
 
 	if (isdir && ok) {
 		pos = le16_to_cpu(pacl->size);
@@ -2277,12 +2277,12 @@ return (0);
 		pacl->size = cpu_to_le16(pos);
 	}
 
-			/*
-			 * now insert (if needed)
-			 * - grants to owner and designated users
-			 * - mask and denials for all groups
-			 * - grants to other
-			 */
+	/*
+	 * now insert (if needed)
+	 * - grants to owner and designated users
+	 * - mask and denials for all groups
+	 * - grants to other
+	 */
 
 	for (i=0; (i<(pxdesc->acccnt + pxdesc->defcnt)) && ok; i++) {
 		if (i >= pxdesc->acccnt) {
@@ -2295,7 +2295,7 @@ return (0);
 				flags = NO_PROPAGATE_INHERIT_ACE;
 			else
 				flags = (isdir ? DIR_INHERITANCE
-					   : FILE_INHERITANCE);
+						: FILE_INHERITANCE);
 			pset = &aceset[0];
 			pxace = &pxdesc->acl.ace[i];
 		}
@@ -2305,64 +2305,64 @@ return (0);
 
 			/* ACE for each owner or allowed user */
 
-		case POSIX_ACL_USER :
-		case POSIX_ACL_USER_OBJ :
-			ok = build_user_grants(pacl,usid,
-					mapping,flags,pxace,pset);
-			break;
+			case POSIX_ACL_USER :
+			case POSIX_ACL_USER_OBJ :
+				ok = build_user_grants(pacl,usid,
+						mapping,flags,pxace,pset);
+				break;
 
-		case POSIX_ACL_GROUP_OBJ :
-			/* denials and grants for group when needed */
-			if (pset->groupowns && !pset->adminowns
-			    && (pset->grpperms == pset->othperms)
-			    && !pset->designates && !pset->withmask) {
-				ok = TRUE;
-			} else {
+			case POSIX_ACL_GROUP_OBJ :
+				/* denials and grants for group when needed */
+				if (pset->groupowns && !pset->adminowns
+						&& (pset->grpperms == pset->othperms)
+						&& !pset->designates && !pset->withmask) {
+					ok = TRUE;
+				} else {
+					ok = build_group_denials_grant(pacl,gsid,
+							mapping,flags,pxace,pset);
+				}
+				break;
+
+			case POSIX_ACL_GROUP :
+
+				/* denials and grants for designated groups */
+
 				ok = build_group_denials_grant(pacl,gsid,
 						mapping,flags,pxace,pset);
-			}
-			break;
+				break;
 
-		case POSIX_ACL_GROUP :
+			case POSIX_ACL_OTHER :
 
-			/* denials and grants for designated groups */
+				/* grants for other users */
 
-			ok = build_group_denials_grant(pacl,gsid,
-					mapping,flags,pxace,pset);
-			break;
-
-		case POSIX_ACL_OTHER :
-
-			/* grants for other users */
-
-			pos = le16_to_cpu(pacl->size);
-			pgace = (ACCESS_ALLOWED_ACE*)&secattr[offs + pos];
-			grants = WORLD_RIGHTS;
-			if (isdir) {
-				if (perms & POSIX_PERM_X)
-					grants |= DIR_EXEC;
-				if (perms & POSIX_PERM_W)
-					grants |= DIR_WRITE;
-				if (perms & POSIX_PERM_R)
-					grants |= DIR_READ;
-			} else {
-				if (perms & POSIX_PERM_X)
-					grants |= FILE_EXEC;
-				if (perms & POSIX_PERM_W)
-					grants |= FILE_WRITE;
-				if (perms & POSIX_PERM_R)
-					grants |= FILE_READ;
-			}
-			pgace->type = ACCESS_ALLOWED_ACE_TYPE;
-			pgace->flags = flags;
-			pgace->size = cpu_to_le16(wsidsz + 8);
-			pgace->mask = grants;
-			memcpy((char*)&pgace->sid, worldsid, wsidsz);
-			pos += wsidsz + 8;
-			acecnt = le16_to_cpu(pacl->ace_count) + 1;
-			pacl->ace_count = cpu_to_le16(acecnt);
-			pacl->size = cpu_to_le16(pos);
-			break;
+				pos = le16_to_cpu(pacl->size);
+				pgace = (ACCESS_ALLOWED_ACE*)&secattr[offs + pos];
+				grants = WORLD_RIGHTS;
+				if (isdir) {
+					if (perms & POSIX_PERM_X)
+						grants |= DIR_EXEC;
+					if (perms & POSIX_PERM_W)
+						grants |= DIR_WRITE;
+					if (perms & POSIX_PERM_R)
+						grants |= DIR_READ;
+				} else {
+					if (perms & POSIX_PERM_X)
+						grants |= FILE_EXEC;
+					if (perms & POSIX_PERM_W)
+						grants |= FILE_WRITE;
+					if (perms & POSIX_PERM_R)
+						grants |= FILE_READ;
+				}
+				pgace->type = ACCESS_ALLOWED_ACE_TYPE;
+				pgace->flags = flags;
+				pgace->size = cpu_to_le16(wsidsz + 8);
+				pgace->mask = grants;
+				memcpy((char*)&pgace->sid, worldsid, wsidsz);
+				pos += wsidsz + 8;
+				acecnt = le16_to_cpu(pacl->ace_count) + 1;
+				pacl->ace_count = cpu_to_le16(acecnt);
+				pacl->size = cpu_to_le16(pos);
+				break;
 		}
 	}
 
@@ -2435,7 +2435,7 @@ return (0);
 #endif /* POSIXACLS */
 
 static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
-	       const SID * usid, const SID * gsid)
+		const SID * usid, const SID * gsid)
 {
 	ACL *pacl;
 	ACCESS_ALLOWED_ACE *pgace;
@@ -2460,7 +2460,7 @@ static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
 	asidsz = ntfs_sid_size(adminsid);
 	ssidsz = ntfs_sid_size(systemsid);
 	adminowns = ntfs_same_sid(usid, adminsid)
-	         || ntfs_same_sid(gsid, adminsid);
+		|| ntfs_same_sid(gsid, adminsid);
 	groupowns = !adminowns && ntfs_same_sid(usid, gsid);
 
 	/* ACL header */
@@ -2497,7 +2497,7 @@ static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
 
 	/* a possible ACE to deny owner what he/she would */
 	/* induely get from administrator, group or world */
-        /* unless owner is administrator or group */
+	/* unless owner is administrator or group */
 
 	denials = const_cpu_to_le32(0);
 	pdace = (ACCESS_DENIED_ACE*) &secattr[offs + pos];
@@ -2549,24 +2549,24 @@ static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
 			acecnt++;
 		}
 	}
-		/*
-		 * for directories, a world execution denial
-		 * inherited to plain files
-		 */
+	/*
+	 * for directories, a world execution denial
+	 * inherited to plain files
+	 */
 
 	if (isdir) {
 		pdace = (ACCESS_DENIED_ACE*) &secattr[offs + pos];
-			pdace->type = ACCESS_DENIED_ACE_TYPE;
-			pdace->flags = INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE;
-			pdace->size = cpu_to_le16(wsidsz + 8);
-			pdace->mask = FILE_EXEC;
-			memcpy((char*)&pdace->sid, worldsid, wsidsz);
-			pos += wsidsz + 8;
-			acecnt++;
+		pdace->type = ACCESS_DENIED_ACE_TYPE;
+		pdace->flags = INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE;
+		pdace->size = cpu_to_le16(wsidsz + 8);
+		pdace->mask = FILE_EXEC;
+		memcpy((char*)&pdace->sid, worldsid, wsidsz);
+		pos += wsidsz + 8;
+		acecnt++;
 	}
 
 
-		/* now insert grants to owner */
+	/* now insert grants to owner */
 	pgace = (ACCESS_ALLOWED_ACE*) &secattr[offs + pos];
 	pgace->type = ACCESS_ALLOWED_ACE_TYPE;
 	pgace->size = cpu_to_le16(usidsz + 8);
@@ -2582,7 +2582,7 @@ static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
 	/* this ACE will be inserted after denials for group */
 
 	if (adminowns
-	    || (((mode >> 3) ^ mode) & 7)) {
+			|| (((mode >> 3) ^ mode) & 7)) {
 		grants = WORLD_RIGHTS;
 		if (isdir) {
 			gflags = DIR_INHERITANCE;
@@ -2637,10 +2637,10 @@ static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
 		}
 
 		if (adminowns
-		   || groupowns
-		   || ((mode >> 3) & ~mode & 7)) {
-				/* now insert grants to group */
-				/* if more rights than other */
+				|| groupowns
+				|| ((mode >> 3) & ~mode & 7)) {
+			/* now insert grants to group */
+			/* if more rights than other */
 			pgace = (ACCESS_ALLOWED_ACE*)&secattr[offs + pos];
 			pgace->type = ACCESS_ALLOWED_ACE_TYPE;
 			pgace->flags = gflags;
@@ -2748,8 +2748,8 @@ static int buildacls(char *secattr, int offs, mode_t mode, int isdir,
  */
 
 char *ntfs_build_descr_posix(struct MAPPING* const mapping[],
-			struct POSIX_SECURITY *pxdesc,
-			int isdir, const SID *usid, const SID *gsid)
+		struct POSIX_SECURITY *pxdesc,
+		int isdir, const SID *usid, const SID *gsid)
 {
 	int newattrsz;
 	SECURITY_DESCRIPTOR_RELATIVE *pnhead;
@@ -2770,24 +2770,24 @@ char *ntfs_build_descr_posix(struct MAPPING* const mapping[],
 
 	/* allocate enough space for the new security attribute */
 	newattrsz = sizeof(SECURITY_DESCRIPTOR_RELATIVE)	/* header */
-	    + usidsz + gsidsz	/* usid and gsid */
-	    + sizeof(ACL)	/* acl header */
-	    + 2*(8 + usidsz)	/* two possible ACE for user */
-	    + 3*(8 + gsidsz)	/* three possible ACE for group and mask */
-	    + 8 + wsidsz	/* one ACE for world */
-	    + 8 + asidsz	/* one ACE for admin */
-	    + 8 + ssidsz;	/* one ACE for system */
+		+ usidsz + gsidsz	/* usid and gsid */
+		+ sizeof(ACL)	/* acl header */
+		+ 2*(8 + usidsz)	/* two possible ACE for user */
+		+ 3*(8 + gsidsz)	/* three possible ACE for group and mask */
+		+ 8 + wsidsz	/* one ACE for world */
+		+ 8 + asidsz	/* one ACE for admin */
+		+ 8 + ssidsz;	/* one ACE for system */
 	if (isdir)			/* a world denial for directories */
 		newattrsz += 8 + wsidsz;
 	if (pxdesc->mode & 07000)	/* a NULL ACE for special modes */
 		newattrsz += 8 + ntfs_sid_size(nullsid);
-				/* account for non-owning users and groups */
+	/* account for non-owning users and groups */
 	for (k=0; k<pxdesc->acccnt; k++) {
 		if ((pxdesc->acl.ace[k].tag == POSIX_ACL_USER)
-		    || (pxdesc->acl.ace[k].tag == POSIX_ACL_GROUP))
+				|| (pxdesc->acl.ace[k].tag == POSIX_ACL_GROUP))
 			newattrsz += 3*MAX_SID_SIZE;
 	}
-				/* account for default ACE's */
+	/* account for default ACE's */
 	newattrsz += 2*MAX_SID_SIZE*pxdesc->defcnt;
 	newattr = (char*)ntfs_malloc(newattrsz);
 	if (newattr) {
@@ -2795,37 +2795,37 @@ char *ntfs_build_descr_posix(struct MAPPING* const mapping[],
 		pnhead = (SECURITY_DESCRIPTOR_RELATIVE*)newattr;
 		pnhead->revision = SECURITY_DESCRIPTOR_REVISION;
 		pnhead->alignment = 0;
-			/*
-			 * The flag SE_DACL_PROTECTED prevents the ACL
-			 * to be changed in an inheritance after creation
-			 */
+		/*
+		 * The flag SE_DACL_PROTECTED prevents the ACL
+		 * to be changed in an inheritance after creation
+		 */
 		pnhead->control = SE_DACL_PRESENT | SE_DACL_PROTECTED
-				    | SE_SELF_RELATIVE;
-			/*
-			 * Windows prefers ACL first, do the same to
-			 * get the same hash value and avoid duplication
-			 */
+			| SE_SELF_RELATIVE;
+		/*
+		 * Windows prefers ACL first, do the same to
+		 * get the same hash value and avoid duplication
+		 */
 		/* build permissions */
 		aclsz = buildacls_posix(mapping,newattr,
-			  sizeof(SECURITY_DESCRIPTOR_RELATIVE),
-			  pxdesc, isdir, usid, gsid);
+				sizeof(SECURITY_DESCRIPTOR_RELATIVE),
+				pxdesc, isdir, usid, gsid);
 		if (aclsz && ((int)(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				+ aclsz + usidsz + gsidsz) <= newattrsz)) {
+						+ aclsz + usidsz + gsidsz) <= newattrsz)) {
 			/* append usid and gsid */
 			memcpy(&newattr[sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				 + aclsz], usid, usidsz);
+					+ aclsz], usid, usidsz);
 			memcpy(&newattr[sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				+ aclsz + usidsz], gsid, gsidsz);
+					+ aclsz + usidsz], gsid, gsidsz);
 			/* positions of ACL, USID and GSID into header */
 			pnhead->owner =
-			    cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				 + aclsz);
+				cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
+						+ aclsz);
 			pnhead->group =
-			    cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				 + aclsz + usidsz);
+				cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
+						+ aclsz + usidsz);
 			pnhead->sacl = const_cpu_to_le32(0);
 			pnhead->dacl =
-			    const_cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE));
+				const_cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE));
 		} else {
 			/* ACL failure (errno set) or overflow */
 			free(newattr);
@@ -2849,7 +2849,7 @@ char *ntfs_build_descr_posix(struct MAPPING* const mapping[],
  */
 
 char *ntfs_build_descr(mode_t mode,
-			int isdir, const SID * usid, const SID * gsid)
+		int isdir, const SID * usid, const SID * gsid)
 {
 	int newattrsz;
 	SECURITY_DESCRIPTOR_RELATIVE *pnhead;
@@ -2869,13 +2869,13 @@ char *ntfs_build_descr(mode_t mode,
 
 	/* allocate enough space for the new security attribute */
 	newattrsz = sizeof(SECURITY_DESCRIPTOR_RELATIVE)	/* header */
-	    + usidsz + gsidsz	/* usid and gsid */
-	    + sizeof(ACL)	/* acl header */
-	    + 2*(8 + usidsz)	/* two possible ACE for user */
-	    + 2*(8 + gsidsz)	/* two possible ACE for group */
-	    + 8 + wsidsz	/* one ACE for world */
-	    + 8 + asidsz 	/* one ACE for admin */
-	    + 8 + ssidsz;	/* one ACE for system */
+		+ usidsz + gsidsz	/* usid and gsid */
+		+ sizeof(ACL)	/* acl header */
+		+ 2*(8 + usidsz)	/* two possible ACE for user */
+		+ 2*(8 + gsidsz)	/* two possible ACE for group */
+		+ 8 + wsidsz	/* one ACE for world */
+		+ 8 + asidsz 	/* one ACE for admin */
+		+ 8 + ssidsz;	/* one ACE for system */
 	if (isdir)			/* a world denial for directories */
 		newattrsz += 8 + wsidsz;
 	if (mode & 07000)	/* a NULL ACE for special modes */
@@ -2886,37 +2886,37 @@ char *ntfs_build_descr(mode_t mode,
 		pnhead = (SECURITY_DESCRIPTOR_RELATIVE*) newattr;
 		pnhead->revision = SECURITY_DESCRIPTOR_REVISION;
 		pnhead->alignment = 0;
-			/*
-			 * The flag SE_DACL_PROTECTED prevents the ACL
-			 * to be changed in an inheritance after creation
-			 */
+		/*
+		 * The flag SE_DACL_PROTECTED prevents the ACL
+		 * to be changed in an inheritance after creation
+		 */
 		pnhead->control = SE_DACL_PRESENT | SE_DACL_PROTECTED
-				    | SE_SELF_RELATIVE;
-			/*
-			 * Windows prefers ACL first, do the same to
-			 * get the same hash value and avoid duplication
-			 */
+			| SE_SELF_RELATIVE;
+		/*
+		 * Windows prefers ACL first, do the same to
+		 * get the same hash value and avoid duplication
+		 */
 		/* build permissions */
 		aclsz = buildacls(newattr,
-			  sizeof(SECURITY_DESCRIPTOR_RELATIVE),
-			  mode, isdir, usid, gsid);
+				sizeof(SECURITY_DESCRIPTOR_RELATIVE),
+				mode, isdir, usid, gsid);
 		if (((int)sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				+ aclsz + usidsz + gsidsz) <= newattrsz) {
+					+ aclsz + usidsz + gsidsz) <= newattrsz) {
 			/* append usid and gsid */
 			memcpy(&newattr[sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				 + aclsz], usid, usidsz);
+					+ aclsz], usid, usidsz);
 			memcpy(&newattr[sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				+ aclsz + usidsz], gsid, gsidsz);
+					+ aclsz + usidsz], gsid, gsidsz);
 			/* positions of ACL, USID and GSID into header */
 			pnhead->owner =
-			    cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				 + aclsz);
+				cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
+						+ aclsz);
 			pnhead->group =
-			    cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
-				 + aclsz + usidsz);
+				cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE)
+						+ aclsz + usidsz);
 			pnhead->sacl = const_cpu_to_le32(0);
 			pnhead->dacl =
-			    const_cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE));
+				const_cpu_to_le32(sizeof(SECURITY_DESCRIPTOR_RELATIVE));
 		} else {
 			/* hope error was detected before overflowing */
 			free(newattr);
@@ -3051,43 +3051,43 @@ static int norm_std_permissions_posix(struct POSIX_SECURITY *posix_desc,
 
 	mode = 0;
 	tagsset = 0;
-		/*
-		 * Determine what is granted to some group or world
-		 * Also get denials to world which are meant to prevent
-		 * execution flags to be inherited by plain files
-		 */
+	/*
+	 * Determine what is granted to some group or world
+	 * Also get denials to world which are meant to prevent
+	 * execution flags to be inherited by plain files
+	 */
 	pxace = posix_desc->acl.ace;
 	grantgrps = 0;
 	grantwrld = 0;
 	denywrld = 0;
 	for (j=start; j<(start + count); j++) {
 		if (pxace[j].perms & POSIX_PERM_DENIAL) {
-				/* deny world exec unless for default */
+			/* deny world exec unless for default */
 			if ((pxace[j].tag == POSIX_ACL_OTHER)
-			&& !start)
+					&& !start)
 				denywrld = pxace[j].perms;
 		} else {
 			switch (pxace[j].tag) {
-			case POSIX_ACL_GROUP_OBJ :
-				grantgrps |= pxace[j].perms;
-				break;
-			case POSIX_ACL_GROUP :
-				if (pxace[j].id)
+				case POSIX_ACL_GROUP_OBJ :
 					grantgrps |= pxace[j].perms;
-				break;
-			case POSIX_ACL_OTHER :
-				grantwrld = pxace[j].perms;
-				break;
-			default :
-				break;
+					break;
+				case POSIX_ACL_GROUP :
+					if (pxace[j].id)
+						grantgrps |= pxace[j].perms;
+					break;
+				case POSIX_ACL_OTHER :
+					grantwrld = pxace[j].perms;
+					break;
+				default :
+					break;
 			}
 		}
 	}
-		/*
-		 * Collect groups of ACEs related to the same id
-		 * and determine what is granted and what is denied.
-		 * It is important the ACEs have been sorted
-		 */
+	/*
+	 * Collect groups of ACEs related to the same id
+	 * and determine what is granted and what is denied.
+	 * It is important the ACEs have been sorted
+	 */
 	j = start;
 	k = target;
 	while (j < (start + count)) {
@@ -3102,17 +3102,17 @@ static int norm_std_permissions_posix(struct POSIX_SECURITY *posix_desc,
 		}
 		j++;
 		while ((j < (start + count))
-		    && (pxace[j].tag == tag)
-		    && (pxace[j].id == id)) {
+				&& (pxace[j].tag == tag)
+				&& (pxace[j].id == id)) {
 			if (pxace[j].perms & POSIX_PERM_DENIAL)
 				deny |= pxace[j].perms;
 			else
 				allow |= pxace[j].perms;
 			j++;
 		}
-			/*
-			 * Build the permissions equivalent to grants and denials
-			 */
+		/*
+		 * Build the permissions equivalent to grants and denials
+		 */
 		if (groupowns) {
 			if (tag == POSIX_ACL_MASK)
 				perms = ~deny;
@@ -3120,59 +3120,59 @@ static int norm_std_permissions_posix(struct POSIX_SECURITY *posix_desc,
 				perms = allow & ~deny;
 		} else
 			switch (tag) {
-			case POSIX_ACL_USER_OBJ :
-				perms = (allow | grantgrps | grantwrld) & ~deny;
-				break;
-			case POSIX_ACL_USER :
-				if (id)
-					perms = (allow | grantgrps | grantwrld)
-						& ~deny;
-				else
-					perms = allow;
-				break;
-			case POSIX_ACL_GROUP_OBJ :
-				perms = (allow | grantwrld) & ~deny;
-				break;
-			case POSIX_ACL_GROUP :
-				if (id)
+				case POSIX_ACL_USER_OBJ :
+					perms = (allow | grantgrps | grantwrld) & ~deny;
+					break;
+				case POSIX_ACL_USER :
+					if (id)
+						perms = (allow | grantgrps | grantwrld)
+							& ~deny;
+					else
+						perms = allow;
+					break;
+				case POSIX_ACL_GROUP_OBJ :
 					perms = (allow | grantwrld) & ~deny;
-				else
-					perms = allow;
-				break;
-			case POSIX_ACL_MASK :
-				perms = ~deny;
-				break;
-			default :
-				perms = allow & ~deny;
-				break;
+					break;
+				case POSIX_ACL_GROUP :
+					if (id)
+						perms = (allow | grantwrld) & ~deny;
+					else
+						perms = allow;
+					break;
+				case POSIX_ACL_MASK :
+					perms = ~deny;
+					break;
+				default :
+					perms = allow & ~deny;
+					break;
 			}
-			/*
-			 * Store into a Posix ACE
-			 */
+		/*
+		 * Store into a Posix ACE
+		 */
 		if (tag != POSIX_ACL_SPECIAL) {
 			pxace[k].tag = tag;
 			pxace[k].id = id;
 			pxace[k].perms = perms
-				 & (POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X);
+				& (POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X);
 			tagsset |= tag;
 			k++;
 		}
 		switch (tag) {
-		case POSIX_ACL_USER_OBJ :
-			mode |= ((perms & 7) << 6);
-			break;
-		case POSIX_ACL_GROUP_OBJ :
-		case POSIX_ACL_MASK :
-			mode = (mode & 07707) | ((perms & 7) << 3);
-			break;
-		case POSIX_ACL_OTHER :
-			mode |= perms & 7;
-			break;
-		case POSIX_ACL_SPECIAL :
-			mode |= (perms & (S_ISVTX | S_ISUID | S_ISGID));
-			break;
-		default :
-			break;
+			case POSIX_ACL_USER_OBJ :
+				mode |= ((perms & 7) << 6);
+				break;
+			case POSIX_ACL_GROUP_OBJ :
+			case POSIX_ACL_MASK :
+				mode = (mode & 07707) | ((perms & 7) << 3);
+				break;
+			case POSIX_ACL_OTHER :
+				mode |= perms & 7;
+				break;
+			case POSIX_ACL_SPECIAL :
+				mode |= (perms & (S_ISVTX | S_ISUID | S_ISGID));
+				break;
+			default :
+				break;
 		}
 	}
 	if (!start) { /* not satisfactory */
@@ -3222,15 +3222,15 @@ static int build_std_permissions(const char *securattr,
 		pace = (const ACCESS_ALLOWED_ACE*)&securattr[offace];
 		if (!(pace->flags & INHERIT_ONLY_ACE)) {
 			if (ntfs_same_sid(usid, &pace->sid)
-			  || ntfs_same_sid(ownersid, &pace->sid)) {
+					|| ntfs_same_sid(ownersid, &pace->sid)) {
 				noown = FALSE;
 				if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
 					allowown |= pace->mask;
 				else if (pace->type == ACCESS_DENIED_ACE_TYPE)
 					denyown |= pace->mask;
-				} else
+			} else
 				if (ntfs_same_sid(gsid, &pace->sid)
-				    && !(pace->mask & WRITE_OWNER)) {
+						&& !(pace->mask & WRITE_OWNER)) {
 					if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
 						allowgrp |= pace->mask;
 					else if (pace->type == ACCESS_DENIED_ACE_TYPE)
@@ -3243,25 +3243,25 @@ static int build_std_permissions(const char *securattr,
 							if (pace->type == ACCESS_DENIED_ACE_TYPE)
 								denyall |= pace->mask;
 					} else
-					if ((ntfs_same_sid((const SID*)&pace->sid,nullsid))
-					   && (pace->type == ACCESS_ALLOWED_ACE_TYPE))
-						special |= pace->mask;
-			}
-			offace += le16_to_cpu(pace->size);
+						if ((ntfs_same_sid((const SID*)&pace->sid,nullsid))
+								&& (pace->type == ACCESS_ALLOWED_ACE_TYPE))
+							special |= pace->mask;
 		}
-		/*
-		 * No indication about owner's rights : grant basic rights
-		 * This happens for files created by Windows in directories
-		 * created by Linux and owned by root, because Windows
-		 * merges the admin ACEs
-		 */
+		offace += le16_to_cpu(pace->size);
+	}
+	/*
+	 * No indication about owner's rights : grant basic rights
+	 * This happens for files created by Windows in directories
+	 * created by Linux and owned by root, because Windows
+	 * merges the admin ACEs
+	 */
 	if (noown)
 		allowown = (FILE_READ_DATA | FILE_WRITE_DATA | FILE_EXECUTE);
-		/*
-		 *  Add to owner rights granted to group or world
-		 * unless denied personaly, and add to group rights
-		 * granted to world unless denied specifically
-		 */
+	/*
+	 *  Add to owner rights granted to group or world
+	 * unless denied personaly, and add to group rights
+	 * granted to world unless denied specifically
+	 */
 	allowown |= (allowgrp | allowall);
 	allowgrp |= allowall;
 	return (merge_permissions(isdir,
@@ -3278,7 +3278,7 @@ static int build_std_permissions(const char *securattr,
  */
 
 static int build_owngrp_permissions(const char *securattr,
-			const SID *usid, BOOL isdir)
+		const SID *usid, BOOL isdir)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	const ACL *pacl;
@@ -3312,15 +3312,15 @@ static int build_owngrp_permissions(const char *securattr,
 		pace = (const ACCESS_ALLOWED_ACE*)&securattr[offace];
 		if (!(pace->flags & INHERIT_ONLY_ACE)) {
 			if ((ntfs_same_sid(usid, &pace->sid)
-			   || ntfs_same_sid(ownersid, &pace->sid))
-			    && (pace->mask & WRITE_OWNER)) {
+						|| ntfs_same_sid(ownersid, &pace->sid))
+					&& (pace->mask & WRITE_OWNER)) {
 				if (pace->type == ACCESS_ALLOWED_ACE_TYPE) {
 					allowown |= pace->mask;
 					ownpresent = TRUE;
 				}
 			} else
 				if (ntfs_same_sid(usid, &pace->sid)
-				   && (!(pace->mask & WRITE_OWNER))) {
+						&& (!(pace->mask & WRITE_OWNER))) {
 					if (pace->type == ACCESS_ALLOWED_ACE_TYPE) {
 						allowgrp |= pace->mask;
 						grppresent = TRUE;
@@ -3333,12 +3333,12 @@ static int build_owngrp_permissions(const char *securattr,
 							if (pace->type == ACCESS_DENIED_ACE_TYPE)
 								denyall |= pace->mask;
 					} else
-					if ((ntfs_same_sid((const SID*)&pace->sid,nullsid))
-					   && (pace->type == ACCESS_ALLOWED_ACE_TYPE))
-						special |= pace->mask;
-			}
-			offace += le16_to_cpu(pace->size);
+						if ((ntfs_same_sid((const SID*)&pace->sid,nullsid))
+								&& (pace->type == ACCESS_ALLOWED_ACE_TYPE))
+							special |= pace->mask;
 		}
+		offace += le16_to_cpu(pace->size);
+	}
 	if (!ownpresent)
 		allowown = allowall;
 	if (!grppresent)
@@ -3376,23 +3376,23 @@ static int norm_ownadmin_permissions_posix(struct POSIX_SECURITY *posix_desc,
 	pxace = posix_desc->acl.ace;
 	tagsset = 0;
 	denywrld = 0;
-		/*
-		 * Get denials to world which are meant to prevent
-		 * execution flags to be inherited by plain files
-		 */
+	/*
+	 * Get denials to world which are meant to prevent
+	 * execution flags to be inherited by plain files
+	 */
 	for (j=start; j<(start + count); j++) {
 		if (pxace[j].perms & POSIX_PERM_DENIAL) {
-				/* deny world exec not for default */
+			/* deny world exec not for default */
 			if ((pxace[j].tag == POSIX_ACL_OTHER)
-			&& !start)
+					&& !start)
 				denywrld = pxace[j].perms;
 		}
 	}
-		/*
-		 * Collect groups of ACEs related to the same id
-		 * and determine what is granted (denials are ignored)
-		 * It is important the ACEs have been sorted
-		 */
+	/*
+	 * Collect groups of ACEs related to the same id
+	 * and determine what is granted (denials are ignored)
+	 * It is important the ACEs have been sorted
+	 */
 	j = start;
 	k = target;
 	deny = 0;
@@ -3404,24 +3404,24 @@ static int norm_ownadmin_permissions_posix(struct POSIX_SECURITY *posix_desc,
 			deny = pxace[j].perms;
 			j++;
 			while ((j < (start + count))
-			    && (pxace[j].tag == POSIX_ACL_MASK))
+					&& (pxace[j].tag == POSIX_ACL_MASK))
 				j++;
 		} else {
 			if (!(pxace[j].perms & POSIX_PERM_DENIAL))
 				allow = pxace[j].perms;
 			j++;
 			while ((j < (start + count))
-			    && (pxace[j].tag == tag)
-			    && (pxace[j].id == id)) {
+					&& (pxace[j].tag == tag)
+					&& (pxace[j].id == id)) {
 				if (!(pxace[j].perms & POSIX_PERM_DENIAL))
 					allow |= pxace[j].perms;
 				j++;
 			}
 		}
 
-			/*
-			 * Store the grants into a Posix ACE
-			 */
+		/*
+		 * Store the grants into a Posix ACE
+		 */
 		if (tag == POSIX_ACL_MASK)
 			perms = ~deny;
 		else
@@ -3430,26 +3430,26 @@ static int norm_ownadmin_permissions_posix(struct POSIX_SECURITY *posix_desc,
 			pxace[k].tag = tag;
 			pxace[k].id = id;
 			pxace[k].perms = perms
-				 & (POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X);
+				& (POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X);
 			tagsset |= tag;
 			k++;
 		}
 		switch (tag) {
-		case POSIX_ACL_USER_OBJ :
-			mode |= ((perms & 7) << 6);
-			break;
-		case POSIX_ACL_GROUP_OBJ :
-		case POSIX_ACL_MASK :
-			mode = (mode & 07707) | ((perms & 7) << 3);
-			break;
-		case POSIX_ACL_OTHER :
-			mode |= perms & 7;
-			break;
-		case POSIX_ACL_SPECIAL :
-			mode |= perms & (S_ISVTX | S_ISUID | S_ISGID);
-			break;
-		default :
-			break;
+			case POSIX_ACL_USER_OBJ :
+				mode |= ((perms & 7) << 6);
+				break;
+			case POSIX_ACL_GROUP_OBJ :
+			case POSIX_ACL_MASK :
+				mode = (mode & 07707) | ((perms & 7) << 3);
+				break;
+			case POSIX_ACL_OTHER :
+				mode |= perms & 7;
+				break;
+			case POSIX_ACL_SPECIAL :
+				mode |= perms & (S_ISVTX | S_ISUID | S_ISGID);
+				break;
+			default :
+				break;
 		}
 	}
 	if (!start) { /* not satisfactory */
@@ -3468,7 +3468,7 @@ static int norm_ownadmin_permissions_posix(struct POSIX_SECURITY *posix_desc,
 
 
 static int build_ownadmin_permissions(const char *securattr,
-			const SID *usid, const SID *gsid, BOOL isdir)
+		const SID *usid, const SID *gsid, BOOL isdir)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	const ACL *pacl;
@@ -3501,40 +3501,40 @@ static int build_ownadmin_permissions(const char *securattr,
 	for (nace = 0; nace < acecnt; nace++) {
 		pace = (const ACCESS_ALLOWED_ACE*)&securattr[offace];
 		if (!(pace->flags & INHERIT_ONLY_ACE)
-		   && !(~pace->mask & (ROOT_OWNER_UNMARK | ROOT_GROUP_UNMARK))) {
+				&& !(~pace->mask & (ROOT_OWNER_UNMARK | ROOT_GROUP_UNMARK))) {
 			if ((ntfs_same_sid(usid, &pace->sid)
-			   || ntfs_same_sid(ownersid, &pace->sid))
-			     && (((pace->mask & WRITE_OWNER) && firstapply))) {
+						|| ntfs_same_sid(ownersid, &pace->sid))
+					&& (((pace->mask & WRITE_OWNER) && firstapply))) {
 				if (pace->type == ACCESS_ALLOWED_ACE_TYPE) {
 					allowown |= pace->mask;
 					isforeign &= ~1;
 				} else
 					if (pace->type == ACCESS_DENIED_ACE_TYPE)
 						denyown |= pace->mask;
-				} else
-				    if (ntfs_same_sid(gsid, &pace->sid)
-					&& (!(pace->mask & WRITE_OWNER))) {
-						if (pace->type == ACCESS_ALLOWED_ACE_TYPE) {
-							allowgrp |= pace->mask;
-							isforeign &= ~2;
-						} else
-							if (pace->type == ACCESS_DENIED_ACE_TYPE)
-								denygrp |= pace->mask;
-					} else if (is_world_sid((const SID*)&pace->sid)) {
-						if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
-							allowall |= pace->mask;
-						else
-							if (pace->type == ACCESS_DENIED_ACE_TYPE)
-								denyall |= pace->mask;
-					}
-			firstapply = FALSE;
 			} else
-				if (!(pace->flags & INHERIT_ONLY_ACE))
-					if ((ntfs_same_sid((const SID*)&pace->sid,nullsid))
-					   && (pace->type == ACCESS_ALLOWED_ACE_TYPE))
-						special |= pace->mask;
-			offace += le16_to_cpu(pace->size);
-		}
+				if (ntfs_same_sid(gsid, &pace->sid)
+						&& (!(pace->mask & WRITE_OWNER))) {
+					if (pace->type == ACCESS_ALLOWED_ACE_TYPE) {
+						allowgrp |= pace->mask;
+						isforeign &= ~2;
+					} else
+						if (pace->type == ACCESS_DENIED_ACE_TYPE)
+							denygrp |= pace->mask;
+				} else if (is_world_sid((const SID*)&pace->sid)) {
+					if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
+						allowall |= pace->mask;
+					else
+						if (pace->type == ACCESS_DENIED_ACE_TYPE)
+							denyall |= pace->mask;
+				}
+			firstapply = FALSE;
+		} else
+			if (!(pace->flags & INHERIT_ONLY_ACE))
+				if ((ntfs_same_sid((const SID*)&pace->sid,nullsid))
+						&& (pace->type == ACCESS_ALLOWED_ACE_TYPE))
+					special |= pace->mask;
+		offace += le16_to_cpu(pace->size);
+	}
 	if (isforeign) {
 		allowown |= (allowgrp | allowall);
 		allowgrp |= allowall;
@@ -3584,8 +3584,8 @@ const SID *ntfs_acl_owner(const char *securattr)
 		do {
 			pace = (const ACCESS_ALLOWED_ACE*)&securattr[offace];
 			if ((pace->mask & WRITE_OWNER)
-			   && (pace->type == ACCESS_ALLOWED_ACE_TYPE)
-			   && ntfs_is_user_sid(&pace->sid))
+					&& (pace->type == ACCESS_ALLOWED_ACE_TYPE)
+					&& ntfs_is_user_sid(&pace->sid))
 				found = TRUE;
 			offace += le16_to_cpu(pace->size);
 		} while (!found && (++nace < acecnt));
@@ -3617,7 +3617,7 @@ const SID *ntfs_acl_owner(const char *securattr)
 
 
 static uid_t find_tenant(struct MAPPING *const mapping[],
-			const char *securattr)
+		const char *securattr)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	const ACL *pacl;
@@ -3641,7 +3641,7 @@ static uid_t find_tenant(struct MAPPING *const mapping[],
 	for (nace = 0; nace < acecnt; nace++) {
 		pace = (const ACCESS_ALLOWED_ACE*)&securattr[offace];
 		if ((pace->type == ACCESS_ALLOWED_ACE_TYPE)
-		   && (pace->mask & DIR_WRITE)) {
+				&& (pace->mask & DIR_WRITE)) {
 			xid = ntfs_find_user(mapping[MAPUSERS], &pace->sid);
 			if (xid) tid = xid;
 		}
@@ -3666,9 +3666,9 @@ static uid_t find_tenant(struct MAPPING *const mapping[],
  */
 
 struct POSIX_SECURITY *ntfs_build_permissions_posix(
-			struct MAPPING *const mapping[],
-			const char *securattr,
-			const SID *usid, const SID *gsid, BOOL isdir)
+		struct MAPPING *const mapping[],
+		const char *securattr,
+		const SID *usid, const SID *gsid, BOOL isdir)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	struct POSIX_SECURITY *pxdesc;
@@ -3713,18 +3713,18 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 	groupowns = ntfs_same_sid(gsid,usid);
 	firstinh = FALSE;
 	genericinh = FALSE;
-		/*
-		 * Build a raw posix security descriptor
-		 * by just translating permissions and ids
-		 * Add 2 to the count of ACE to be able to insert
-		 * a group ACE later in access and default ACLs
-		 * and add 2 more to be able to insert ACEs for owner
-		 * and 2 more for other
-		 */
+	/*
+	 * Build a raw posix security descriptor
+	 * by just translating permissions and ids
+	 * Add 2 to the count of ACE to be able to insert
+	 * a group ACE later in access and default ACLs
+	 * and add 2 more to be able to insert ACEs for owner
+	 * and 2 more for other
+	 */
 	alloccnt = acecnt + 6;
 	pxdesc = (struct POSIX_SECURITY*)malloc(
-				sizeof(struct POSIX_SECURITY)
-				+ alloccnt*sizeof(struct POSIX_ACE));
+			sizeof(struct POSIX_SECURITY)
+			+ alloccnt*sizeof(struct POSIX_ACE));
 	k = 0;
 	l = alloccnt;
 	for (i=0; i<2; i++) {
@@ -3748,20 +3748,20 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 			pctx = &ctx[0];
 		}
 		ignore = FALSE;
-			/*
-			 * grants for root as a designated user or group
-			 */
+		/*
+		 * grants for root as a designated user or group
+		 */
 		if ((~pace->mask & (ROOT_OWNER_UNMARK | ROOT_GROUP_UNMARK))
-		   && (pace->type == ACCESS_ALLOWED_ACE_TYPE)
-		   && ntfs_same_sid(&pace->sid, adminsid)) {
+				&& (pace->type == ACCESS_ALLOWED_ACE_TYPE)
+				&& ntfs_same_sid(&pace->sid, adminsid)) {
 			pxace->tag = (pace->mask & ROOT_OWNER_UNMARK ? POSIX_ACL_GROUP : POSIX_ACL_USER);
 			pxace->id = 0;
 			if ((pace->mask & (GENERIC_ALL | WRITE_OWNER))
-			   && (pace->flags & INHERIT_ONLY_ACE))
+					&& (pace->flags & INHERIT_ONLY_ACE))
 				ignore = genericinh = TRUE;
 		} else
-		if (ntfs_same_sid(usid, &pace->sid)) {
-			pxace->id = -1;
+			if (ntfs_same_sid(usid, &pace->sid)) {
+				pxace->id = -1;
 				/*
 				 * Owner has no write-owner right :
 				 * a group was defined same as owner
@@ -3769,149 +3769,149 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 				 * denials are meant to owner
 				 * and grants are meant to group
 				 */
-			if (!(pace->mask & (WRITE_OWNER | GENERIC_ALL))
-			    && (pace->type == ACCESS_ALLOWED_ACE_TYPE)) {
-				if (ntfs_same_sid(gsid,usid)) {
-					pxace->tag = POSIX_ACL_GROUP_OBJ;
-					pxace->id = -1;
-				} else {
-					if (ntfs_same_sid(&pace->sid,usid))
-						groupowns = TRUE;
-					gid = ntfs_find_group(mapping[MAPGROUPS],&pace->sid);
-					if (gid) {
-						pxace->tag = POSIX_ACL_GROUP;
-						pxace->id = gid;
-						pctx->prevgid = gid;
+				if (!(pace->mask & (WRITE_OWNER | GENERIC_ALL))
+						&& (pace->type == ACCESS_ALLOWED_ACE_TYPE)) {
+					if (ntfs_same_sid(gsid,usid)) {
+						pxace->tag = POSIX_ACL_GROUP_OBJ;
+						pxace->id = -1;
 					} else {
-					uid = ntfs_find_user(mapping[MAPUSERS],&pace->sid);
-					if (uid) {
-						pxace->tag = POSIX_ACL_USER;
-						pxace->id = uid;
-					} else
-						ignore = TRUE;
+						if (ntfs_same_sid(&pace->sid,usid))
+							groupowns = TRUE;
+						gid = ntfs_find_group(mapping[MAPGROUPS],&pace->sid);
+						if (gid) {
+							pxace->tag = POSIX_ACL_GROUP;
+							pxace->id = gid;
+							pctx->prevgid = gid;
+						} else {
+							uid = ntfs_find_user(mapping[MAPUSERS],&pace->sid);
+							if (uid) {
+								pxace->tag = POSIX_ACL_USER;
+								pxace->id = uid;
+							} else
+								ignore = TRUE;
+						}
+					}
+				} else {
+					/*
+					 * when group owns, late denials for owner
+					 * mean group mask
+					 */
+					if ((pace->type == ACCESS_DENIED_ACE_TYPE)
+							&& (pace->mask & WRITE_OWNER)) {
+						pxace->tag = POSIX_ACL_MASK;
+						pctx->gotownermask = TRUE;
+						if (pctx->gotowner)
+							pctx->groupmasks++;
+					} else {
+						if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
+							pctx->gotowner = TRUE;
+						if (pctx->gotownermask && !pctx->gotowner) {
+							uid = ntfs_find_user(mapping[MAPUSERS],&pace->sid);
+							pxace->id = uid;
+							pxace->tag = POSIX_ACL_USER;
+						} else
+							pxace->tag = POSIX_ACL_USER_OBJ;
+						/* system ignored, and admin */
+						/* ignored at first position */
+						if (pace->flags & INHERIT_ONLY_ACE) {
+							if ((firstinh && ntfs_same_sid(&pace->sid,adminsid))
+									|| ntfs_same_sid(&pace->sid,systemsid))
+								ignore = TRUE;
+							if (!firstinh) {
+								firstinh = TRUE;
+							}
+						} else {
+							if ((adminowns && ntfs_same_sid(&pace->sid,adminsid))
+									|| ntfs_same_sid(&pace->sid,systemsid))
+								ignore = TRUE;
+							if (ntfs_same_sid(usid,adminsid))
+								adminowns = TRUE;
+						}
 					}
 				}
-			} else {
-				/*
-				 * when group owns, late denials for owner
-				 * mean group mask
-				 */
+			} else if (ntfs_same_sid(gsid, &pace->sid)) {
 				if ((pace->type == ACCESS_DENIED_ACE_TYPE)
-				    && (pace->mask & WRITE_OWNER)) {
+						&& (pace->mask & WRITE_OWNER)) {
 					pxace->tag = POSIX_ACL_MASK;
-					pctx->gotownermask = TRUE;
+					pxace->id = -1;
 					if (pctx->gotowner)
 						pctx->groupmasks++;
 				} else {
-					if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
-						pctx->gotowner = TRUE;
-					if (pctx->gotownermask && !pctx->gotowner) {
-						uid = ntfs_find_user(mapping[MAPUSERS],&pace->sid);
+					if (pctx->gotgroup || (pctx->groupmasks > 1)) {
+						gid = ntfs_find_group(mapping[MAPGROUPS],&pace->sid);
+						if (gid) {
+							pxace->id = gid;
+							pxace->tag = POSIX_ACL_GROUP;
+							pctx->prevgid = gid;
+						} else
+							ignore = TRUE;
+					} else {
+						pxace->id = -1;
+						pxace->tag = POSIX_ACL_GROUP_OBJ;
+						if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
+							pctx->gotgroup = TRUE;
+					}
+
+					if (ntfs_same_sid(gsid,adminsid)
+							|| ntfs_same_sid(gsid,systemsid)) {
+						if (pace->mask & (WRITE_OWNER | GENERIC_ALL))
+							ignore = TRUE;
+						if (ntfs_same_sid(gsid,adminsid))
+							adminowns = TRUE;
+						else
+							genericinh = ignore;
+					}
+				}
+			} else if (is_world_sid((const SID*)&pace->sid)) {
+				pxace->id = -1;
+				pxace->tag = POSIX_ACL_OTHER;
+				if ((pace->type == ACCESS_DENIED_ACE_TYPE)
+						&& (pace->flags & INHERIT_ONLY_ACE))
+					ignore = TRUE;
+			} else if (ntfs_same_sid((const SID*)&pace->sid,nullsid)) {
+				pxace->id = -1;
+				pxace->tag = POSIX_ACL_SPECIAL;
+			} else {
+				uid = ntfs_find_user(mapping[MAPUSERS],&pace->sid);
+				if (uid) {
+					if ((pace->type == ACCESS_DENIED_ACE_TYPE)
+							&& (pace->mask & WRITE_OWNER)
+							&& (pctx->prevuid != uid)) {
+						pxace->id = -1;
+						pxace->tag = POSIX_ACL_MASK;
+					} else {
 						pxace->id = uid;
 						pxace->tag = POSIX_ACL_USER;
-					} else
-						pxace->tag = POSIX_ACL_USER_OBJ;
-						/* system ignored, and admin */
-						/* ignored at first position */
-					if (pace->flags & INHERIT_ONLY_ACE) {
-						if ((firstinh && ntfs_same_sid(&pace->sid,adminsid))
-						   || ntfs_same_sid(&pace->sid,systemsid))
-							ignore = TRUE;
-						if (!firstinh) {
-							firstinh = TRUE;
-						}
-					} else {
-						if ((adminowns && ntfs_same_sid(&pace->sid,adminsid))
-						   || ntfs_same_sid(&pace->sid,systemsid))
-							ignore = TRUE;
-						if (ntfs_same_sid(usid,adminsid))
-							adminowns = TRUE;
 					}
-				}
-			}
-		} else if (ntfs_same_sid(gsid, &pace->sid)) {
-			if ((pace->type == ACCESS_DENIED_ACE_TYPE)
-			    && (pace->mask & WRITE_OWNER)) {
-				pxace->tag = POSIX_ACL_MASK;
-				pxace->id = -1;
-				if (pctx->gotowner)
-					pctx->groupmasks++;
-			} else {
-				if (pctx->gotgroup || (pctx->groupmasks > 1)) {
+					pctx->prevuid = uid;
+				} else {
 					gid = ntfs_find_group(mapping[MAPGROUPS],&pace->sid);
 					if (gid) {
+						if ((pace->type == ACCESS_DENIED_ACE_TYPE)
+								&& (pace->mask & WRITE_OWNER)
+								&& (pctx->prevgid != gid)) {
+							pxace->tag = POSIX_ACL_MASK;
+							pctx->groupmasks++;
+						} else {
+							pxace->tag = POSIX_ACL_GROUP;
+						}
 						pxace->id = gid;
-						pxace->tag = POSIX_ACL_GROUP;
 						pctx->prevgid = gid;
-					} else
-						ignore = TRUE;
-				} else {
-					pxace->id = -1;
-					pxace->tag = POSIX_ACL_GROUP_OBJ;
-					if (pace->type == ACCESS_ALLOWED_ACE_TYPE)
-						pctx->gotgroup = TRUE;
-				}
-
-				if (ntfs_same_sid(gsid,adminsid)
-				    || ntfs_same_sid(gsid,systemsid)) {
-					if (pace->mask & (WRITE_OWNER | GENERIC_ALL))
-						ignore = TRUE;
-					if (ntfs_same_sid(gsid,adminsid))
-						adminowns = TRUE;
-					else
-						genericinh = ignore;
-				}
-			}
-		} else if (is_world_sid((const SID*)&pace->sid)) {
-			pxace->id = -1;
-			pxace->tag = POSIX_ACL_OTHER;
-			if ((pace->type == ACCESS_DENIED_ACE_TYPE)
-			   && (pace->flags & INHERIT_ONLY_ACE))
-				ignore = TRUE;
-		} else if (ntfs_same_sid((const SID*)&pace->sid,nullsid)) {
-			pxace->id = -1;
-			pxace->tag = POSIX_ACL_SPECIAL;
-		} else {
-			uid = ntfs_find_user(mapping[MAPUSERS],&pace->sid);
-			if (uid) {
-				if ((pace->type == ACCESS_DENIED_ACE_TYPE)
-				    && (pace->mask & WRITE_OWNER)
-				    && (pctx->prevuid != uid)) {
-					pxace->id = -1;
-					pxace->tag = POSIX_ACL_MASK;
-				} else {
-					pxace->id = uid;
-					pxace->tag = POSIX_ACL_USER;
-				}
-				pctx->prevuid = uid;
-			} else {
-				gid = ntfs_find_group(mapping[MAPGROUPS],&pace->sid);
-				if (gid) {
-					if ((pace->type == ACCESS_DENIED_ACE_TYPE)
-					    && (pace->mask & WRITE_OWNER)
-					    && (pctx->prevgid != gid)) {
-						pxace->tag = POSIX_ACL_MASK;
-						pctx->groupmasks++;
 					} else {
-						pxace->tag = POSIX_ACL_GROUP;
+						/*
+						 * do not grant rights to unknown
+						 * people and do not define root as a
+						 * designated user or group
+						 */
+						ignore = TRUE;
 					}
-					pxace->id = gid;
-					pctx->prevgid = gid;
-				} else {
-					/*
-					 * do not grant rights to unknown
-					 * people and do not define root as a
-					 * designated user or group
-					 */
-					ignore = TRUE;
 				}
 			}
-		}
 		if (((pace->type == ACCESS_ALLOWED_ACE_TYPE)
-			|| (pace->type == ACCESS_DENIED_ACE_TYPE))
-		    && !ignore) {
+					|| (pace->type == ACCESS_DENIED_ACE_TYPE))
+				&& !ignore) {
 			pxace->perms = 0;
-				/* specific decoding for vtx/uid/gid */
+			/* specific decoding for vtx/uid/gid */
 			if (pxace->tag == POSIX_ACL_SPECIAL) {
 				if (pace->mask & FILE_APPEND_DATA)
 					pxace->perms |= S_ISUID;
@@ -3928,10 +3928,10 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 					if (pace->mask & DIR_GREAD)
 						pxace->perms |= POSIX_PERM_R;
 					if ((pace->mask & GENERIC_ALL)
-					   && (pace->flags & INHERIT_ONLY_ACE))
+							&& (pace->flags & INHERIT_ONLY_ACE))
 						pxace->perms |= POSIX_PERM_X
-								| POSIX_PERM_W
-								| POSIX_PERM_R;
+							| POSIX_PERM_W
+							| POSIX_PERM_R;
 				} else {
 					if (pace->mask & FILE_GEXEC)
 						pxace->perms |= POSIX_PERM_X;
@@ -3955,12 +3955,12 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 		}
 		offace += le16_to_cpu(pace->size);
 	}
-		/*
-		 * Create world perms if none (both lists)
-		 */
+	/*
+	 * Create world perms if none (both lists)
+	 */
 	for (i=0; i<2; i++)
 		if ((genericinh || !i)
-		    && !(ctx[i].tagsset & POSIX_ACL_OTHER)) {
+				&& !(ctx[i].tagsset & POSIX_ACL_OTHER)) {
 			if (i)
 				pxace = &pxdesc->acl.ace[--l];
 			else
@@ -3971,15 +3971,15 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 			ctx[i].tagsset |= POSIX_ACL_OTHER;
 			ctx[i].permswrld = 0;
 		}
-		/*
-		 * Set basic owner perms if none (both lists)
-		 * This happens for files created by Windows in directories
-		 * created by Linux and owned by root, because Windows
-		 * merges the admin ACEs
-		 */
+	/*
+	 * Set basic owner perms if none (both lists)
+	 * This happens for files created by Windows in directories
+	 * created by Linux and owned by root, because Windows
+	 * merges the admin ACEs
+	 */
 	for (i=0; i<2; i++)
 		if (!(ctx[i].tagsset & POSIX_ACL_USER_OBJ)
-		  && (ctx[i].tagsset & POSIX_ACL_OTHER)) {
+				&& (ctx[i].tagsset & POSIX_ACL_OTHER)) {
 			if (i)
 				pxace = &pxdesc->acl.ace[--l];
 			else
@@ -3989,12 +3989,12 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 			pxace->perms = POSIX_PERM_R | POSIX_PERM_W | POSIX_PERM_X;
 			ctx[i].tagsset |= POSIX_ACL_USER_OBJ;
 		}
-		/*
-		 * Duplicate world perms as group_obj perms if none
-		 */
+	/*
+	 * Duplicate world perms as group_obj perms if none
+	 */
 	for (i=0; i<2; i++)
 		if ((ctx[i].tagsset & POSIX_ACL_OTHER)
-		    && !(ctx[i].tagsset & POSIX_ACL_GROUP_OBJ)) {
+				&& !(ctx[i].tagsset & POSIX_ACL_GROUP_OBJ)) {
 			if (i)
 				pxace = &pxdesc->acl.ace[--l];
 			else
@@ -4004,17 +4004,17 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 			pxace->perms = ctx[i].permswrld;
 			ctx[i].tagsset |= POSIX_ACL_GROUP_OBJ;
 		}
-		/*
-		 * Also duplicate world perms as group perms if they
-		 * were converted to mask and not followed by a group entry
-		 */
+	/*
+	 * Also duplicate world perms as group perms if they
+	 * were converted to mask and not followed by a group entry
+	 */
 	if (ctx[0].groupmasks) {
 		for (j=k-2; j>=0; j--) {
 			if ((pxdesc->acl.ace[j].tag == POSIX_ACL_MASK)
-			   && (pxdesc->acl.ace[j].id != -1)
-			   && ((pxdesc->acl.ace[j+1].tag != POSIX_ACL_GROUP)
-			     || (pxdesc->acl.ace[j+1].id
-				!= pxdesc->acl.ace[j].id))) {
+					&& (pxdesc->acl.ace[j].id != -1)
+					&& ((pxdesc->acl.ace[j+1].tag != POSIX_ACL_GROUP)
+						|| (pxdesc->acl.ace[j+1].id
+							!= pxdesc->acl.ace[j].id))) {
 				pxace = &pxdesc->acl.ace[k];
 				pxace->tag = POSIX_ACL_GROUP;
 				pxace->id = pxdesc->acl.ace[j].id;
@@ -4029,10 +4029,10 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 	if (ctx[1].groupmasks) {
 		for (j=l; j<(alloccnt-1); j++) {
 			if ((pxdesc->acl.ace[j].tag == POSIX_ACL_MASK)
-			   && (pxdesc->acl.ace[j].id != -1)
-			   && ((pxdesc->acl.ace[j+1].tag != POSIX_ACL_GROUP)
-			     || (pxdesc->acl.ace[j+1].id
-				!= pxdesc->acl.ace[j].id))) {
+					&& (pxdesc->acl.ace[j].id != -1)
+					&& ((pxdesc->acl.ace[j+1].tag != POSIX_ACL_GROUP)
+						|| (pxdesc->acl.ace[j+1].id
+							!= pxdesc->acl.ace[j].id))) {
 				pxace = &pxdesc->acl.ace[l - 1];
 				pxace->tag = POSIX_ACL_GROUP;
 				pxace->id = pxdesc->acl.ace[j].id;
@@ -4045,14 +4045,14 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 		}
 	}
 
-		/*
-		 * Insert default mask if none present and
-		 * there are designated users or groups
-		 * (the space for it has not beed used)
-		 */
+	/*
+	 * Insert default mask if none present and
+	 * there are designated users or groups
+	 * (the space for it has not beed used)
+	 */
 	for (i=0; i<2; i++)
 		if ((ctx[i].tagsset & (POSIX_ACL_USER | POSIX_ACL_GROUP))
-		    && !(ctx[i].tagsset & POSIX_ACL_MASK)) {
+				&& !(ctx[i].tagsset & POSIX_ACL_MASK)) {
 			if (i)
 				pxace = &pxdesc->acl.ace[--l];
 			else
@@ -4097,9 +4097,9 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
 	}
 	if (pxdesc && !ntfs_valid_posix(pxdesc)) {
 		ntfs_log_error("Invalid Posix descriptor built\n");
-                errno = EIO;
-                free(pxdesc);
-                pxdesc = (struct POSIX_SECURITY*)NULL;
+		errno = EIO;
+		free(pxdesc);
+		pxdesc = (struct POSIX_SECURITY*)NULL;
 	}
 	return (pxdesc);
 }
@@ -4113,14 +4113,14 @@ struct POSIX_SECURITY *ntfs_build_permissions_posix(
  */
 
 int ntfs_build_permissions(const char *securattr,
-			const SID *usid, const SID *gsid, BOOL isdir)
+		const SID *usid, const SID *gsid, BOOL isdir)
 {
 	int perm;
 	BOOL adminowns;
 	BOOL groupowns;
 
 	adminowns = ntfs_same_sid(usid,adminsid)
-	         || ntfs_same_sid(gsid,adminsid);
+		|| ntfs_same_sid(gsid,adminsid);
 	groupowns = !adminowns && ntfs_same_sid(gsid,usid);
 	if (adminowns)
 		perm = build_ownadmin_permissions(securattr, usid, gsid, isdir);
@@ -4180,7 +4180,7 @@ static SID *encodesid(const char *sidstr)
 		}
 		bsid->sub_authority_count = cnt;
 		if ((cnt > 0) && ntfs_valid_sid(bsid)
-		    && (ntfs_is_user_sid(bsid) || ntfs_known_group_sid(bsid))) {
+				&& (ntfs_is_user_sid(bsid) || ntfs_known_group_sid(bsid))) {
 			sid = (SID*) ntfs_malloc(4 * cnt + 8);
 			if (sid)
 				memcpy(sid, bsid, 4 * cnt + 8);
@@ -4210,13 +4210,13 @@ static struct MAPLIST *getmappingitem(FILEREADER reader, void *fileid,
 
 	src = *psrc;
 	dst = 0;
-			/* allocate and get a full line */
+	/* allocate and get a full line */
 	item = (struct MAPLIST*)ntfs_malloc(sizeof(struct MAPLIST));
 	if (item) {
 		do {
 			gotend = 0;
 			while ((src < *psize)
-			       && (buf[src] != '\n')) {
+					&& (buf[src] != '\n')) {
 				if (dst < LINESZ)
 					item->maptext[dst++] = buf[src];
 				src++;
@@ -4250,7 +4250,7 @@ static struct MAPLIST *getmappingitem(FILEREADER reader, void *fileid,
 				*pu = *pg = '\0';
 			else {
 				ntfs_log_early_error("Bad mapping item \"%s\"\n",
-					item->maptext);
+						item->maptext);
 				free(item);
 				item = (struct MAPLIST*)NULL;
 			}
@@ -4296,7 +4296,7 @@ struct MAPLIST *ntfs_read_mapping(FILEREADER reader, void *fileid)
 		src = 0;
 		do {
 			item = getmappingitem(reader, fileid, &offs,
-				buf, &src, &size);
+					buf, &src, &size);
 			if (item) {
 				item->next = (struct MAPLIST*)NULL;
 				if (lastitem)
@@ -4320,7 +4320,7 @@ void ntfs_free_mapping(struct MAPPING *mapping[])
 	struct MAPPING *user;
 	struct MAPPING *group;
 
-		/* free user mappings */
+	/* free user mappings */
 	while (mapping[MAPUSERS]) {
 		user = mapping[MAPUSERS];
 		/* do not free SIDs used for group mappings */
@@ -4329,18 +4329,18 @@ void ntfs_free_mapping(struct MAPPING *mapping[])
 			group = group->next;
 		if (!group)
 			free(user->sid);
-			/* free group list if any */
+		/* free group list if any */
 		if (user->grcnt)
 			free(user->groups);
-			/* unchain item and free */
+		/* unchain item and free */
 		mapping[MAPUSERS] = user->next;
 		free(user);
 	}
-		/* free group mappings */
+	/* free group mappings */
 	while (mapping[MAPGROUPS]) {
 		group = mapping[MAPGROUPS];
 		free(group->sid);
-			/* unchain item and free */
+		/* unchain item and free */
 		mapping[MAPGROUPS] = group->next;
 		free(group);
 	}
@@ -4379,33 +4379,33 @@ struct MAPPING *ntfs_do_user_mapping(struct MAPLIST *firstitem)
 					uid = pwd->pw_uid;
 				else
 					ntfs_log_early_error("Invalid user \"%s\"\n",
-						item->uidstr);
+							item->uidstr);
 			}
 		}
-			/*
-			 * Records with no uid and no gid are inserted
-			 * to define the implicit mapping pattern
-			 */
+		/*
+		 * Records with no uid and no gid are inserted
+		 * to define the implicit mapping pattern
+		 */
 		if (uid
-		   || (!item->uidstr[0] && !item->gidstr[0])) {
+				|| (!item->uidstr[0] && !item->gidstr[0])) {
 			sid = encodesid(item->sidstr);
 			if (sid && ntfs_known_group_sid(sid)) {
 				ntfs_log_error("Bad user SID %s\n",
-					item->sidstr);
+						item->sidstr);
 				free(sid);
 				sid = (SID*)NULL;
 			}
 			if (sid && !item->uidstr[0] && !item->gidstr[0]
-			    && !ntfs_valid_pattern(sid)) {
+					&& !ntfs_valid_pattern(sid)) {
 				ntfs_log_error("Bad implicit SID pattern %s\n",
-					item->sidstr);
+						item->sidstr);
 				free(sid);
 				sid = (SID*)NULL;
-				}
+			}
 			if (sid) {
 				mapping =
-				    (struct MAPPING*)
-				    ntfs_malloc(sizeof(struct MAPPING));
+					(struct MAPPING*)
+					ntfs_malloc(sizeof(struct MAPPING));
 				if (mapping) {
 					mapping->sid = sid;
 					mapping->xid = uid;
@@ -4458,7 +4458,7 @@ struct MAPPING *ntfs_do_group_mapping(struct MAPLIST *firstitem)
 				|| !item->gidstr[0];
 			ok = (step == 1 ? !secondstep : secondstep);
 			if ((item->gidstr[0] >= '0')
-			     && (item->gidstr[0] <= '9'))
+					&& (item->gidstr[0] <= '9'))
 				gid = atoi(item->gidstr);
 			else {
 				gid = 0;
@@ -4468,7 +4468,7 @@ struct MAPPING *ntfs_do_group_mapping(struct MAPLIST *firstitem)
 						gid = grp->gr_gid;
 					else
 						ntfs_log_early_error("Invalid group \"%s\"\n",
-							item->gidstr);
+								item->gidstr);
 				}
 			}
 			/*
@@ -4476,26 +4476,26 @@ struct MAPPING *ntfs_do_group_mapping(struct MAPLIST *firstitem)
 			 * second step to define the implicit mapping pattern
 			 */
 			if (ok
-			    && (gid
-				 || (!item->uidstr[0] && !item->gidstr[0]))) {
+					&& (gid
+						|| (!item->uidstr[0] && !item->gidstr[0]))) {
 				if (sid)
 					free(sid);
 				sid = encodesid(item->sidstr);
 				if (sid && !item->uidstr[0] && !item->gidstr[0]
-				    && !ntfs_valid_pattern(sid)) {
+						&& !ntfs_valid_pattern(sid)) {
 					/* error already logged */
 					sid = (SID*)NULL;
-					}
+				}
 				if (sid) {
 					mapping = (struct MAPPING*)
-					    ntfs_malloc(sizeof(struct MAPPING));
+						ntfs_malloc(sizeof(struct MAPPING));
 					if (mapping) {
 						mapping->sid = sid;
 						mapping->xid = gid;
-					/* special groups point to themselves */
+						/* special groups point to themselves */
 						if (ntfs_known_group_sid(sid)) {
 							mapping->groups =
-							  (gid_t*)&mapping->xid;
+								(gid_t*)&mapping->xid;
 							mapping->grcnt = 1;
 						} else
 							mapping->grcnt = 0;

--- a/libntfs/attrib.c
+++ b/libntfs/attrib.c
@@ -68,21 +68,21 @@
 
 ntfschar AT_UNNAMED[] = { const_cpu_to_le16('\0') };
 ntfschar STREAM_SDS[] = { const_cpu_to_le16('$'),
-			const_cpu_to_le16('S'),
-			const_cpu_to_le16('D'),
-			const_cpu_to_le16('S'),
-			const_cpu_to_le16('\0') };
+	const_cpu_to_le16('S'),
+	const_cpu_to_le16('D'),
+	const_cpu_to_le16('S'),
+	const_cpu_to_le16('\0') };
 
 ntfschar TXF_DATA[] = { const_cpu_to_le16('$'),
-			const_cpu_to_le16('T'),
-			const_cpu_to_le16('X'),
-			const_cpu_to_le16('F'),
-			const_cpu_to_le16('_'),
-			const_cpu_to_le16('D'),
-			const_cpu_to_le16('A'),
-			const_cpu_to_le16('T'),
-			const_cpu_to_le16('A'),
-			const_cpu_to_le16('\0') };
+	const_cpu_to_le16('T'),
+	const_cpu_to_le16('X'),
+	const_cpu_to_le16('F'),
+	const_cpu_to_le16('_'),
+	const_cpu_to_le16('D'),
+	const_cpu_to_le16('A'),
+	const_cpu_to_le16('T'),
+	const_cpu_to_le16('A'),
+	const_cpu_to_le16('\0') };
 
 static int NAttrFlag(ntfs_attr *na, FILE_ATTR_FLAGS flag)
 {
@@ -97,7 +97,7 @@ static void NAttrSetFlag(ntfs_attr *na, FILE_ATTR_FLAGS flag)
 		na->ni->flags |= flag;
 	else
 		ntfs_log_trace("Denied setting flag %d for not unnamed data "
-			       "attribute\n", le32_to_cpu(flag));
+				"attribute\n", le32_to_cpu(flag));
 }
 
 static void NAttrClearFlag(ntfs_attr *na, FILE_ATTR_FLAGS flag)
@@ -107,13 +107,13 @@ static void NAttrClearFlag(ntfs_attr *na, FILE_ATTR_FLAGS flag)
 }
 
 #define GenNAttrIno(func_name, flag)					\
-int NAttr##func_name(ntfs_attr *na) { return NAttrFlag   (na, flag); } 	\
+int NAttr##func_name(ntfs_attr *na) { return NAttrFlag   (na, flag); }	\
 void NAttrSet##func_name(ntfs_attr *na)	 { NAttrSetFlag  (na, flag); }	\
 void NAttrClear##func_name(ntfs_attr *na){ NAttrClearFlag(na, flag); }
 
 GenNAttrIno(Compressed, FILE_ATTR_COMPRESSED)
-GenNAttrIno(Encrypted, 	FILE_ATTR_ENCRYPTED)
-GenNAttrIno(Sparse, 	FILE_ATTR_SPARSE_FILE)
+GenNAttrIno(Encrypted,	FILE_ATTR_ENCRYPTED)
+GenNAttrIno(Sparse,	FILE_ATTR_SPARSE_FILE)
 
 /**
  * ntfs_get_attribute_value_length - Find the length of an attribute
@@ -156,27 +156,27 @@ void ntfs_set_attribute_value_length(ATTR_RECORD *a, s64 length)
 BOOL ntfs_is_valid_attr_type(const ATTR_RECORD *a)
 {
 	switch (a->type) {
-	case AT_UNUSED:
-	case AT_STANDARD_INFORMATION:
-	case AT_ATTRIBUTE_LIST:
-	case AT_FILE_NAME:
-	case AT_OBJECT_ID:
-	case AT_SECURITY_DESCRIPTOR:
-	case AT_VOLUME_NAME:
-	case AT_VOLUME_INFORMATION:
-	case AT_DATA:
-	case AT_INDEX_ROOT:
-	case AT_INDEX_ALLOCATION:
-	case AT_BITMAP:
-	case AT_REPARSE_POINT:
-	case AT_EA_INFORMATION:
-	case AT_EA:
-	case AT_PROPERTY_SET:
-	case AT_LOGGED_UTILITY_STREAM:
-	case AT_FIRST_USER_DEFINED_ATTRIBUTE:
-	case AT_END:
-		if (a->length != 0)
-			return TRUE;
+		case AT_UNUSED:
+		case AT_STANDARD_INFORMATION:
+		case AT_ATTRIBUTE_LIST:
+		case AT_FILE_NAME:
+		case AT_OBJECT_ID:
+		case AT_SECURITY_DESCRIPTOR:
+		case AT_VOLUME_NAME:
+		case AT_VOLUME_INFORMATION:
+		case AT_DATA:
+		case AT_INDEX_ROOT:
+		case AT_INDEX_ALLOCATION:
+		case AT_BITMAP:
+		case AT_REPARSE_POINT:
+		case AT_EA_INFORMATION:
+		case AT_EA:
+		case AT_PROPERTY_SET:
+		case AT_LOGGED_UTILITY_STREAM:
+		case AT_FIRST_USER_DEFINED_ATTRIBUTE:
+		case AT_END:
+			if (a->length != 0)
+				return TRUE;
 	}
 
 	return FALSE;
@@ -212,7 +212,7 @@ s64 ntfs_get_attribute_value(const ntfs_volume *vol,
 	 */
 	if (a->type != AT_ATTRIBUTE_LIST && a->flags) {
 		ntfs_log_error("Non-zero (%04x) attribute flags. Cannot handle "
-			       "this yet.\n", le16_to_cpu(a->flags));
+				"this yet.\n", le16_to_cpu(a->flags));
 		errno = EOPNOTSUPP;
 		return 0;
 	}
@@ -284,11 +284,11 @@ s64 ntfs_get_attribute_value(const ntfs_volume *vol,
 			 */
 			intlth = (sle64_to_cpu(a->data_size) - total
 					+ vol->cluster_size - 1)
-					>> vol->cluster_size_bits;
+				>> vol->cluster_size_bits;
 			if (rl[i].length < intlth)
 				intlth = rl[i].length;
 			intbuf = (u8*)ntfs_malloc(intlth
-						<< vol->cluster_size_bits);
+					<< vol->cluster_size_bits);
 			if (!intbuf) {
 				free(rl);
 				return 0;
@@ -464,7 +464,7 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 	le16 cs;
 
 	ntfs_log_enter("Entering for inode %lld, attr 0x%x.\n",
-		       (unsigned long long)ni->mft_no, le32_to_cpu(type));
+			(unsigned long long)ni->mft_no, le32_to_cpu(type));
 
 	if (!ni || !ni->vol || !ni->mrec) {
 		errno = EINVAL;
@@ -479,7 +479,7 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 		/* A null char leads to a short name and unallocated bytes */
 		if (ntfs_ucsnlen(name, name_len) != name_len) {
 			ntfs_log_error("Null character in attribute name"
-				" of inode %lld\n",(long long)ni->mft_no);
+					" of inode %lld\n",(long long)ni->mft_no);
 			goto err_out;
 		}
 		name = ntfs_ucsndup(name, name_len);
@@ -505,10 +505,10 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 					+ le16_to_cpu(a->name_offset));
 			/* A null character leads to illegal memory access */
 			if (ntfs_ucsnlen(attr_name, a->name_length)
-						!= a->name_length) {
+					!= a->name_length) {
 				ntfs_log_error("Null character in attribute"
-					" name in inode %lld\n",
-					(long long)ni->mft_no);
+						" name in inode %lld\n",
+						(long long)ni->mft_no);
 				goto put_err_out;
 			}
 			name = ntfs_ucsndup(attr_name, a->name_length);
@@ -533,7 +533,7 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 		a->flags = const_cpu_to_le16(0);
 
 	if ((type == AT_DATA)
-	   && (a->non_resident ? !a->initialized_size : !a->value_length)) {
+			&& (a->non_resident ? !a->initialized_size : !a->value_length)) {
 		/*
 		 * Define/redefine the compression state if stream is
 		 * empty, based on the compression mark on parent
@@ -547,9 +547,9 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 		 */
 		a->flags &= ~ATTR_COMPRESSION_MASK;
 		if ((ni->flags & FILE_ATTR_COMPRESSED)
-		    && (ni->vol->major_ver >= 3)
-		    && NVolCompression(ni->vol)
-		    && (ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE))
+				&& (ni->vol->major_ver >= 3)
+				&& NVolCompression(ni->vol)
+				&& (ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE))
 			a->flags |= ATTR_IS_COMPRESSED;
 	}
 
@@ -557,8 +557,8 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 
 	/* a file may be sparse though its unnamed data is not (cf $UsnJrnl) */
 	if (na->type == AT_DATA && na->name == AT_UNNAMED &&
-	    (((a->flags & ATTR_IS_SPARSE)     && !NAttrSparse(na)) ||
-	     (!(a->flags & ATTR_IS_ENCRYPTED)  != !NAttrEncrypted(na)))) {
+			(((a->flags & ATTR_IS_SPARSE)     && !NAttrSparse(na)) ||
+			 (!(a->flags & ATTR_IS_ENCRYPTED)  != !NAttrEncrypted(na)))) {
 		errno = EIO;
 		ntfs_log_perror("Inode %lld has corrupt attribute flags "
 				"(0x%x <> 0x%x)",(unsigned long long)ni->mft_no,
@@ -568,8 +568,8 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 
 	if (a->non_resident) {
 		if (((a->flags & ATTR_COMPRESSION_MASK)
-			|| a->compression_unit)
-		    && (ni->vol->major_ver < 3)) {
+					|| a->compression_unit)
+				&& (ni->vol->major_ver < 3)) {
 			errno = EIO;
 			ntfs_log_perror("Compressed inode %lld not allowed"
 					" on NTFS %d.%d",
@@ -579,7 +579,7 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 			goto put_err_out;
 		}
 		if ((a->flags & ATTR_COMPRESSION_MASK)
-				 && !a->compression_unit) {
+				&& !a->compression_unit) {
 			errno = EIO;
 			ntfs_log_perror("Compressed inode %lld attr 0x%x has "
 					"no compression unit",
@@ -587,7 +587,7 @@ ntfs_attr *ntfs_attr_open(ntfs_inode *ni, const ATTR_TYPES type,
 			goto put_err_out;
 		}
 		if ((a->flags & ATTR_COMPRESSION_MASK)
-				 && (a->compression_unit
+				&& (a->compression_unit
 					!= STANDARD_COMPRESSION_UNIT)) {
 			errno = EIO;
 			ntfs_log_perror("Compressed inode %lld attr 0x%lx has "
@@ -641,7 +641,7 @@ void ntfs_attr_close(ntfs_attr *na)
 		free(na->rl);
 	/* Don't release if using an internal constant. */
 	if (na->name != AT_UNNAMED && na->name != NTFS_INDEX_I30
-				&& na->name != STREAM_SDS)
+			&& na->name != STREAM_SDS)
 		free(na->name);
 	free(na);
 }
@@ -661,7 +661,7 @@ int ntfs_attr_map_runlist(ntfs_attr *na, VCN vcn)
 	ntfs_attr_search_ctx *ctx;
 
 	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x, vcn 0x%llx.\n",
-		(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type), (long long)vcn);
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type), (long long)vcn);
 
 	lcn = ntfs_rl_vcn_to_lcn(na->rl, vcn);
 	if (lcn >= 0 || lcn == LCN_HOLE || lcn == LCN_ENOENT)
@@ -673,7 +673,7 @@ int ntfs_attr_map_runlist(ntfs_attr *na, VCN vcn)
 
 	/* Find the attribute in the mft record. */
 	if (!ntfs_attr_lookup(na->type, na->name, na->name_len, CASE_SENSITIVE,
-			vcn, NULL, 0, ctx)) {
+				vcn, NULL, 0, ctx)) {
 		runlist_element *rl;
 
 		/* Decode the runlist. */
@@ -730,14 +730,14 @@ static int ntfs_attr_map_partial_runlist(ntfs_attr *na, VCN vcn)
 		newrunlist = FALSE;
 		/* Find the attribute in the mft record. */
 		if (!ntfs_attr_lookup(na->type, na->name, na->name_len, CASE_SENSITIVE,
-				needed, NULL, 0, ctx)) {
+					needed, NULL, 0, ctx)) {
 
 			a = ctx->attr;
-				/* Decode and merge the runlist. */
+			/* Decode and merge the runlist. */
 			if (ntfs_rl_vcn_to_lcn(na->rl, needed)
-						== LCN_RL_NOT_MAPPED) {
+					== LCN_RL_NOT_MAPPED) {
 				rl = ntfs_mapping_pairs_decompress(na->ni->vol,
-					a, na->rl);
+						a, na->rl);
 				newrunlist = TRUE;
 			} else
 				rl = na->rl;
@@ -745,9 +745,9 @@ static int ntfs_attr_map_partial_runlist(ntfs_attr *na, VCN vcn)
 				na->rl = rl;
 				highest_vcn = sle64_to_cpu(a->highest_vcn);
 				if (highest_vcn < needed) {
-				/* corruption detection on unchanged runlists */
+					/* corruption detection on unchanged runlists */
 					if (newrunlist
-					    && ((highest_vcn + 1) < last_vcn)) {
+							&& ((highest_vcn + 1) < last_vcn)) {
 						ntfs_log_error("Corrupt attribute list\n");
 						rl = (runlist_element*)NULL;
 						errno = EIO;
@@ -763,18 +763,18 @@ static int ntfs_attr_map_partial_runlist(ntfs_attr *na, VCN vcn)
 		}
 	} while (rl && !done && (needed < last_vcn));
 	ntfs_attr_put_search_ctx(ctx);
-		/*
-		 * Make sure we reached the end, unless the last
-		 * runlist was modified earlier (using HOLES_DELAY
-		 * leads to have a visibility over attributes which
-		 * have not yet been fully updated)
-		 */
+	/*
+	 * Make sure we reached the end, unless the last
+	 * runlist was modified earlier (using HOLES_DELAY
+	 * leads to have a visibility over attributes which
+	 * have not yet been fully updated)
+	 */
 	if (done && newrunlist && (needed < last_vcn)) {
 		ntfs_log_error("End of runlist not reached\n");
 		rl = (runlist_element*)NULL;
 		errno = EIO;
 	}
-		/* mark fully mapped if we did so */
+	/* mark fully mapped if we did so */
 	if (rl && startseen)
 		NAttrSetFullyMapped(na);
 	return (rl ? 0 : -1);
@@ -804,9 +804,9 @@ int ntfs_attr_map_whole_runlist(ntfs_attr *na)
 	int not_mapped;
 
 	ntfs_log_enter("Entering for inode %llu, attr 0x%x.\n",
-		       (unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
 
-		/* avoid multiple full runlist mappings */
+	/* avoid multiple full runlist mappings */
 	if (NAttrFullyMapped(na)) {
 		ret = 0;
 		goto out;
@@ -826,7 +826,7 @@ int ntfs_attr_map_whole_runlist(ntfs_attr *na)
 			not_mapped = 1;
 
 		if (ntfs_attr_lookup(na->type, na->name, na->name_len,
-				CASE_SENSITIVE, next_vcn, NULL, 0, ctx))
+					CASE_SENSITIVE, next_vcn, NULL, 0, ctx))
 			break;
 
 		a = ctx->attr;
@@ -834,7 +834,7 @@ int ntfs_attr_map_whole_runlist(ntfs_attr *na)
 		if (not_mapped) {
 			/* Decode the runlist. */
 			rl = ntfs_mapping_pairs_decompress(na->ni->vol,
-								a, na->rl);
+					a, na->rl);
 			if (!rl)
 				goto err_out;
 			na->rl = rl;
@@ -842,16 +842,16 @@ int ntfs_attr_map_whole_runlist(ntfs_attr *na)
 
 		/* Are we in the first extent? */
 		if (!next_vcn) {
-			 if (a->lowest_vcn) {
-				 errno = EIO;
-				 ntfs_log_perror("First extent of inode %llu "
-					"attribute has non-zero lowest_vcn",
-					(unsigned long long)na->ni->mft_no);
-				 goto err_out;
+			if (a->lowest_vcn) {
+				errno = EIO;
+				ntfs_log_perror("First extent of inode %llu "
+						"attribute has non-zero lowest_vcn",
+						(unsigned long long)na->ni->mft_no);
+				goto err_out;
 			}
 			/* Get the last vcn in the attribute. */
 			last_vcn = sle64_to_cpu(a->allocated_size) >>
-					vol->cluster_size_bits;
+				vol->cluster_size_bits;
 		}
 
 		/* Get the lowest vcn for the next extent. */
@@ -876,12 +876,12 @@ int ntfs_attr_map_whole_runlist(ntfs_attr *na)
 		ntfs_log_perror("Couldn't find attribute for runlist mapping");
 		goto err_out;
 	}
-		/*
-		 * Cannot check highest_vcn when the last runlist has
-		 * been modified earlier, as runlists and sizes may be
-		 * updated without highest_vcn being in sync, when
-		 * HOLES_DELAY is used
-		 */
+	/*
+	 * Cannot check highest_vcn when the last runlist has
+	 * been modified earlier, as runlists and sizes may be
+	 * updated without highest_vcn being in sync, when
+	 * HOLES_DELAY is used
+	 */
 	if (not_mapped && highest_vcn && highest_vcn != last_vcn - 1) {
 		errno = EIO;
 		ntfs_log_perror("Failed to load full runlist: inode: %llu "
@@ -931,7 +931,7 @@ LCN ntfs_attr_vcn_to_lcn(ntfs_attr *na, const VCN vcn)
 		return (LCN)LCN_EINVAL;
 
 	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x.\n", (unsigned long
-			long)na->ni->mft_no, le32_to_cpu(na->type));
+				long)na->ni->mft_no, le32_to_cpu(na->type));
 retry:
 	/* Convert vcn to lcn. If that fails map the runlist and retry once. */
 	lcn = ntfs_rl_vcn_to_lcn(na->rl, vcn);
@@ -983,8 +983,8 @@ runlist_element *ntfs_attr_find_vcn(ntfs_attr *na, const VCN vcn)
 	}
 
 	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x, vcn %llx\n",
-		       (unsigned long long)na->ni->mft_no, le32_to_cpu(na->type),
-		       (long long)vcn);
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type),
+			(long long)vcn);
 retry:
 	rl = na->rl;
 	if (!rl)
@@ -1000,17 +1000,17 @@ retry:
 		rl++;
 	}
 	switch (rl->lcn) {
-	case (LCN)LCN_RL_NOT_MAPPED:
-		goto map_rl;
-	case (LCN)LCN_ENOENT:
-		errno = ENOENT;
-		break;
-	case (LCN)LCN_EINVAL:
-		errno = EINVAL;
-		break;
-	default:
-		errno = EIO;
-		break;
+		case (LCN)LCN_RL_NOT_MAPPED:
+			goto map_rl;
+		case (LCN)LCN_ENOENT:
+			errno = ENOENT;
+			break;
+		case (LCN)LCN_EINVAL:
+			errno = EINVAL;
+			break;
+		default:
+			errno = EIO;
+			break;
 	}
 	return NULL;
 map_rl:
@@ -1044,10 +1044,10 @@ static s64 ntfs_attr_pread_i(ntfs_attr *na, const s64 pos, s64 count, void *b)
 
 	if ((na->data_flags & ATTR_COMPRESSION_MASK) && NAttrNonResident(na)) {
 		if ((na->data_flags & ATTR_COMPRESSION_MASK)
-		    == ATTR_IS_COMPRESSED)
+				== ATTR_IS_COMPRESSED)
 			return ntfs_compressed_attr_pread(na, pos, count, b);
 		else {
-				/* compression mode not supported */
+			/* compression mode not supported */
 			errno = EOPNOTSUPP;
 			return -1;
 		}
@@ -1065,16 +1065,16 @@ static s64 ntfs_attr_pread_i(ntfs_attr *na, const s64 pos, s64 count, void *b)
 
 	if (!count)
 		return 0;
-		/*
-		 * Truncate reads beyond end of attribute,
-		 * but round to next 512 byte boundary for encrypted
-		 * attributes with efs_raw mount option
-		 */
+	/*
+	 * Truncate reads beyond end of attribute,
+	 * but round to next 512 byte boundary for encrypted
+	 * attributes with efs_raw mount option
+	 */
 	max_read = na->data_size;
 	max_init = na->initialized_size;
 	if (na->ni->vol->efs_raw
-	    && (na->data_flags & ATTR_IS_ENCRYPTED)
-	    && NAttrNonResident(na)) {
+			&& (na->data_flags & ATTR_IS_ENCRYPTED)
+			&& NAttrNonResident(na)) {
 		if (na->data_size != na->initialized_size) {
 			ntfs_log_error("uninitialized encrypted file not supported\n");
 			errno = EINVAL;
@@ -1096,7 +1096,7 @@ static s64 ntfs_attr_pread_i(ntfs_attr *na, const s64 pos, s64 count, void *b)
 		if (!ctx)
 			return -1;
 		if (ntfs_attr_lookup(na->type, na->name, na->name_len, 0,
-				0, NULL, 0, ctx)) {
+					0, NULL, 0, ctx)) {
 res_err_out:
 			ntfs_attr_put_search_ctx(ctx);
 			return -1;
@@ -1124,12 +1124,12 @@ res_err_out:
 		count -= total2;
 		memset((u8*)b + count, 0, total2);
 	}
-		/*
-		 * for encrypted non-resident attributes with efs_raw set
-		 * the last two bytes aren't read from disk but contain
-		 * the number of padding bytes so original size can be
-		 * restored
-		 */
+	/*
+	 * for encrypted non-resident attributes with efs_raw set
+	 * the last two bytes aren't read from disk but contain
+	 * the number of padding bytes so original size can be
+	 * restored
+	 */
 	if (na->ni->vol->efs_raw &&
 			(na->data_flags & ATTR_IS_ENCRYPTED) &&
 			((pos + count) > max_init-2)) {
@@ -1199,7 +1199,7 @@ res_err_out:
 			}
 			/* It is a hole, just zero the matching @b range. */
 			to_read = min(count, (rl->length <<
-					vol->cluster_size_bits) - ofs);
+						vol->cluster_size_bits) - ofs);
 			memset(b, 0, to_read);
 			/* Update progress counters. */
 			total += to_read;
@@ -1213,7 +1213,7 @@ res_err_out:
 retry:
 		ntfs_log_trace("Reading %lld bytes from vcn %lld, lcn %lld, ofs"
 				" %lld.\n", (long long)to_read, (long long)rl->vcn,
-			       (long long )rl->lcn, (long long)ofs);
+				(long long )rl->lcn, (long long)ofs);
 		br = ntfs_pread(vol->dev, (rl->lcn << vol->cluster_size_bits) +
 				ofs, to_read, b);
 		/* If everything ok, update progress counters and continue. */
@@ -1275,8 +1275,8 @@ s64 ntfs_attr_pread(ntfs_attr *na, const s64 pos, s64 count, void *b)
 	}
 
 	ntfs_log_enter("Entering for inode %lld attr 0x%x pos %lld count "
-		       "%lld\n", (unsigned long long)na->ni->mft_no,
-		       le32_to_cpu(na->type), (long long)pos, (long long)count);
+			"%lld\n", (unsigned long long)na->ni->mft_no,
+			le32_to_cpu(na->type), (long long)pos, (long long)count);
 
 	ret = ntfs_attr_pread_i(na, pos, count, b);
 
@@ -1294,7 +1294,7 @@ static int ntfs_attr_fill_zero(ntfs_attr *na, s64 pos, s64 count)
 	int ret = -1;
 
 	ntfs_log_trace("pos %lld, count %lld\n", (long long)pos,
-		       (long long)count);
+			(long long)count);
 
 	if (!na || pos < 0 || count < 0) {
 		errno = EINVAL;
@@ -1309,27 +1309,27 @@ static int ntfs_attr_fill_zero(ntfs_attr *na, s64 pos, s64 count)
 	ofsi = 0;
 	vol = na->ni->vol;
 	while (pos < end) {
-		while (rli->length && (ofsi + (rli->length <<
-	                        vol->cluster_size_bits) <= pos)) {
-	                ofsi += (rli->length << vol->cluster_size_bits);
+		while (rli->length &&
+				(ofsi + (rli->length << vol->cluster_size_bits) <= pos)) {
+			ofsi += (rli->length << vol->cluster_size_bits);
 			rli++;
 		}
 		size = min(end - pos, NTFS_BUF_SIZE);
-			/*
-			 * If the zeroed block is fully within a hole,
-			 * we need not write anything, so advance as far
-			 * as possible within the hole.
-			 */
+		/*
+		 * If the zeroed block is fully within a hole,
+		 * we need not write anything, so advance as far
+		 * as possible within the hole.
+		 */
 		if ((rli->lcn == (LCN)LCN_HOLE)
-		    && (ofsi <= pos)
-		    && (ofsi + (rli->length << vol->cluster_size_bits)
-				>= (pos + size))) {
+				&& (ofsi <= pos)
+				&& (ofsi + (rli->length << vol->cluster_size_bits)
+					>= (pos + size))) {
 			size = min(end - pos, ofsi - pos
-				+ (rli->length << vol->cluster_size_bits));
+					+ (rli->length << vol->cluster_size_bits));
 			pos += size;
 		} else {
 			written = ntfs_rl_pwrite(vol, rli, ofsi, pos,
-							size, buf);
+					size, buf);
 			if (written <= 0) {
 				ntfs_log_perror("Failed to zero space");
 				goto err_free;
@@ -1346,7 +1346,7 @@ err_out:
 }
 
 static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
-			       runlist_element **rl, VCN *update_from)
+		runlist_element **rl, VCN *update_from)
 {
 	s64 to_write;
 	s64 need;
@@ -1373,8 +1373,8 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 	from_vcn = (*rl)->vcn + (*ofs >> vol->cluster_size_bits);
 
 	ntfs_log_trace("count: %lld, cur_vcn: %lld, from: %lld, to: %lld, ofs: "
-		       "%lld\n", (long long)count, (long long)cur_vcn,
-		       (long long)from_vcn, (long long)to_write, (long long)*ofs);
+			"%lld\n", (long long)count, (long long)cur_vcn,
+			(long long)from_vcn, (long long)to_write, (long long)*ofs);
 
 	/* Map the runlist to be able to update mapping pairs later. */
 #if PARTIAL_RUNLIST_UPDATING
@@ -1385,8 +1385,8 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 		/* make sure the run ahead of hole is mapped */
 		if ((*rl)->lcn == LCN_HOLE) {
 			if (ntfs_attr_map_partial_runlist(na,
-				(cur_vcn ? cur_vcn - 1 : cur_vcn)))
-					goto err_out;
+						(cur_vcn ? cur_vcn - 1 : cur_vcn)))
+				goto err_out;
 		}
 	}
 #else
@@ -1398,7 +1398,7 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 	*rl = ntfs_attr_find_vcn(na, cur_vcn);
 	if (!*rl) {
 		ntfs_log_error("Failed to find run after mapping runlist. "
-			       "Please report to %s.\n", NTFS_DEV_LIST);
+				"Please report to %s.\n", NTFS_DEV_LIST);
 		errno = EIO;
 		goto err_out;
 	}
@@ -1408,12 +1408,12 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 	while (rlc->vcn) {
 		rlc--;
 		if (rlc->lcn >= 0) {
-				/*
-				 * avoid fragmenting a compressed file
-				 * Windows does not do that, and that may
-				 * not be desirable for files which can
-				 * be updated
-				 */
+			/*
+			 * avoid fragmenting a compressed file
+			 * Windows does not do that, and that may
+			 * not be desirable for files which can
+			 * be updated
+			 */
 			if (na->data_flags & ATTR_COMPRESSION_MASK)
 				lcn_seek_from = rlc->lcn + rlc->length;
 			else
@@ -1436,9 +1436,9 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 	}
 
 	need = ((*ofs + to_write - 1) >> vol->cluster_size_bits)
-			 + 1 + (*rl)->vcn - from_vcn;
+		+ 1 + (*rl)->vcn - from_vcn;
 	if ((na->data_flags & ATTR_COMPRESSION_MASK)
-	    && (need < na->compression_block_clusters)) {
+			&& (need < na->compression_block_clusters)) {
 		/*
 		 * for a compressed file, be sure to allocate the full
 		 * compression block, as we may need space to decompress
@@ -1463,10 +1463,10 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 			goto err_out;
 		}
 		rlc = ntfs_cluster_alloc(vol, alloc_vcn, need,
-				 lcn_seek_from, DATA_ZONE);
+				lcn_seek_from, DATA_ZONE);
 	} else
 		rlc = ntfs_cluster_alloc(vol, from_vcn, need,
-				 lcn_seek_from, DATA_ZONE);
+				lcn_seek_from, DATA_ZONE);
 	if (!rlc)
 		goto err_out;
 	if (na->data_flags & (ATTR_COMPRESSION_MASK | ATTR_IS_SPARSE))
@@ -1474,10 +1474,10 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 
 	*rl = ntfs_runlists_merge(na->rl, rlc);
 	NAttrSetRunlistDirty(na);
-		/*
-		 * For a compressed attribute, we must be sure there are two
-		 * available entries, so reserve them before it gets too late.
-		 */
+	/*
+	 * For a compressed attribute, we must be sure there are two
+	 * available entries, so reserve them before it gets too late.
+	 */
 	if (*rl && (na->data_flags & ATTR_COMPRESSION_MASK)) {
 		runlist_element *oldrl = na->rl;
 		na->rl = *rl;
@@ -1505,7 +1505,7 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 		 * we missed it during instantiating of the hole.
 		 */
 		ntfs_log_error("Failed to find run after hole instantiation. "
-			       "Please report to %s.\n", NTFS_DEV_LIST);
+				"Please report to %s.\n", NTFS_DEV_LIST);
 		errno = EIO;
 		goto err_out;
 	}
@@ -1515,7 +1515,7 @@ static int ntfs_attr_fill_hole(ntfs_attr *na, s64 count, s64 *ofs,
 	/* Now LCN shoudn't be less than 0. */
 	if ((*rl)->lcn < 0) {
 		ntfs_log_error("BUG! LCN is lesser than 0. "
-			       "Please report to the %s.\n", NTFS_DEV_LIST);
+				"Please report to the %s.\n", NTFS_DEV_LIST);
 		errno = EIO;
 		goto err_out;
 	}
@@ -1562,7 +1562,7 @@ static int stuff_hole(ntfs_attr *na, const s64 pos);
  */
 
 static int split_compressed_hole(ntfs_attr *na, runlist_element **prl,
-    		s64 pos, s64 count, VCN *update_from)
+		s64 pos, s64 count, VCN *update_from)
 {
 	int compressed_part;
 	int cluster_size_bits = na->ni->vol->cluster_size_bits;
@@ -1570,7 +1570,7 @@ static int split_compressed_hole(ntfs_attr *na, runlist_element **prl,
 
 	compressed_part
 		= na->compression_block_clusters;
-		/* reserve entries in runlist if we have to split */
+	/* reserve entries in runlist if we have to split */
 	if (rl->length > na->compression_block_clusters) {
 		*prl = ntfs_rl_extend(na,*prl,2);
 		if (!*prl) {
@@ -1587,16 +1587,16 @@ static int split_compressed_hole(ntfs_attr *na, runlist_element **prl,
 		 */
 		int beginwrite = (pos >> cluster_size_bits) - rl->vcn;
 		s32 endblock = (((pos + count - 1) >> cluster_size_bits)
-			| (na->compression_block_clusters - 1)) + 1 - rl->vcn;
+				| (na->compression_block_clusters - 1)) + 1 - rl->vcn;
 
 		compressed_part = na->compression_block_clusters
 			- (rl->length & (na->compression_block_clusters - 1));
 		if ((beginwrite + compressed_part) >= na->compression_block_clusters)
 			compressed_part = na->compression_block_clusters;
-			/*
-			 * if the run ends beyond end of needed block
-			 * we have to split the run
-			 */
+		/*
+		 * if the run ends beyond end of needed block
+		 * we have to split the run
+		 */
 		if (endblock < rl[0].length) {
 			runlist_element *xrl;
 			int n;
@@ -1609,7 +1609,7 @@ static int split_compressed_hole(ntfs_attr *na, runlist_element **prl,
 			 */
 			if (endblock > na->compression_block_clusters) {
 				if (na->unused_runs < 2) {
-ntfs_log_error("No free run, case 1\n");
+					ntfs_log_error("No free run, case 1\n");
 				}
 				na->unused_runs -= 2;
 				xrl = rl;
@@ -1638,7 +1638,7 @@ ntfs_log_error("No free run, case 1\n");
 				 * first one
 				 */
 				if (!na->unused_runs) {
-ntfs_log_error("No free run, case 2\n");
+					ntfs_log_error("No free run, case 2\n");
 				}
 				na->unused_runs--;
 				xrl = rl;
@@ -1659,7 +1659,7 @@ ntfs_log_error("No free run, case 2\n");
 					rl[1].lcn = LCN_HOLE;
 				} else {
 					/* we will write into the second part of hole */
-// impossible ?
+					// impossible ?
 					rl[1].length = rl[0].length - endblock;
 					rl[0].length = endblock;
 					rl[1].vcn = rl[0].vcn + rl[0].length;
@@ -1677,7 +1677,7 @@ ntfs_log_error("No free run, case 2\n");
 				 * last one
 				 */
 				if (!na->unused_runs) {
-ntfs_log_error("No free run, case 4\n");
+					ntfs_log_error("No free run, case 4\n");
 				}
 				na->unused_runs--;
 				xrl = rl;
@@ -1703,9 +1703,9 @@ ntfs_log_error("No free run, case 4\n");
 				rl = ++(*prl);
 			}
 		}
-	NAttrSetRunlistDirty(na);
-	if ((*update_from == -1) || ((*prl)->vcn < *update_from))
-		*update_from = (*prl)->vcn;
+		NAttrSetRunlistDirty(na);
+		if ((*update_from == -1) || ((*prl)->vcn < *update_from))
+			*update_from = (*prl)->vcn;
 	}
 	return (compressed_part);
 }
@@ -1724,7 +1724,7 @@ ntfs_log_error("No free run, case 4\n");
  */
 
 static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
-    		s64 pos, s64 count, VCN *update_from, BOOL wasnonresident)
+		s64 pos, s64 count, VCN *update_from, BOOL wasnonresident)
 {
 	int compressed_part = 0;
 	int cluster_size_bits = na->ni->vol->cluster_size_bits;
@@ -1736,7 +1736,7 @@ static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
 	BOOL undecided;
 	BOOL nothole;
 
-		/* check whether the compression block is fully allocated */
+	/* check whether the compression block is fully allocated */
 	endblock = (((pos + count - 1) >> cluster_size_bits) | (na->compression_block_clusters - 1)) + 1 - rl->vcn;
 	allocated = 0;
 	zrl = rl;
@@ -1756,23 +1756,23 @@ static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
 #if PARTIAL_RUNLIST_UPDATING
 		VCN prevblock;
 #endif
-			/*
-			 * Map the runlist, unless it has not been created.
-			 * If appending data, a partial mapping from the
-			 * end of previous block will do.
-			 */
+		/*
+		 * Map the runlist, unless it has not been created.
+		 * If appending data, a partial mapping from the
+		 * end of previous block will do.
+		 */
 		irl = *prl - na->rl;
 #if PARTIAL_RUNLIST_UPDATING
 		prevblock = pos >> cluster_size_bits;
 		if (prevblock)
 			prevblock--;
 		if (!NAttrBeingNonResident(na)
-		    && (NAttrDataAppending(na)
-			? ntfs_attr_map_partial_runlist(na,prevblock)
-			: ntfs_attr_map_whole_runlist(na))) {
+			&& (NAttrDataAppending(na)
+				? ntfs_attr_map_partial_runlist(na,prevblock)
+				: ntfs_attr_map_whole_runlist(na))) {
 #else
 		if (!NAttrBeingNonResident(na)
-			&& ntfs_attr_map_whole_runlist(na)) {
+				&& ntfs_attr_map_whole_runlist(na)) {
 #endif
 			rl = (runlist_element*)NULL;
 		} else {
@@ -1790,10 +1790,10 @@ static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
 				*prl = zrl;
 			}
 			if (!(*prl)->length) {
-				 ntfs_log_error("Mapped run not found,"
-					" inode %lld lcn 0x%llx\n",
-					(long long)na->ni->mft_no,
-					(long long)olcn);
+				ntfs_log_error("Mapped run not found,"
+						" inode %lld lcn 0x%llx\n",
+						(long long)na->ni->mft_no,
+						(long long)olcn);
 				rl = (runlist_element*)NULL;
 			} else {
 				rl = ntfs_rl_extend(na,*prl,2);
@@ -1806,29 +1806,29 @@ static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
 			zrl = rl;
 			irl = 0;
 			while (zrl->length && (zrl->lcn >= 0)
-			    && (allocated < endblock)) {
+					&& (allocated < endblock)) {
 				allocated += zrl->length;
 				zrl++;
 				irl++;
 			}
 		}
 	}
-		/*
-		 * compression block not fully allocated and followed
-		 * by a hole : we must allocate in the hole.
-		 */
+	/*
+	 * compression block not fully allocated and followed
+	 * by a hole : we must allocate in the hole.
+	 */
 	if (rl && (allocated < endblock) && (zrl->lcn == LCN_HOLE)) {
 		s64 xofs;
 
-			/*
-			 * split the hole if not fully needed
-			 */
+		/*
+		 * split the hole if not fully needed
+		 */
 		if ((allocated + zrl->length) > endblock) {
 			runlist_element *xrl;
 
 			*prl = ntfs_rl_extend(na,*prl,1);
 			if (*prl) {
-					/* beware : rl was reallocated */
+				/* beware : rl was reallocated */
 				rl = *prl;
 				zrl = &rl[irl];
 				na->unused_runs = 0;
@@ -1846,14 +1846,14 @@ static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
 		if (*prl) {
 			if (wasnonresident)
 				compressed_part = na->compression_block_clusters
-				   - zrl->length;
+					- zrl->length;
 			xofs = 0;
 			if (ntfs_attr_fill_hole(na,
-				    zrl->length << cluster_size_bits,
-				    &xofs, &zrl, update_from))
-					compressed_part = -1;
+						zrl->length << cluster_size_bits,
+						&xofs, &zrl, update_from))
+				compressed_part = -1;
 			else {
-			/* go back to initial cluster, now reallocated */
+				/* go back to initial cluster, now reallocated */
 				while (zrl->vcn > (pos >> cluster_size_bits))
 					zrl--;
 				*prl = zrl;
@@ -1870,7 +1870,7 @@ static int borrow_from_hole(ntfs_attr *na, runlist_element **prl,
 }
 
 static int ntfs_attr_truncate_i(ntfs_attr *na, const s64 newsize,
-				hole_type holes);
+		hole_type holes);
 
 /**
  * ntfs_attr_pwrite - positioned write to an ntfs attribute
@@ -1892,7 +1892,7 @@ static int ntfs_attr_truncate_i(ntfs_attr *na, const s64 newsize,
  * invalid arguments.
  */
 static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
-								const void *b)
+		const void *b)
 {
 	s64 written, to_write, ofs, old_initialized_size, old_data_size;
 	s64 total = 0;
@@ -1913,7 +1913,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 
 	vol = na->ni->vol;
 	compressed = (na->data_flags & ATTR_COMPRESSION_MASK)
-			 != const_cpu_to_le16(0);
+		!= const_cpu_to_le16(0);
 	na->unused_runs = 0; /* prepare overflow checks */
 	/*
 	 * Encrypted attributes are only supported in raw mode.  We return
@@ -1921,29 +1921,29 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 	 * Moreover a file cannot be both encrypted and compressed.
 	 */
 	if ((na->data_flags & ATTR_IS_ENCRYPTED)
-	   && (compressed || !vol->efs_raw)) {
+			&& (compressed || !vol->efs_raw)) {
 		errno = EACCES;
 		goto errno_set;
 	}
-		/*
-		 * Fill the gap, when writing beyond the end of a compressed
-		 * file. This will make recursive calls
-		 */
+	/*
+	 * Fill the gap, when writing beyond the end of a compressed
+	 * file. This will make recursive calls
+	 */
 	if (compressed
-	    && (na->type == AT_DATA)
-	    && (pos > na->initialized_size)
-	    && stuff_hole(na,pos))
+			&& (na->type == AT_DATA)
+			&& (pos > na->initialized_size)
+			&& stuff_hole(na,pos))
 		goto errno_set;
 	/* If this is a compressed attribute it needs special treatment. */
 	wasnonresident = NAttrNonResident(na) != 0;
-		/*
-		 * Compression is restricted to data streams and
-		 * only ATTR_IS_COMPRESSED compression mode is supported.
-                 */
+	/*
+	 * Compression is restricted to data streams and
+	 * only ATTR_IS_COMPRESSED compression mode is supported.
+	 */
 	if (compressed
-	    && ((na->type != AT_DATA)
-		|| ((na->data_flags & ATTR_COMPRESSION_MASK)
-			 != ATTR_IS_COMPRESSED))) {
+			&& ((na->type != AT_DATA)
+				|| ((na->data_flags & ATTR_COMPRESSION_MASK)
+					!= ATTR_IS_COMPRESSED))) {
 		errno = EOPNOTSUPP;
 		goto errno_set;
 	}
@@ -1956,7 +1956,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 	old_data_size = na->data_size;
 	/* identify whether this is appending to a non resident data attribute */
 	if ((na->type == AT_DATA) && (pos >= old_data_size)
-	    && NAttrNonResident(na))
+			&& NAttrNonResident(na))
 		NAttrSetDataAppending(na);
 	if (pos + count > na->data_size) {
 #if PARTIAL_RUNLIST_UPDATING
@@ -1970,7 +1970,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		 */
 		if (ntfs_attr_truncate_i(na, pos + count,
 					(NAttrDataAppending(na) ?
-						HOLES_DELAY : HOLES_OK))) {
+					 HOLES_DELAY : HOLES_OK))) {
 			ntfs_log_perror("Failed to enlarge attribute");
 			goto errno_set;
 		}
@@ -1987,19 +1987,19 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 			goto errno_set;
 		}
 #endif
-			/* resizing may change the compression mode */
+		/* resizing may change the compression mode */
 		compressed = (na->data_flags & ATTR_COMPRESSION_MASK)
-				!= const_cpu_to_le16(0);
+			!= const_cpu_to_le16(0);
 		need_to.undo_data_size = 1;
 	}
-		/*
-		 * For compressed data, a single full block was allocated
-		 * to deal with compression, possibly in a previous call.
-		 * We are not able to process several blocks because
-		 * some clusters are freed after compression and
-		 * new allocations have to be done before proceeding,
-		 * so truncate the requested count if needed (big buffers).
-		 */
+	/*
+	 * For compressed data, a single full block was allocated
+	 * to deal with compression, possibly in a previous call.
+	 * We are not able to process several blocks because
+	 * some clusters are freed after compression and
+	 * new allocations have to be done before proceeding,
+	 * so truncate the requested count if needed (big buffers).
+	 */
 	if (compressed) {
 		fullcount = (pos | (na->compression_block_size - 1)) + 1 - pos;
 		if (count > fullcount)
@@ -2014,7 +2014,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		if (!ctx)
 			goto err_out;
 		if (ntfs_attr_lookup(na->type, na->name, na->name_len, 0,
-				0, NULL, 0, ctx)) {
+					0, NULL, 0, ctx)) {
 			ntfs_log_perror("%s: lookup failed", __FUNCTION__);
 			goto err_out;
 		}
@@ -2028,7 +2028,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		}
 		memcpy(val + pos, b, count);
 		if (ntfs_mft_record_write(vol, ctx->ntfs_ino->mft_no,
-				ctx->mrec)) {
+					ctx->mrec)) {
 			/*
 			 * NOTE: We are in a bad state at this moment. We have
 			 * dirtied the mft record but we failed to commit it to
@@ -2062,7 +2062,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 			VCN block_begin;
 
 			if (NAttrDataAppending(na)
-			    || (pos < na->initialized_size))
+					|| (pos < na->initialized_size))
 				block_begin = pos >> vol->cluster_size_bits;
 			else
 				block_begin = na->initialized_size >> vol->cluster_size_bits;
@@ -2077,8 +2077,8 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 				update_from = block_begin;
 		}
 #else
-			if (ntfs_attr_map_whole_runlist(na))
-				goto err_out;
+		if (ntfs_attr_map_whole_runlist(na))
+			goto err_out;
 #endif
 		/*
 		 * For a compressed attribute, we must be sure there is an
@@ -2097,7 +2097,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		if (!ctx)
 			goto err_out;
 		if (ntfs_attr_lookup(na->type, na->name, na->name_len, 0,
-				0, NULL, 0, ctx))
+					0, NULL, 0, ctx))
 			goto err_out;
 
 		/* If write starts beyond initialized_size, zero the gap. */
@@ -2113,13 +2113,13 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 			ctx->attr->data_size = ctx->attr->initialized_size;
 		}
 		if (ntfs_mft_record_write(vol, ctx->ntfs_ino->mft_no,
-				ctx->mrec)) {
+					ctx->mrec)) {
 			/*
 			 * Undo the change in the in-memory copy and send it
 			 * back for writing.
 			 */
 			ctx->attr->initialized_size =
-					cpu_to_sle64(old_initialized_size);
+				cpu_to_sle64(old_initialized_size);
 			ntfs_mft_record_write(vol, ctx->ntfs_ino->mft_no,
 					ctx->mrec);
 			goto err_out;
@@ -2127,8 +2127,8 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		na->initialized_size = pos + count;
 #if CACHE_NIDATA_SIZE
 		if (na->ni->mrec->flags & MFT_RECORD_IS_DIRECTORY
-		    ? na->type == AT_INDEX_ROOT && na->name == NTFS_INDEX_I30
-		    : na->type == AT_DATA && na->name == AT_UNNAMED) {
+				? na->type == AT_INDEX_ROOT && na->name == NTFS_INDEX_I30
+				: na->type == AT_DATA && na->name == AT_UNNAMED) {
 			na->ni->data_size = na->data_size;
 			if ((compressed || NAttrSparse(na))
 					&& NAttrNonResident(na))
@@ -2162,25 +2162,25 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		}
 		goto err_out;
 	}
-		/*
-		 * Determine if there is compressed data in the current
-		 * compression block (when appending to an existing file).
-		 * If so, decompression will be needed, and the full block
-		 * must be allocated to be identified as uncompressed.
-		 * This comes in two variants, depending on whether
-		 * compression has saved at least one cluster.
-		 * The compressed size can never be over full size by
-		 * more than 485 (maximum for 15 compression blocks
-		 * compressed to 4098 and the last 3640 bytes compressed
-		 * to 3640 + 3640/8 = 4095, with 15*2 + 4095 - 3640 = 485)
-		 * This is less than the smallest cluster, so the hole is
-		 * is never beyond the cluster next to the position of
-		 * the first uncompressed byte to write.
-		 */
+	/*
+	 * Determine if there is compressed data in the current
+	 * compression block (when appending to an existing file).
+	 * If so, decompression will be needed, and the full block
+	 * must be allocated to be identified as uncompressed.
+	 * This comes in two variants, depending on whether
+	 * compression has saved at least one cluster.
+	 * The compressed size can never be over full size by
+	 * more than 485 (maximum for 15 compression blocks
+	 * compressed to 4098 and the last 3640 bytes compressed
+	 * to 3640 + 3640/8 = 4095, with 15*2 + 4095 - 3640 = 485)
+	 * This is less than the smallest cluster, so the hole is
+	 * is never beyond the cluster next to the position of
+	 * the first uncompressed byte to write.
+	 */
 	compressed_part = 0;
 	if (compressed) {
 		if ((rl->lcn == (LCN)LCN_HOLE)
-		    && wasnonresident) {
+				&& wasnonresident) {
 			if (rl->length < na->compression_block_clusters)
 				/*
 				 * the needed block is in a hole smaller
@@ -2189,7 +2189,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 				 */
 				compressed_part
 					= na->compression_block_clusters
-					   - rl->length;
+					- rl->length;
 			else {
 				/*
 				 * the needed block is in a hole bigger
@@ -2197,7 +2197,7 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 				 * split the hole and use it partially
 				 */
 				compressed_part = split_compressed_hole(na,
-					&rl, pos, count, &update_from);
+						&rl, pos, count, &update_from);
 			}
 		} else {
 			if (rl->lcn >= 0) {
@@ -2207,17 +2207,17 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 				 * allocated. Borrow from hole if needed
 				 */
 				compressed_part = borrow_from_hole(na,
-					&rl, pos, count, &update_from,
-					wasnonresident);
+						&rl, pos, count, &update_from,
+						wasnonresident);
 			}
 		}
 
 		if (compressed_part < 0)
 			goto err_out;
 
-			/* just making non-resident, so not yet compressed */
+		/* just making non-resident, so not yet compressed */
 		if (NAttrBeingNonResident(na)
-		    && (compressed_part < na->compression_block_clusters))
+				&& (compressed_part < na->compression_block_clusters))
 			compressed_part = 0;
 	}
 	ofs = pos - (rl->vcn << vol->cluster_size_bits);
@@ -2256,12 +2256,12 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 				goto rl_err_out;
 			}
 			if (ntfs_attr_fill_hole(na, fullcount, &ofs, &rl,
-					 &update_from))
+						&update_from))
 				goto err_out;
 		}
 		if (compressed) {
 			while (rl->length
-			    && (ofs >= (rl->length << vol->cluster_size_bits))) {
+					&& (ofs >= (rl->length << vol->cluster_size_bits))) {
 				ofs -= rl->length << vol->cluster_size_bits;
 				rl++;
 			}
@@ -2271,8 +2271,8 @@ static s64 ntfs_attr_pwrite_i(ntfs_attr *na, const s64 pos, s64 count,
 		to_write = min(count, (rl->length << vol->cluster_size_bits) - ofs);
 retry:
 		ntfs_log_trace("Writing %lld bytes to vcn %lld, lcn %lld, ofs "
-			       "%lld.\n", (long long)to_write, (long long)rl->vcn,
-			       (long long)rl->lcn, (long long)ofs);
+				"%lld.\n", (long long)to_write, (long long)rl->vcn,
+				(long long)rl->lcn, (long long)ofs);
 
 		if (!NVolReadOnly(vol)) {
 
@@ -2292,7 +2292,7 @@ retry:
 			 * data is generally first written uncompressed.
 			 */
 			if (rounding && ((wend == na->initialized_size) ||
-				(wend < (hole_end << vol->cluster_size_bits)))){
+						(wend < (hole_end << vol->cluster_size_bits)))){
 
 				char *cb;
 
@@ -2307,12 +2307,12 @@ retry:
 
 				if (compressed) {
 					written = ntfs_compressed_pwrite(na,
-						rl, wpos, ofs, to_write,
-						rounding, cb, compressed_part,
-						&update_from);
+							rl, wpos, ofs, to_write,
+							rounding, cb, compressed_part,
+							&update_from);
 				} else {
 					written = ntfs_pwrite(vol->dev, wpos,
-						rounding, cb);
+							rounding, cb);
 					if (written == rounding)
 						written = to_write;
 				}
@@ -2321,12 +2321,12 @@ retry:
 			} else {
 				if (compressed) {
 					written = ntfs_compressed_pwrite(na,
-						rl, wpos, ofs, to_write,
-						to_write, b, compressed_part,
-						&update_from);
+							rl, wpos, ofs, to_write,
+							to_write, b, compressed_part,
+							&update_from);
 				} else
 					written = ntfs_pwrite(vol->dev, wpos,
-						to_write, b);
+							to_write, b);
 			}
 		} else
 			written = to_write;
@@ -2351,15 +2351,15 @@ retry:
 done:
 	if (ctx)
 		ntfs_attr_put_search_ctx(ctx);
-		/*
-		 *	 Update mapping pairs if needed.
-		 * For a compressed file, we try to make a partial update
-		 * of the mapping list. This makes a difference only if
-		 * inode extents were needed.
-		 */
+	/*
+	 *	 Update mapping pairs if needed.
+	 * For a compressed file, we try to make a partial update
+	 * of the mapping list. This makes a difference only if
+	 * inode extents were needed.
+	 */
 	if (NAttrRunlistDirty(na)) {
 		if (ntfs_attr_update_mapping_pairs(na,
-				(update_from < 0 ? 0 : update_from))) {
+					(update_from < 0 ? 0 : update_from))) {
 			/*
 			 * FIXME: trying to recover by goto rl_err_out;
 			 * could cause driver hang by infinite looping.
@@ -2444,8 +2444,8 @@ s64 ntfs_attr_pwrite(ntfs_attr *na, const s64 pos, s64 count, const void *b)
 	s64 written;
 
 	ntfs_log_enter("Entering for inode %lld, attr 0x%x, pos 0x%llx, count "
-		       "0x%llx.\n", (long long)na->ni->mft_no, le32_to_cpu(na->type),
-		       (long long)pos, (long long)count);
+			"0x%llx.\n", (long long)na->ni->mft_no, le32_to_cpu(na->type),
+			(long long)pos, (long long)count);
 
 	total = 0;
 	if (!na || !na->ni || !na->ni->vol || !b || pos < 0 || count < 0) {
@@ -2455,10 +2455,10 @@ s64 ntfs_attr_pwrite(ntfs_attr *na, const s64 pos, s64 count, const void *b)
 		goto out;
 	}
 
-		/*
-		 * Compressed attributes may be written partially, so
-		 * we may have to iterate.
-		 */
+	/*
+	 * Compressed attributes may be written partially, so
+	 * we may have to iterate.
+	 */
 	do {
 		written = ntfs_attr_pwrite_i(na, pos + total,
 				count - total, (const u8*)b + total);
@@ -2496,7 +2496,7 @@ int ntfs_attr_pclose(ntfs_attr *na)
 	vol = na->ni->vol;
 	na->unused_runs = 0;
 	compressed = (na->data_flags & ATTR_COMPRESSION_MASK)
-			 != const_cpu_to_le16(0);
+		!= const_cpu_to_le16(0);
 	/*
 	 * Encrypted non-resident attributes are not supported.  We return
 	 * access denied, which is what Windows NT4 does, too.
@@ -2510,7 +2510,7 @@ int ntfs_attr_pclose(ntfs_attr *na)
 	if (!compressed || !NAttrNonResident(na))
 		goto out;
 
-		/* safety check : no recursion on close */
+	/* safety check : no recursion on close */
 	if (NAttrComprClosing(na)) {
 		errno = EIO;
 		ntfs_log_error("Bad ntfs_attr_pclose"
@@ -2519,10 +2519,10 @@ int ntfs_attr_pclose(ntfs_attr *na)
 		goto out;
 	}
 	NAttrSetComprClosing(na);
-		/*
-		 * For a compressed attribute, we must be sure there are two
-		 * available entries, so reserve them before it gets too late.
-		 */
+	/*
+	 * For a compressed attribute, we must be sure there are two
+	 * available entries, so reserve them before it gets too late.
+	 */
 	if (ntfs_attr_map_whole_runlist(na))
 		goto err_out;
 	na->rl = ntfs_rl_extend(na,na->rl,2);
@@ -2549,7 +2549,7 @@ int ntfs_attr_pclose(ntfs_attr *na)
 	 * length.
 	 */
 	compressed_part = 0;
- 	if (rl->lcn >= 0) {
+	if (rl->lcn >= 0) {
 		runlist_element *xrl;
 
 		xrl = rl;
@@ -2557,18 +2557,18 @@ int ntfs_attr_pclose(ntfs_attr *na)
 			xrl++;
 		} while (xrl->lcn >= 0);
 		compressed_part = (-xrl->length)
-					& (na->compression_block_clusters - 1);
+			& (na->compression_block_clusters - 1);
 	} else
 		if (rl->lcn == (LCN)LCN_HOLE) {
 			if (rl->length < na->compression_block_clusters)
 				compressed_part
-        	                        = na->compression_block_clusters
-                	                           - rl->length;
+					= na->compression_block_clusters
+					- rl->length;
 			else
 				compressed_part
 					= na->compression_block_clusters;
 		}
-		/* done, if the last block set was compressed */
+	/* done, if the last block set was compressed */
 	if (compressed_part)
 		goto out;
 
@@ -2584,7 +2584,7 @@ int ntfs_attr_pclose(ntfs_attr *na)
 			}
 			goto rl_err_out;
 		}
-			/* Needed for case when runs merged. */
+		/* Needed for case when runs merged. */
 		ofs = na->initialized_size - (rl->vcn << vol->cluster_size_bits);
 	}
 	if (!rl->length) {
@@ -2605,7 +2605,7 @@ int ntfs_attr_pclose(ntfs_attr *na)
 			goto err_out;
 	}
 	while (rl->length
-	    && (ofs >= (rl->length << vol->cluster_size_bits))) {
+			&& (ofs >= (rl->length << vol->cluster_size_bits))) {
 		ofs -= rl->length << vol->cluster_size_bits;
 		rl++;
 	}
@@ -2617,8 +2617,8 @@ retry:
 		failed = ntfs_compressed_close(na, rl, ofs, &update_from);
 #if CACHE_NIDATA_SIZE
 		if (na->ni->mrec->flags & MFT_RECORD_IS_DIRECTORY
-		    ? na->type == AT_INDEX_ROOT && na->name == NTFS_INDEX_I30
-		    : na->type == AT_DATA && na->name == AT_UNNAMED) {
+				? na->type == AT_INDEX_ROOT && na->name == NTFS_INDEX_I30
+				: na->type == AT_DATA && na->name == AT_UNNAMED) {
 			na->ni->data_size = na->data_size;
 			na->ni->allocated_size = na->compressed_size;
 			set_nino_flag(na->ni,KnownSize);
@@ -2643,18 +2643,18 @@ retry:
 			 */
 			ok = FALSE;
 			goto out;
-	}
+		}
 out:
 	NAttrClearComprClosing(na);
 	ntfs_log_leave("\n");
 	return (!ok);
 rl_err_out:
-		/*
-		 * need not restore old sizes, only compressed_size
-		 * can have changed. It has been set according to
-		 * the current runlist while updating the mapping pairs,
-		 * and must be kept consistent with the runlists.
-		 */
+	/*
+	 * need not restore old sizes, only compressed_size
+	 * can have changed. It has been set according to
+	 * the current runlist while updating the mapping pairs,
+	 * and must be kept consistent with the runlists.
+	 */
 err_out:
 	eo = errno;
 	if (ctx)
@@ -2716,7 +2716,7 @@ s64 ntfs_attr_mst_pread(ntfs_attr *na, const s64 pos, const s64 bk_cnt,
 	if (br <= 0)
 		return br;
 	br /= bk_size;
-		/* log errors unless silenced */
+	/* log errors unless silenced */
 	warn = !na->ni || !na->ni->vol || !NVolNoFixupWarn(na->ni->vol);
 	for (end = (u8*)dst + br * bk_size; (u8*)dst < end; dst = (u8*)dst +
 			bk_size)
@@ -2793,7 +2793,7 @@ s64 ntfs_attr_mst_pwrite(ntfs_attr *na, const s64 pos, s64 bk_cnt,
 	/* Quickly deprotect the data again. */
 	for (i = 0; i < bk_cnt; ++i)
 		ntfs_mst_post_write_fixup((NTFS_RECORD*)((u8*)src + i *
-				bk_size));
+					bk_size));
 	if (written <= 0)
 		return written;
 	/* Finally, return the number of complete blocks written. */
@@ -2915,14 +2915,14 @@ static int ntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 		offs = p2n(a) - p2n(ctx->mrec);
 		space = le32_to_cpu(ctx->mrec->bytes_in_use) - offs;
 		if ((offs < 0)
-		    || (((space < (ptrdiff_t)offsetof(ATTR_RECORD,
-						resident_end))
-			|| (space < (ptrdiff_t)le32_to_cpu(a->length)))
-			    && ((space < 4) || (a->type != AT_END))))
+				|| (((space < (ptrdiff_t)offsetof(ATTR_RECORD,
+								resident_end))
+						|| (space < (ptrdiff_t)le32_to_cpu(a->length)))
+					&& ((space < 4) || (a->type != AT_END))))
 			break;
 		ctx->attr = a;
 		if (((type != AT_UNUSED) && (le32_to_cpu(a->type) >
-				le32_to_cpu(type))) ||
+						le32_to_cpu(type))) ||
 				(a->type == AT_END)) {
 			errno = ENOENT;
 			return -1;
@@ -2949,19 +2949,19 @@ static int ntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 			register int rc;
 
 			if (a->name_length
-			    && ((le16_to_cpu(a->name_offset)
-					+ a->name_length * sizeof(ntfschar))
-					> le32_to_cpu(a->length))) {
+					&& ((le16_to_cpu(a->name_offset)
+							+ a->name_length * sizeof(ntfschar))
+						> le32_to_cpu(a->length))) {
 				ntfs_log_error("Corrupt attribute name"
-					" in MFT record %lld\n",
-					(long long)ctx->ntfs_ino->mft_no);
+						" in MFT record %lld\n",
+						(long long)ctx->ntfs_ino->mft_no);
 				break;
 			}
 			if (name && ((rc = ntfs_names_full_collate(name,
-					name_len, (ntfschar*)((char*)a +
-						le16_to_cpu(a->name_offset)),
-					a->name_length, ic,
-					upcase, upcase_len)))) {
+								name_len, (ntfschar*)((char*)a +
+									le16_to_cpu(a->name_offset)),
+								a->name_length, ic,
+								upcase, upcase_len)))) {
 				/*
 				 * If @name collates before a->name,
 				 * there is no matching attribute.
@@ -2970,8 +2970,8 @@ static int ntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 					errno = ENOENT;
 					return -1;
 				}
-			/* If the strings are not equal, continue search. */
-			continue;
+				/* If the strings are not equal, continue search. */
+				continue;
 			}
 		}
 		/*
@@ -2987,7 +2987,7 @@ static int ntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 
 			rc = memcmp(val, (char*)a +le16_to_cpu(a->value_offset),
 					min(val_len,
-					le32_to_cpu(a->value_length)));
+						le32_to_cpu(a->value_length)));
 			/*
 			 * If @val collates before the current attribute's
 			 * value, there is no matching attribute.
@@ -3162,19 +3162,19 @@ static int ntfs_external_attr_find(ATTR_TYPES type, const ntfschar *name,
 				le32_to_cpu(AT_ATTRIBUTE_LIST))
 			goto find_attr_list_attr;
 	} else {
-			/* Check for small entry */
+		/* Check for small entry */
 		if (((p2n(al_end) - p2n(ctx->al_entry))
-				< (long)offsetof(ATTR_LIST_ENTRY, name))
-		    || (le16_to_cpu(ctx->al_entry->length) & 7)
-		    || (le16_to_cpu(ctx->al_entry->length)
-				< offsetof(ATTR_LIST_ENTRY, name)))
+					< (long)offsetof(ATTR_LIST_ENTRY, name))
+				|| (le16_to_cpu(ctx->al_entry->length) & 7)
+				|| (le16_to_cpu(ctx->al_entry->length)
+					< offsetof(ATTR_LIST_ENTRY, name)))
 			goto corrupt;
 
 		al_entry = (ATTR_LIST_ENTRY*)((char*)ctx->al_entry +
 				le16_to_cpu(ctx->al_entry->length));
 		if ((u8*)al_entry == al_end)
 			goto not_found;
-			/* Preliminary check for small entry */
+		/* Preliminary check for small entry */
 		if ((p2n(al_end) - p2n(al_entry))
 				< (long)offsetof(ATTR_LIST_ENTRY, name))
 			goto corrupt;
@@ -3242,14 +3242,14 @@ find_attr_list_attr:
 			goto not_found;
 
 		if ((((u8*)al_entry + offsetof(ATTR_LIST_ENTRY, name)) > al_end)
-		    || ((u8*)al_entry + le16_to_cpu(al_entry->length) > al_end)
-		    || (le16_to_cpu(al_entry->length) & 7)
-		    || (le16_to_cpu(al_entry->length)
-				< offsetof(ATTR_LIST_ENTRY, name_length))
-		    || (al_entry->name_length
-			&& ((u8*)al_entry + al_entry->name_offset
-				+ al_entry->name_length * sizeof(ntfschar))
-				> al_end))
+				|| ((u8*)al_entry + le16_to_cpu(al_entry->length) > al_end)
+				|| (le16_to_cpu(al_entry->length) & 7)
+				|| (le16_to_cpu(al_entry->length)
+					< offsetof(ATTR_LIST_ENTRY, name_length))
+				|| (al_entry->name_length
+					&& ((u8*)al_entry + al_entry->name_offset
+						+ al_entry->name_length * sizeof(ntfschar))
+					> al_end))
 			break; /* corrupt */
 
 		next_al_entry = (ATTR_LIST_ENTRY*)((u8*)al_entry +
@@ -3280,8 +3280,8 @@ find_attr_list_attr:
 			int rc;
 
 			if (name && ((rc = ntfs_names_full_collate(name,
-					name_len, al_name, al_name_len, ic,
-					vol->upcase, vol->upcase_len)))) {
+								name_len, al_name, al_name_len, ic,
+								vol->upcase, vol->upcase_len)))) {
 
 				/*
 				 * If @name collates before al_name,
@@ -3304,12 +3304,12 @@ find_attr_list_attr:
 				(u8*)next_al_entry + le16_to_cpu(
 					next_al_entry->length) <= al_end    &&
 				sle64_to_cpu(next_al_entry->lowest_vcn) <=
-					lowest_vcn			    &&
+				lowest_vcn			    &&
 				next_al_entry->type == al_entry->type	    &&
 				next_al_entry->name_length == al_name_len   &&
 				ntfs_names_are_equal((ntfschar*)((char*)
-					next_al_entry +
-					next_al_entry->name_offset),
+						next_al_entry +
+						next_al_entry->name_offset),
 					next_al_entry->name_length,
 					al_name, al_name_len, CASE_SENSITIVE,
 					vol->upcase, vol->upcase_len))
@@ -3318,7 +3318,7 @@ is_enumeration:
 		if (MREF_LE(al_entry->mft_reference) == ni->mft_no) {
 			if (MSEQNO_LE(al_entry->mft_reference) !=
 					le16_to_cpu(
-					ni->mrec->sequence_number)) {
+						ni->mrec->sequence_number)) {
 				ntfs_log_error("Found stale mft reference in "
 						"attribute list!\n");
 				break;
@@ -3333,8 +3333,8 @@ is_enumeration:
 				/* We want an extent record. */
 				if (!vol->mft_na) {
 					ntfs_log_perror("$MFT not ready for "
-					    "opening an extent to inode %lld\n",
-					    (long long)base_ni->mft_no);
+							"opening an extent to inode %lld\n",
+							(long long)base_ni->mft_no);
 					break;
 				}
 				ni = ntfs_extent_inode_open(base_ni,
@@ -3378,7 +3378,7 @@ do_next_attr_loop:
 		if (!a->length)
 			break;
 		if ((space < (ptrdiff_t)offsetof(ATTR_RECORD, resident_end))
-		    || (space < (ptrdiff_t)le32_to_cpu(a->length)))
+				|| (space < (ptrdiff_t)le32_to_cpu(a->length)))
 			break;
 		if (al_entry->instance != a->instance)
 			goto do_next_attr;
@@ -3390,10 +3390,10 @@ do_next_attr_loop:
 		if (al_entry->type != a->type)
 			break;
 		if (!ntfs_names_are_equal((ntfschar*)((char*)a +
-				le16_to_cpu(a->name_offset)),
-				a->name_length, al_name,
-				al_name_len, CASE_SENSITIVE,
-				vol->upcase, vol->upcase_len))
+						le16_to_cpu(a->name_offset)),
+					a->name_length, al_name,
+					al_name_len, CASE_SENSITIVE,
+					vol->upcase, vol->upcase_len))
 			break;
 		ctx->attr = a;
 		/*
@@ -3402,9 +3402,9 @@ do_next_attr_loop:
 		 * want the current attribute.
 		 */
 		if ((type == AT_UNUSED) || !val || (!a->non_resident &&
-				le32_to_cpu(a->value_length) == val_len &&
-				!memcmp((char*)a + le16_to_cpu(a->value_offset),
-				val, val_len))) {
+					le32_to_cpu(a->value_length) == val_len &&
+					!memcmp((char*)a + le16_to_cpu(a->value_offset),
+						val, val_len))) {
 			return 0;
 		}
 do_next_attr:
@@ -3487,7 +3487,7 @@ not_found:
  */
 
 int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
-	const MFT_REF mref, BOOL *fixed)
+		const MFT_REF mref, BOOL *fixed)
 {
 	FILE_NAME_ATTR *fn;
 	INDEX_ROOT *ir;
@@ -3515,21 +3515,21 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 
 	if (a->non_resident) {
 		if ((a->non_resident != 1)
-		    || (le32_to_cpu(a->length)
-			< offsetof(ATTR_RECORD, non_resident_end))
-		    || (le16_to_cpu(a->mapping_pairs_offset) & 7)
-		    || (le16_to_cpu(a->mapping_pairs_offset)
-				>= le32_to_cpu(a->length))
-		    || (a->name_length
-			 && (((u32)le16_to_cpu(a->name_offset)
-				+ a->name_length * sizeof(ntfschar))
-				> le32_to_cpu(a->length)))
-		    || (le64_to_cpu(a->highest_vcn)
-				< le64_to_cpu(a->lowest_vcn))) {
+				|| (le32_to_cpu(a->length)
+					< offsetof(ATTR_RECORD, non_resident_end))
+				|| (le16_to_cpu(a->mapping_pairs_offset) & 7)
+				|| (le16_to_cpu(a->mapping_pairs_offset)
+					>= le32_to_cpu(a->length))
+				|| (a->name_length
+					&& (((u32)le16_to_cpu(a->name_offset)
+							+ a->name_length * sizeof(ntfschar))
+						> le32_to_cpu(a->length)))
+				|| (le64_to_cpu(a->highest_vcn)
+					< le64_to_cpu(a->lowest_vcn))) {
 			ntfs_log_error("Corrupt non resident attribute"
-				" 0x%x in MFT record %lld\n",
-				(int)le32_to_cpu(a->type),
-				(long long)inum);
+					" 0x%x in MFT record %lld\n",
+					(int)le32_to_cpu(a->type),
+					(long long)inum);
 			errno = EIO;
 			ret = -1;
 			goto out;
@@ -3542,9 +3542,9 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 
 		if ((value_len & 0xff000000)) {
 			ntfs_log_error("Corrupt resident attribute"
-				" 0x%x in MFT record %lld\n",
-				(int)le32_to_cpu(a->type),
-				(long long)inum);
+					" 0x%x in MFT record %lld\n",
+					(int)le32_to_cpu(a->type),
+					(long long)inum);
 			errno = EIO;
 			ret = -1;
 			goto out;
@@ -3565,7 +3565,7 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 				}
 			} else {
 				ntfs_log_error("Value offset badly aligned in attribute(type : 0x%x)",
-					       a->type);
+						a->type);
 				errno = EIO;
 				ret = -1;
 				goto out;
@@ -3573,7 +3573,7 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 		}
 
 		if (a->name_offset && (u32)le16_to_cpu(a->name_offset) <
-		    offsetof(ATTR_RECORD, resident_end)) {
+				offsetof(ATTR_RECORD, resident_end)) {
 			if (NVolFsck(vol)) {
 				fsck_err_found();
 				if (ntfs_fix_problem(vol, PR_ATTR_NAME_OFFSET_CORRUPTED, &pctx)) {
@@ -3582,7 +3582,7 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 					fsck_err_fixed();
 				} else {
 					ntfs_log_error("Name offset is corrupted in attribute(type : 0x%x)",
-						       a->type);
+							a->type);
 					errno = EIO;
 					ret = -1;
 					goto out;
@@ -3609,7 +3609,7 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 				}
 			} else {
 				ntfs_log_error("Value offset is corrupted in attribute(type : 0x%x)\n",
-					     a->type);
+						a->type);
 				errno = EIO;
 				ret = -1;
 				goto out;
@@ -3624,7 +3624,7 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 		}
 
 		if (((value_off + value_len + 7) & ~7) > attr_len ||
-		    attr_len < offsetof(ATTR_RECORD, resident_end)) {
+				attr_len < offsetof(ATTR_RECORD, resident_end)) {
 			if (NVolFsck(vol)) {
 				fsck_err_found();
 				if (ntfs_fix_problem(vol, PR_ATTR_LENGTH_CORRUPTED, &pctx)) {
@@ -3639,7 +3639,7 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 				}
 			} else {
 				ntfs_log_error("Attribute length is corrupted in attribute(type : 0x%x)\n",
-					       a->type);
+						a->type);
 				errno = EIO;
 				ret = -1;
 				goto out;
@@ -3659,152 +3659,152 @@ int ntfs_attr_inconsistent(ntfs_volume *vol, ATTR_RECORD *a,
 		 * a->value_length cannot look like being negative.
 		 */
 		switch(a->type) {
-		case AT_FILE_NAME :
-			/* Check file names are resident and do not overflow */
-			fn = (FILE_NAME_ATTR *)((const u8 *)a
-				+ le16_to_cpu(a->value_offset));
+			case AT_FILE_NAME :
+				/* Check file names are resident and do not overflow */
+				fn = (FILE_NAME_ATTR *)((const u8 *)a
+						+ le16_to_cpu(a->value_offset));
 
-			if (a->non_resident
-			    || (le32_to_cpu(a->value_length)
-				< offsetof(FILE_NAME_ATTR, file_name))
-			    || !fn->file_name_length
-			    || ((fn->file_name_length * sizeof(ntfschar)
-				+ offsetof(FILE_NAME_ATTR, file_name))
-				> le32_to_cpu(a->value_length))) {
-				ntfs_log_error("Corrupt file name"
-					" attribute in MFT record %lld.\n",
-					(long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
-
-			if (!ret && a->resident_flags != RESIDENT_ATTR_IS_INDEXED &&
-					!(fn->file_attributes & FILE_ATTR_NOT_CONTENT_INDEXED)) {
-				if (NVolFsck(vol)) {
-					fsck_err_found();
-					if (ntfs_fix_problem(vol, PR_ATTR_FN_FLAG_MISMATCH, &pctx)) {
-						mod_a->resident_flags = RESIDENT_ATTR_IS_INDEXED;
-						*fixed = TRUE;
-						fsck_err_fixed();
-					}
-				} else {
-					ntfs_log_error("$FILE_NAME attribute's flag "
-						       "is not set to be indexed\n");
+				if (a->non_resident
+						|| (le32_to_cpu(a->value_length)
+							< offsetof(FILE_NAME_ATTR, file_name))
+						|| !fn->file_name_length
+						|| ((fn->file_name_length * sizeof(ntfschar)
+								+ offsetof(FILE_NAME_ATTR, file_name))
+							> le32_to_cpu(a->value_length))) {
+					ntfs_log_error("Corrupt file name"
+							" attribute in MFT record %lld.\n",
+							(long long)inum);
 					errno = EIO;
 					ret = -1;
 				}
-			}
 
-			break;
-		case AT_INDEX_ROOT :
-			/* Check root index is resident and does not overflow */
-			ir = (INDEX_ROOT *)((const u8 *)a +
-				le16_to_cpu(a->value_offset));
+				if (!ret && a->resident_flags != RESIDENT_ATTR_IS_INDEXED &&
+						!(fn->file_attributes & FILE_ATTR_NOT_CONTENT_INDEXED)) {
+					if (NVolFsck(vol)) {
+						fsck_err_found();
+						if (ntfs_fix_problem(vol, PR_ATTR_FN_FLAG_MISMATCH, &pctx)) {
+							mod_a->resident_flags = RESIDENT_ATTR_IS_INDEXED;
+							*fixed = TRUE;
+							fsck_err_fixed();
+						}
+					} else {
+						ntfs_log_error("$FILE_NAME attribute's flag "
+								"is not set to be indexed\n");
+						errno = EIO;
+						ret = -1;
+					}
+				}
 
-			/* index.allocated_size may overflow while resizing */
-			if (a->non_resident
-			    || (le32_to_cpu(a->value_length)
-				< offsetof(INDEX_ROOT, index.reserved))
-			    || (le32_to_cpu(ir->index.entries_offset)
-				< sizeof(INDEX_HEADER))
-			    || (le32_to_cpu(ir->index.index_length) & 7)
-			    || (le32_to_cpu(ir->index.allocated_size) & 7)
-			    || (le32_to_cpu(ir->index.index_length)
-				< le32_to_cpu(ir->index.entries_offset))
-			    || (le32_to_cpu(ir->index.entries_offset) & 7)
-			    || (le32_to_cpu(ir->index.entries_offset)
-				!= sizeof(INDEX_HEADER))
-			    || (le32_to_cpu(ir->index.allocated_size)
-				< le32_to_cpu(ir->index.index_length))
-			    || (le32_to_cpu(a->value_length)
-				< (le32_to_cpu(ir->index.allocated_size)
-				    + offsetof(INDEX_ROOT, reserved)))) {
-				ntfs_log_error("Corrupt index root"
-					" in MFT record %lld.\n",
-					(long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
+				break;
+			case AT_INDEX_ROOT :
+				/* Check root index is resident and does not overflow */
+				ir = (INDEX_ROOT *)((const u8 *)a +
+						le16_to_cpu(a->value_offset));
 
-			/* Is it needed? */
-			if (!ret && le32_to_cpu(ir->index_block_size) !=
+				/* index.allocated_size may overflow while resizing */
+				if (a->non_resident
+						|| (le32_to_cpu(a->value_length)
+							< offsetof(INDEX_ROOT, index.reserved))
+						|| (le32_to_cpu(ir->index.entries_offset)
+							< sizeof(INDEX_HEADER))
+						|| (le32_to_cpu(ir->index.index_length) & 7)
+						|| (le32_to_cpu(ir->index.allocated_size) & 7)
+						|| (le32_to_cpu(ir->index.index_length)
+							< le32_to_cpu(ir->index.entries_offset))
+						|| (le32_to_cpu(ir->index.entries_offset) & 7)
+						|| (le32_to_cpu(ir->index.entries_offset)
+							!= sizeof(INDEX_HEADER))
+						|| (le32_to_cpu(ir->index.allocated_size)
+							< le32_to_cpu(ir->index.index_length))
+						|| (le32_to_cpu(a->value_length)
+							< (le32_to_cpu(ir->index.allocated_size)
+								+ offsetof(INDEX_ROOT, reserved)))) {
+					ntfs_log_error("Corrupt index root"
+							" in MFT record %lld.\n",
+							(long long)inum);
+					errno = EIO;
+					ret = -1;
+				}
+
+				/* Is it needed? */
+				if (!ret && le32_to_cpu(ir->index_block_size) !=
 						vol->indx_record_size) {
-				if (NVolFsck(vol)) {
-					fsck_err_found();
-					if (ntfs_fix_problem(vol, PR_ATTR_IR_SIZE_MISMATCH, &pctx)) {
-						ir->index_block_size = le32_to_cpu(vol->indx_record_size);
-						*fixed = TRUE;
-						fsck_err_fixed();
+					if (NVolFsck(vol)) {
+						fsck_err_found();
+						if (ntfs_fix_problem(vol, PR_ATTR_IR_SIZE_MISMATCH, &pctx)) {
+							ir->index_block_size = le32_to_cpu(vol->indx_record_size);
+							*fixed = TRUE;
+							fsck_err_fixed();
+						}
+					} else {
+						ntfs_log_error("Corrupt index block size(%u %u) "
+								"in MFT record %llu.\n",
+								le32_to_cpu(ir->index_block_size),
+								vol->indx_record_size,
+								(unsigned long long)inum);
+						errno = EIO;
+						ret = -1;
 					}
-				} else {
-					ntfs_log_error("Corrupt index block size(%u %u) "
-						       "in MFT record %llu.\n",
-						       le32_to_cpu(ir->index_block_size),
-						       vol->indx_record_size,
-						       (unsigned long long)inum);
+				}
+
+				break;
+			case AT_STANDARD_INFORMATION :
+				if (a->non_resident
+						|| (le32_to_cpu(a->value_length)
+							< offsetof(STANDARD_INFORMATION,
+								v1_end))) {
+					ntfs_log_error("Corrupt standard information"
+							" in MFT record %lld\n",
+							(long long)inum);
 					errno = EIO;
 					ret = -1;
 				}
-			}
+				break;
+			case AT_OBJECT_ID :
+				if (a->non_resident
+						|| (le32_to_cpu(a->value_length)
+							< sizeof(GUID))) {
+					ntfs_log_error("Corrupt object id"
+							" in MFT record %lld\n",
+							(long long)inum);
+					errno = EIO;
+					ret = -1;
+				}
+				break;
+			case AT_VOLUME_NAME :
+			case AT_EA_INFORMATION :
+				if (a->non_resident) {
+					ntfs_log_error("Attribute 0x%x in MFT record"
+							" %lld should be resident.\n",
+							(int)le32_to_cpu(a->type),
+							(long long)inum);
+					errno = EIO;
+					ret = -1;
+				}
+				break;
+			case AT_VOLUME_INFORMATION :
+				if (a->non_resident
+						|| (le32_to_cpu(a->value_length)
+							< sizeof(VOLUME_INFORMATION))) {
+					ntfs_log_error("Corrupt volume information"
+							" in MFT record %lld\n",
+							(long long)inum);
+					errno = EIO;
+					ret = -1;
+				}
+				break;
+			case AT_INDEX_ALLOCATION :
 
-			break;
-		case AT_STANDARD_INFORMATION :
-			if (a->non_resident
-			    || (le32_to_cpu(a->value_length)
-					< offsetof(STANDARD_INFORMATION,
-							v1_end))) {
-				ntfs_log_error("Corrupt standard information"
-					" in MFT record %lld\n",
-					(long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
-			break;
-		case AT_OBJECT_ID :
-			if (a->non_resident
-			    || (le32_to_cpu(a->value_length)
-					< sizeof(GUID))) {
-				ntfs_log_error("Corrupt object id"
-					" in MFT record %lld\n",
-					(long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
-			break;
-		case AT_VOLUME_NAME :
-		case AT_EA_INFORMATION :
-			if (a->non_resident) {
-				ntfs_log_error("Attribute 0x%x in MFT record"
-					" %lld should be resident.\n",
-					(int)le32_to_cpu(a->type),
-					(long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
-			break;
-		case AT_VOLUME_INFORMATION :
-			if (a->non_resident
-			    || (le32_to_cpu(a->value_length)
-					< sizeof(VOLUME_INFORMATION))) {
-				ntfs_log_error("Corrupt volume information"
-					" in MFT record %lld\n",
-					(long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
-			break;
-		case AT_INDEX_ALLOCATION :
+				if (!a->non_resident) {
+					ntfs_log_error("Corrupt index allocation"
+							" in MFT record %lld", (long long)inum);
+					errno = EIO;
+					ret = -1;
+				}
 
-			if (!a->non_resident) {
-				ntfs_log_error("Corrupt index allocation"
-					" in MFT record %lld", (long long)inum);
-				errno = EIO;
-				ret = -1;
-			}
-
-			break;
-		default :
-			break;
+				break;
+			default :
+				break;
 		}
 	}
 
@@ -3893,8 +3893,8 @@ int ntfs_attr_lookup(const ATTR_TYPES type, const ntfschar *name,
 	ntfs_log_enter("Entering for attribute type 0x%x\n", le32_to_cpu(type));
 
 	if (!ctx || !ctx->mrec || !ctx->attr || (name && name != AT_UNNAMED &&
-			(!ctx->ntfs_ino || !(vol = ctx->ntfs_ino->vol) ||
-			!vol->upcase || !vol->upcase_len))) {
+				(!ctx->ntfs_ino || !(vol = ctx->ntfs_ino->vol) ||
+				 !vol->upcase || !vol->upcase_len))) {
 		errno = EINVAL;
 		ntfs_log_perror("%s", __FUNCTION__);
 		goto out;
@@ -3908,7 +3908,7 @@ int ntfs_attr_lookup(const ATTR_TYPES type, const ntfschar *name,
 		ret = ntfs_attr_find(type, name, name_len, ic, val, val_len, ctx);
 	else
 		ret = ntfs_external_attr_find(type, name, name_len, ic,
-					      lowest_vcn, val, val_len, ctx);
+				lowest_vcn, val, val_len, ctx);
 out:
 	ntfs_log_leave("\n");
 	return ret;
@@ -3929,7 +3929,7 @@ out:
  *	EINVAL	Invalid arguments.
  *	EIO	I/O error or corrupt data structures found.
  *	ENOMEM	Not enough memory to allocate necessary buffers.
- * 	ENOSPC  No attribute was found after 'type', only AT_END.
+ *	ENOSPC  No attribute was found after 'type', only AT_END.
  */
 int ntfs_attr_position(const ATTR_TYPES type, ntfs_attr_search_ctx *ctx)
 {
@@ -4065,7 +4065,7 @@ ATTR_DEF *ntfs_attr_find_in_attrdef(const ntfs_volume *vol,
 		return NULL;
 	}
 	for (ad = vol->attrdef; ((ptrdiff_t)((u8*)ad - (u8*)vol->attrdef
-				+ sizeof(ATTR_DEF)) <= vol->attrdef_len)
+					+ sizeof(ATTR_DEF)) <= vol->attrdef_len)
 			&& ad->type; ++ad) {
 		/* We haven't found it yet, carry on searching. */
 		if (le32_to_cpu(ad->type) < le32_to_cpu(type))
@@ -4135,11 +4135,11 @@ int ntfs_attr_size_bounds_check(const ntfs_volume *vol, const ATTR_TYPES type,
 		min_size = 0;
 
 	if ((min_size && (size < min_size)) ||
-	    ((max_size > 0) && (size > max_size))) {
+			((max_size > 0) && (size > max_size))) {
 		errno = ERANGE;
 		ntfs_log_perror("Attr type %d size check failed (min,size,max="
-			"%lld,%lld,%lld)", le32_to_cpu(type), (long long)min_size,
-			(long long)size, (long long)max_size);
+				"%lld,%lld,%lld)", le32_to_cpu(type), (long long)min_size,
+				(long long)size, (long long)max_size);
 		return -1;
 	}
 	return 0;
@@ -4165,7 +4165,7 @@ int ntfs_attr_size_bounds_check(const ntfs_volume *vol, const ATTR_TYPES type,
  *	EINVAL	- Invalid parameters (e.g. @vol is not valid).
  */
 static int ntfs_attr_can_be_non_resident(const ntfs_volume *vol, const ATTR_TYPES type,
-					const ntfschar *name, int name_len)
+		const ntfschar *name, int name_len)
 {
 	ATTR_DEF *ad;
 	BOOL allowed;
@@ -4179,9 +4179,9 @@ static int ntfs_attr_can_be_non_resident(const ntfs_volume *vol, const ATTR_TYPE
 	 * thus cannot mount it at all.
 	 */
 	if ((type == AT_LOGGED_UTILITY_STREAM)
-	    && name
-	    && ntfs_names_are_equal(TXF_DATA, 9, name, name_len,
-			CASE_SENSITIVE, vol->upcase, vol->upcase_len))
+			&& name
+			&& ntfs_names_are_equal(TXF_DATA, 9, name, name_len,
+				CASE_SENSITIVE, vol->upcase, vol->upcase_len))
 		allowed = FALSE;
 	else {
 		/* Find the attribute definition record in $AttrDef. */
@@ -4254,7 +4254,7 @@ int ntfs_make_room_for_attr(MFT_RECORD *m, u8 *pos, u32 size)
 	u32 biu;
 
 	ntfs_log_trace("Entering for pos 0x%d, size %u.\n",
-		(int)(pos - (u8*)m), (unsigned) size);
+			(int)(pos - (u8*)m), (unsigned) size);
 
 	/* Make size 8-byte alignment. */
 	size = (size + 7) & ~7;
@@ -4277,7 +4277,7 @@ int ntfs_make_room_for_attr(MFT_RECORD *m, u8 *pos, u32 size)
 	biu = le32_to_cpu(m->bytes_in_use);
 	/* Do we have enough space? */
 	if (biu + size > le32_to_cpu(m->bytes_allocated) ||
-	    pos + size > (u8*)m + le32_to_cpu(m->bytes_allocated)) {
+			pos + size > (u8*)m + le32_to_cpu(m->bytes_allocated)) {
 		errno = ENOSPC;
 		ntfs_log_trace("No enough space in the MFT record\n");
 		return -1;
@@ -4307,8 +4307,8 @@ int ntfs_make_room_for_attr(MFT_RECORD *m, u8 *pos, u32 size)
  *	EIO	- I/O error occurred or damaged filesystem.
  */
 int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
-			const ntfschar *name, u8 name_len, const u8 *val,
-			u32 size, ATTR_FLAGS data_flags)
+		const ntfschar *name, u8 name_len, const u8 *val,
+		u32 size, ATTR_FLAGS data_flags)
 {
 	ntfs_attr_search_ctx *ctx;
 	u32 length;
@@ -4318,7 +4318,7 @@ int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	ntfs_inode *base_ni;
 
 	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x, flags 0x%x.\n",
-		(long long) ni->mft_no, (unsigned) le32_to_cpu(type), (unsigned) le16_to_cpu(data_flags));
+			(long long) ni->mft_no, (unsigned) le32_to_cpu(type), (unsigned) le16_to_cpu(data_flags));
 
 	if (!ni || (!name && name_len)) {
 		errno = EINVAL;
@@ -4343,7 +4343,7 @@ int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	 * file record.
 	 */
 	if (!ntfs_attr_find(type, name, name_len, CASE_SENSITIVE, val, size,
-			ctx)) {
+				ctx)) {
 		err = EEXIST;
 		ntfs_log_trace("Attribute already present.\n");
 		goto put_err_out;
@@ -4357,8 +4357,8 @@ int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 
 	/* Make room for attribute. */
 	length = offsetof(ATTR_RECORD, resident_end) +
-				((name_len * sizeof(ntfschar) + 7) & ~7) +
-				((size + 7) & ~7);
+		((name_len * sizeof(ntfschar) + 7) & ~7) +
+		((size + 7) & ~7);
 	if (ntfs_make_room_for_attr(ctx->mrec, (u8*) ctx->attr, length)) {
 		err = errno;
 		ntfs_log_trace("Failed to make room for attribute.\n");
@@ -4372,8 +4372,8 @@ int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	a->non_resident = 0;
 	a->name_length = name_len;
 	a->name_offset = (name_len
-		? const_cpu_to_le16(offsetof(ATTR_RECORD, resident_end))
-		: const_cpu_to_le16(0));
+			? const_cpu_to_le16(offsetof(ATTR_RECORD, resident_end))
+			: const_cpu_to_le16(0));
 	a->flags = data_flags;
 	a->instance = m->next_attr_instance;
 	a->value_length = cpu_to_le32(size);
@@ -4388,7 +4388,7 @@ int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 		a->resident_flags = 0;
 	if (name_len)
 		memcpy((u8*)a + le16_to_cpu(a->name_offset),
-			name, sizeof(ntfschar) * name_len);
+				name, sizeof(ntfschar) * name_len);
 	m->next_attr_instance =
 		cpu_to_le16((le16_to_cpu(m->next_attr_instance) + 1) & 0xffff);
 	if (ni->nr_extents == -1)
@@ -4405,8 +4405,8 @@ int ntfs_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 		}
 	}
 	if (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY
-	    ? type == AT_INDEX_ROOT && name == NTFS_INDEX_I30
-	    : type == AT_DATA && name == AT_UNNAMED) {
+			? type == AT_INDEX_ROOT && name == NTFS_INDEX_I30
+			: type == AT_DATA && name == AT_UNNAMED) {
 		ni->data_size = size;
 		ni->allocated_size = (size + 7) & ~7;
 		set_nino_flag(ni,KnownSize);
@@ -4477,7 +4477,7 @@ int ntfs_non_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	 * file record.
 	 */
 	if (!ntfs_attr_find(type, name, name_len, CASE_SENSITIVE, NULL, 0,
-			ctx)) {
+				ctx)) {
 		err = EEXIST;
 		ntfs_log_perror("Attribute 0x%x already present", le32_to_cpu(type));
 		goto put_err_out;
@@ -4493,9 +4493,9 @@ int ntfs_non_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	/* Make room for attribute. */
 	dataruns_size = (dataruns_size + 7) & ~7;
 	length = offsetof(ATTR_RECORD, compressed_size) + ((sizeof(ntfschar) *
-			name_len + 7) & ~7) + dataruns_size +
-			((flags & (ATTR_IS_COMPRESSED | ATTR_IS_SPARSE)) ?
-			sizeof(a->compressed_size) : 0);
+				name_len + 7) & ~7) + dataruns_size +
+		((flags & (ATTR_IS_COMPRESSED | ATTR_IS_SPARSE)) ?
+		 sizeof(a->compressed_size) : 0);
 	if (ntfs_make_room_for_attr(ctx->mrec, (u8*) ctx->attr, length)) {
 		err = errno;
 		ntfs_log_perror("Failed to make room for attribute");
@@ -4509,13 +4509,13 @@ int ntfs_non_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	a->name_length = name_len;
 	a->name_offset = cpu_to_le16(offsetof(ATTR_RECORD, compressed_size) +
 			((flags & (ATTR_IS_COMPRESSED | ATTR_IS_SPARSE)) ?
-			sizeof(a->compressed_size) : 0));
+			 sizeof(a->compressed_size) : 0));
 	a->flags = flags;
 	a->instance = m->next_attr_instance;
 	a->lowest_vcn = cpu_to_sle64(lowest_vcn);
 	a->mapping_pairs_offset = cpu_to_le16(length - dataruns_size);
 	a->compression_unit = (flags & ATTR_IS_COMPRESSED)
-			? STANDARD_COMPRESSION_UNIT : 0;
+		? STANDARD_COMPRESSION_UNIT : 0;
 	/* If @lowest_vcn == 0, than setup empty attribute. */
 	if (!lowest_vcn) {
 		a->highest_vcn = const_cpu_to_sle64(-1);
@@ -4527,7 +4527,7 @@ int ntfs_non_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	}
 	if (name_len)
 		memcpy((u8*)a + le16_to_cpu(a->name_offset),
-			name, sizeof(ntfschar) * name_len);
+				name, sizeof(ntfschar) * name_len);
 	m->next_attr_instance =
 		cpu_to_le16((le16_to_cpu(m->next_attr_instance) + 1) & 0xffff);
 	if (ni->nr_extents == -1)
@@ -4550,7 +4550,7 @@ int ntfs_non_resident_attr_record_add(ntfs_inode *ni, ATTR_TYPES type,
 	 */
 	ntfs_attr_reinit_search_ctx(ctx);
 	if (ntfs_attr_lookup(type, name, name_len, CASE_SENSITIVE,
-					lowest_vcn, NULL, 0, ctx)) {
+				lowest_vcn, NULL, 0, ctx)) {
 		ntfs_log_perror("%s: attribute lookup failed", __FUNCTION__);
 		ntfs_attr_put_search_ctx(ctx);
 		return -1;
@@ -4652,7 +4652,7 @@ int ntfs_attr_record_rm(ntfs_attr_search_ctx *ctx)
 	if (!ntfs_attrlist_need(base_ni)) {
 		ntfs_attr_reinit_search_ctx(ctx);
 		if (ntfs_attr_lookup(AT_ATTRIBUTE_LIST, NULL, 0, CASE_SENSITIVE,
-				0, NULL, 0, ctx)) {
+					0, NULL, 0, ctx)) {
 			/*
 			 * FIXME: Should we succeed here? Definitely something
 			 * goes wrong because NInoAttrList(base_ni) returned
@@ -4791,11 +4791,11 @@ int ntfs_attr_add(ntfs_inode *ni, ATTR_TYPES type,
 	/* Calculate attribute record size. */
 	if (is_resident)
 		attr_rec_size = offsetof(ATTR_RECORD, resident_end) +
-				((name_len * sizeof(ntfschar) + 7) & ~7) +
-				((size + 7) & ~7);
+			((name_len * sizeof(ntfschar) + 7) & ~7) +
+			((size + 7) & ~7);
 	else
 		attr_rec_size = offsetof(ATTR_RECORD, non_resident_end) +
-				((name_len * sizeof(ntfschar) + 7) & ~7) + 8;
+			((name_len * sizeof(ntfschar) + 7) & ~7) + 8;
 
 	/*
 	 * If we have enough free space for the new attribute in the base MFT
@@ -4841,11 +4841,11 @@ int ntfs_attr_add(ntfs_inode *ni, ATTR_TYPES type,
 
 add_attr_record:
 	if ((ni->flags & FILE_ATTR_COMPRESSED)
-	    && (ni->vol->major_ver >= 3)
-	    && NVolCompression(ni->vol)
-	    && (ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE)
-	    && ((type == AT_DATA)
-	       || ((type == AT_INDEX_ROOT) && (name == NTFS_INDEX_I30))))
+			&& (ni->vol->major_ver >= 3)
+			&& NVolCompression(ni->vol)
+			&& (ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE)
+			&& ((type == AT_DATA)
+				|| ((type == AT_INDEX_ROOT) && (name == NTFS_INDEX_I30))))
 		data_flags = ATTR_IS_COMPRESSED;
 	else
 		data_flags = const_cpu_to_le16(0);
@@ -4866,7 +4866,7 @@ add_attr_record:
 add_non_resident:
 	/* Add non resident attribute. */
 	offset = ntfs_non_resident_attr_record_add(attr_ni, type, name,
-				name_len, 0, 8, data_flags);
+			name_len, 0, 8, data_flags);
 	if (offset < 0) {
 		err = errno;
 		ntfs_log_perror("Failed to add non resident attribute");
@@ -4900,7 +4900,7 @@ add_non_resident:
 rm_attr_err_out:
 	/* Remove just added attribute. */
 	if (ntfs_attr_record_resize(attr_ni->mrec,
-			(ATTR_RECORD*)((u8*)attr_ni->mrec + offset), 0))
+				(ATTR_RECORD*)((u8*)attr_ni->mrec + offset), 0))
 		ntfs_log_perror("Failed to remove just added attribute #2");
 free_err_out:
 	/* Free MFT record, if it doesn't contain attributes. */
@@ -4931,7 +4931,7 @@ int ntfs_attr_set_flags(ntfs_inode *ni, ATTR_TYPES type, const ntfschar *name,
 					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			/* do the requested change (all small endian le16) */
 			ctx->attr->flags = (ctx->attr->flags & ~mask)
-						| (flags & mask);
+				| (flags & mask);
 			NInoSetDirty(ni);
 			res = 0;
 		}
@@ -4962,7 +4962,7 @@ int ntfs_attr_rm(ntfs_attr *na)
 	}
 
 	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x.\n",
-		(long long) na->ni->mft_no, le32_to_cpu(na->type));
+			(long long) na->ni->mft_no, le32_to_cpu(na->type));
 
 	/* Free cluster allocation. */
 	if (NAttrNonResident(na)) {
@@ -5024,8 +5024,8 @@ int ntfs_attr_record_resize(MFT_RECORD *m, ATTR_RECORD *a, u32 new_size)
 	attr_size  = le32_to_cpu(a->length);
 
 	ntfs_log_trace("Sizes: old=%u alloc=%u attr=%u new=%u\n",
-		       (unsigned)old_size, (unsigned)alloc_size,
-		       (unsigned)attr_size, (unsigned)new_size);
+			(unsigned)old_size, (unsigned)alloc_size,
+			(unsigned)attr_size, (unsigned)new_size);
 
 	/* Align to 8 bytes, just in case the caller hasn't. */
 	new_size = (new_size + 7) & ~7;
@@ -5039,12 +5039,12 @@ int ntfs_attr_record_resize(MFT_RECORD *m, ATTR_RECORD *a, u32 new_size)
 		if (new_muse > alloc_size) {
 			errno = ENOSPC;
 			ntfs_log_trace("Not enough space in the MFT record "
-				       "(%u > %u)\n", new_muse, alloc_size);
+					"(%u > %u)\n", new_muse, alloc_size);
 			return -1;
 		}
 
 		if (a->type == AT_INDEX_ROOT && new_size > attr_size &&
-		    new_muse + 120 > alloc_size && old_size + 120 <= alloc_size) {
+				new_muse + 120 > alloc_size && old_size + 120 <= alloc_size) {
 			errno = ENOSPC;
 			ntfs_log_trace("Too big INDEX_ROOT (%u > %u)\n",
 					new_muse, alloc_size);
@@ -5054,13 +5054,13 @@ int ntfs_attr_record_resize(MFT_RECORD *m, ATTR_RECORD *a, u32 new_size)
 		/* Move attributes following @a to their new location. */
 		if (((u8 *)m + old_size) < ((u8 *)a + attr_size)) {
 			ntfs_log_error("Attribute 0x%x overflows"
-				" from MFT record\n",
-				(int)le32_to_cpu(a->type));
+					" from MFT record\n",
+					(int)le32_to_cpu(a->type));
 			errno = EIO;
 			return (-1);
 		}
 		memmove((u8 *)a + new_size, (u8 *)a + attr_size,
-			old_size - ((u8 *)a - (u8 *)m) - attr_size);
+				old_size - ((u8 *)a - (u8 *)m) - attr_size);
 
 		/* Adjust @m to reflect the change in used space. */
 		m->bytes_in_use = cpu_to_le32(new_muse);
@@ -5094,15 +5094,15 @@ int ntfs_resident_attr_value_resize(MFT_RECORD *m, ATTR_RECORD *a,
 	ntfs_log_trace("Entering for new size %u.\n", (unsigned)new_size);
 
 	if (!a->value_length) {
-			/* Offset is unsafe when no value */
+		/* Offset is unsafe when no value */
 		int offset = ((offsetof(ATTR_RECORD, resident_end)
-			+ a->name_length*sizeof(ntfschar) - 1) | 7) + 1;
+					+ a->name_length*sizeof(ntfschar) - 1) | 7) + 1;
 		a->value_offset = cpu_to_le16(offset);
 	}
 
 	/* Resize the resident part of the attribute record. */
 	if ((ret = ntfs_attr_record_resize(m, a, (le16_to_cpu(a->value_offset) +
-			new_size + 7) & ~7)) < 0)
+						new_size + 7) & ~7)) < 0)
 		return ret;
 	/*
 	 * If we made the attribute value bigger, clear the area between the
@@ -5166,9 +5166,9 @@ int ntfs_attr_record_move_to(ntfs_attr_search_ctx *ctx, ntfs_inode *ni)
 	 * attribute in @ni->mrec, not any extent inode in case if @ni is base
 	 * file record.
 	 */
-	if (!ntfs_attr_find(a->type, (ntfschar*)((u8*)a + le16_to_cpu(
-			a->name_offset)), a->name_length, CASE_SENSITIVE, NULL,
-			0, nctx)) {
+	if (!ntfs_attr_find(a->type,
+			(ntfschar*)((u8*)a + le16_to_cpu(a->name_offset)),
+			a->name_length, CASE_SENSITIVE, NULL, 0, nctx)) {
 		ntfs_log_trace("Attribute of such type, with same name already "
 				"present in this MFT record.\n");
 		err = EEXIST;
@@ -5182,7 +5182,7 @@ int ntfs_attr_record_move_to(ntfs_attr_search_ctx *ctx, ntfs_inode *ni)
 
 	/* Make space and move attribute. */
 	if (ntfs_make_room_for_attr(ni->mrec, (u8*) nctx->attr,
-					le32_to_cpu(a->length))) {
+				le32_to_cpu(a->length))) {
 		err = errno;
 		ntfs_log_trace("Couldn't make space for attribute.\n");
 		goto put_err_out;
@@ -5190,7 +5190,7 @@ int ntfs_attr_record_move_to(ntfs_attr_search_ctx *ctx, ntfs_inode *ni)
 	memcpy(nctx->attr, a, le32_to_cpu(a->length));
 	nctx->attr->instance = nctx->mrec->next_attr_instance;
 	nctx->mrec->next_attr_instance = cpu_to_le16(
-		(le16_to_cpu(nctx->mrec->next_attr_instance) + 1) & 0xffff);
+			(le16_to_cpu(nctx->mrec->next_attr_instance) + 1) & 0xffff);
 	ntfs_attr_record_resize(ctx->mrec, a, 0);
 	ntfs_inode_mark_dirty(ctx->ntfs_ino);
 	ntfs_inode_mark_dirty(ni);
@@ -5323,8 +5323,8 @@ int ntfs_attr_make_non_resident(ntfs_attr *na,
 	runlist *rl;
 	int mp_size, mp_ofs, name_ofs, arec_size, err;
 
-	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x.\n", (unsigned long
-			long)na->ni->mft_no, le32_to_cpu(na->type));
+	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x.\n",
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
 
 	/* Some preliminary sanity checking. */
 	if (NAttrNonResident(na)) {
@@ -5342,13 +5342,12 @@ int ntfs_attr_make_non_resident(ntfs_attr *na,
 			- 1) & ~(vol->cluster_size - 1);
 
 	if (new_allocated_size > 0) {
-			if ((a->flags & ATTR_COMPRESSION_MASK)
-					== ATTR_IS_COMPRESSED) {
-				/* must allocate full compression blocks */
-				new_allocated_size = ((new_allocated_size - 1)
+		if ((a->flags & ATTR_COMPRESSION_MASK) == ATTR_IS_COMPRESSED) {
+			/* must allocate full compression blocks */
+			new_allocated_size = ((new_allocated_size - 1)
 					| ((1L << (STANDARD_COMPRESSION_UNIT
-					   + vol->cluster_size_bits)) - 1)) + 1;
-			}
+								+ vol->cluster_size_bits)) - 1)) + 1;
+		}
 		/* Start by allocating clusters to hold the attribute value. */
 		rl = ntfs_cluster_alloc(vol, 0, new_allocated_size >>
 				vol->cluster_size_bits, -1, DATA_ZONE);
@@ -5372,7 +5371,7 @@ int ntfs_attr_make_non_resident(ntfs_attr *na,
 	NAttrClearSparse(na);
 	NAttrClearEncrypted(na);
 	if ((a->flags & ATTR_COMPRESSION_MASK) == ATTR_IS_COMPRESSED) {
-			/* set compression writing parameters */
+		/* set compression writing parameters */
 		na->compression_block_size
 			= 1 << (STANDARD_COMPRESSION_UNIT + vol->cluster_size_bits);
 		na->compression_block_clusters = 1 << STANDARD_COMPRESSION_UNIT;
@@ -5434,7 +5433,7 @@ int ntfs_attr_make_non_resident(ntfs_attr *na,
 	/* Setup the fields specific to non-resident attributes. */
 	a->lowest_vcn = const_cpu_to_sle64(0);
 	a->highest_vcn = cpu_to_sle64((new_allocated_size - 1) >>
-						vol->cluster_size_bits);
+			vol->cluster_size_bits);
 
 	a->mapping_pairs_offset = cpu_to_le16(mp_ofs);
 
@@ -5447,7 +5446,7 @@ int ntfs_attr_make_non_resident(ntfs_attr *na,
 	 */
 	a->flags &= ~(ATTR_IS_SPARSE | ATTR_IS_ENCRYPTED);
 	if ((a->flags & ATTR_COMPRESSION_MASK) == ATTR_IS_COMPRESSED) {
-			/* support only ATTR_IS_COMPRESSED compression mode */
+		/* support only ATTR_IS_COMPRESSED compression mode */
 		a->compression_unit = STANDARD_COMPRESSION_UNIT;
 		a->compressed_size = const_cpu_to_sle64(0);
 	} else {
@@ -5463,7 +5462,7 @@ int ntfs_attr_make_non_resident(ntfs_attr *na,
 
 	/* Generate the mapping pairs array in the attribute record. */
 	if (ntfs_mapping_pairs_build(vol, (u8*)a + mp_ofs, arec_size - mp_ofs,
-			rl, 0, NULL) < 0) {
+				rl, 0, NULL) < 0) {
 		// FIXME: Eeek! We need rollback! (AIA)
 		ntfs_log_trace("Eeek!  Failed to build mapping pairs.  Leaving "
 				"corrupt attribute record on disk.  In memory "
@@ -5502,15 +5501,15 @@ static int ntfs_resident_attr_resize(ntfs_attr *na, const s64 newsize);
  *
  * On success return 0
  * On error return values are:
- * 	STATUS_RESIDENT_ATTRIBUTE_FILLED_MFT
- * 	STATUS_ERROR - otherwise
+ *	STATUS_RESIDENT_ATTRIBUTE_FILLED_MFT
+ *	STATUS_ERROR - otherwise
  * The following error codes are defined:
  *	ENOMEM - Not enough memory to complete operation.
  *	ERANGE - @newsize is not valid for the attribute type of @na.
  *	ENOSPC - There is no enough space in base mft to resize $ATTRIBUTE_LIST.
  */
 static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
-			hole_type holes)
+		hole_type holes)
 {
 	ntfs_attr_search_ctx *ctx;
 	ntfs_volume *vol;
@@ -5518,15 +5517,15 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 	int err, ret = STATUS_ERROR;
 
 	ntfs_log_trace("Inode 0x%llx attr 0x%x new size %lld\n",
-		       (unsigned long long)na->ni->mft_no, le32_to_cpu(na->type),
-		       (long long)newsize);
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type),
+			(long long)newsize);
 
 	/* Get the attribute record that needs modification. */
 	ctx = ntfs_attr_get_search_ctx(na->ni, NULL);
 	if (!ctx)
 		return -1;
 	if (ntfs_attr_lookup(na->type, na->name, na->name_len, 0, 0, NULL, 0,
-			ctx)) {
+				ctx)) {
 		err = errno;
 		ntfs_log_perror("ntfs_attr_lookup failed");
 		goto put_err_out;
@@ -5551,19 +5550,19 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 	if ((newsize < vol->mft_record_size) && (holes != HOLES_NONRES)) {
 		/* Perform the resize of the attribute record. */
 		if (!(ret = ntfs_resident_attr_value_resize(ctx->mrec, ctx->attr,
-				newsize))) {
+						newsize))) {
 			/* Update attribute size everywhere. */
 			na->data_size = na->initialized_size = newsize;
 			na->allocated_size = (newsize + 7) & ~7;
 			if ((na->data_flags & ATTR_COMPRESSION_MASK)
-			    || NAttrSparse(na))
+					|| NAttrSparse(na))
 				na->compressed_size = na->allocated_size;
 			if (na->ni->mrec->flags & MFT_RECORD_IS_DIRECTORY
-			    ? na->type == AT_INDEX_ROOT && na->name == NTFS_INDEX_I30
-			    : na->type == AT_DATA && na->name == AT_UNNAMED) {
+					? na->type == AT_INDEX_ROOT && na->name == NTFS_INDEX_I30
+					: na->type == AT_DATA && na->name == AT_UNNAMED) {
 				na->ni->data_size = na->data_size;
 				if (((na->data_flags & ATTR_COMPRESSION_MASK)
-					|| NAttrSparse(na))
+							|| NAttrSparse(na))
 						&& NAttrNonResident(na))
 					na->ni->allocated_size
 						= na->compressed_size;
@@ -5597,7 +5596,7 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 			ret = 0;
 			if (newsize != na->data_size) {
 				ntfs_log_error("Cannot change size when"
-					" forcing non-resident\n");
+						" forcing non-resident\n");
 				errno = EIO;
 				ret = STATUS_ERROR;
 			}
@@ -5625,13 +5624,13 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 		 * Check out whether convert is reasonable. Assume that mapping
 		 * pairs will take 8 bytes.
 		 */
-		if (le32_to_cpu(a->length) <= offsetof(ATTR_RECORD,
-				compressed_size) + ((a->name_length *
-				sizeof(ntfschar) + 7) & ~7) + 8)
+		if (le32_to_cpu(a->length) <=
+				offsetof(ATTR_RECORD, compressed_size) +
+				((a->name_length * sizeof(ntfschar) + 7) & ~7) + 8)
 			continue;
 
 		tna = ntfs_attr_open(na->ni, a->type, (ntfschar*)((u8*)a +
-				le16_to_cpu(a->name_offset)), a->name_length);
+					le16_to_cpu(a->name_offset)), a->name_length);
 		if (!tna) {
 			err = errno;
 			ntfs_log_perror("Couldn't open attribute");
@@ -5651,8 +5650,8 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 			NInoFileNameSetDirty(tna->ni);
 		}
 		if (((tna->data_flags & ATTR_COMPRESSION_MASK)
-						== ATTR_IS_COMPRESSED)
-		   && ntfs_attr_pclose(tna)) {
+					== ATTR_IS_COMPRESSED)
+				&& ntfs_attr_pclose(tna)) {
 			err = errno;
 			ntfs_attr_close(tna);
 			goto put_err_out;
@@ -5680,7 +5679,7 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 			return -1;
 		}
 		if (ntfs_inode_free_space(na->ni, offsetof(ATTR_RECORD,
-				non_resident_end) + 8)) {
+						non_resident_end) + 8)) {
 			ntfs_log_perror("Could not free space in MFT record");
 			return -1;
 		}
@@ -5695,7 +5694,7 @@ static int ntfs_resident_attr_resize_i(ntfs_attr *na, const s64 newsize,
 	/* Point search context back to attribute which we need resize. */
 	ntfs_attr_init_search_ctx(ctx, na->ni, NULL);
 	if (ntfs_attr_lookup(na->type, na->name, na->name_len, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		ntfs_log_perror("%s: Attribute lookup failed 2", __FUNCTION__);
 		err = errno;
 		goto put_err_out;
@@ -5824,8 +5823,8 @@ int ntfs_attr_make_resident(ntfs_attr *na, ntfs_attr_search_ctx *ctx)
 	int name_ofs, val_ofs, err = EIO;
 	s64 arec_size, bytes_read;
 
-	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x.\n", (unsigned long
-			long)na->ni->mft_no, le32_to_cpu(na->type));
+	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x.\n",
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
 
 	/* Should be called for the first extent of the attribute. */
 	if (sle64_to_cpu(a->lowest_vcn)) {
@@ -5907,11 +5906,11 @@ int ntfs_attr_make_resident(ntfs_attr *na, ntfs_attr_search_ctx *ctx)
 	 *  to current state of compression flag
 	 */
 	if (!na->data_size
-	    && (na->type == AT_DATA)
-	    && (na->ni->vol->major_ver >= 3)
-	    && NVolCompression(na->ni->vol)
-	    && (na->ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE)
-	    && (na->ni->flags & FILE_ATTR_COMPRESSED)) {
+			&& (na->type == AT_DATA)
+			&& (na->ni->vol->major_ver >= 3)
+			&& NVolCompression(na->ni->vol)
+			&& (na->ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE)
+			&& (na->ni->flags & FILE_ATTR_COMPRESSED)) {
 		a->flags |= ATTR_IS_COMPRESSED;
 		na->data_flags = a->flags;
 	}
@@ -5982,12 +5981,12 @@ int ntfs_attr_make_resident(ntfs_attr *na, ntfs_attr_search_ctx *ctx)
  * update allocated and compressed size.
  */
 static int ntfs_attr_update_meta(ATTR_RECORD *a, ntfs_attr *na, MFT_RECORD *m,
-				hole_type holes, ntfs_attr_search_ctx *ctx)
+		hole_type holes, ntfs_attr_search_ctx *ctx)
 {
 	int sparse, ret = 0;
 
 	ntfs_log_trace("Entering for inode 0x%llx, attr 0x%x\n",
-		       (unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
 
 	if (a->lowest_vcn)
 		goto out;
@@ -6007,17 +6006,17 @@ static int ntfs_attr_update_meta(ATTR_RECORD *a, ntfs_attr *na, MFT_RECORD *m,
 
 	/* Check whether attribute becomes sparse, unless check is delayed. */
 	if ((holes != HOLES_DELAY)
-	    && sparse
-	    && !(a->flags & (ATTR_IS_SPARSE | ATTR_IS_COMPRESSED))) {
+			&& sparse
+			&& !(a->flags & (ATTR_IS_SPARSE | ATTR_IS_COMPRESSED))) {
 		/*
 		 * Move attribute to another mft record, if attribute is too
 		 * small to add compressed_size field to it and we have no
 		 * free space in the current mft record.
 		 */
 		if ((le32_to_cpu(a->length) -
-				le16_to_cpu(a->mapping_pairs_offset) == 8)
-		    && !(le32_to_cpu(m->bytes_allocated) -
-				le32_to_cpu(m->bytes_in_use))) {
+					le16_to_cpu(a->mapping_pairs_offset) == 8)
+				&& !(le32_to_cpu(m->bytes_allocated) -
+					le32_to_cpu(m->bytes_in_use))) {
 
 			if (!NInoAttrList(na->ni)) {
 				ntfs_attr_put_search_ctx(ctx);
@@ -6042,12 +6041,13 @@ static int ntfs_attr_update_meta(ATTR_RECORD *a, ntfs_attr *na, MFT_RECORD *m,
 		NAttrSetSparse(na);
 		a->flags |= ATTR_IS_SPARSE;
 		na->data_flags = a->flags;
-		a->compression_unit = STANDARD_COMPRESSION_UNIT;  /* Windows
-		 set it so, even if attribute is not actually compressed. */
+
+		/* Windows set it so, even if attribute is not actually compressed. */
+		a->compression_unit = STANDARD_COMPRESSION_UNIT;
 
 		memmove((u8*)a + le16_to_cpu(a->name_offset) + 8,
-			(u8*)a + le16_to_cpu(a->name_offset),
-			a->name_length * sizeof(ntfschar));
+				(u8*)a + le16_to_cpu(a->name_offset),
+				a->name_length * sizeof(ntfschar));
 
 		a->name_offset = cpu_to_le16(le16_to_cpu(a->name_offset) + 8);
 
@@ -6057,7 +6057,7 @@ static int ntfs_attr_update_meta(ATTR_RECORD *a, ntfs_attr *na, MFT_RECORD *m,
 
 	/* Attribute no longer sparse. */
 	if (!sparse && (a->flags & ATTR_IS_SPARSE) &&
-	    !(a->flags & ATTR_IS_COMPRESSED)) {
+			!(a->flags & ATTR_IS_COMPRESSED)) {
 
 		NAttrClearSparse(na);
 		a->flags &= ~ATTR_IS_SPARSE;
@@ -6065,8 +6065,8 @@ static int ntfs_attr_update_meta(ATTR_RECORD *a, ntfs_attr *na, MFT_RECORD *m,
 		a->compression_unit = 0;
 
 		memmove((u8*)a + le16_to_cpu(a->name_offset) - 8,
-			(u8*)a + le16_to_cpu(a->name_offset),
-			a->name_length * sizeof(ntfschar));
+				(u8*)a + le16_to_cpu(a->name_offset),
+				a->name_length * sizeof(ntfschar));
 
 		if (le16_to_cpu(a->name_offset) >= 8)
 			a->name_offset = cpu_to_le16(le16_to_cpu(a->name_offset) - 8);
@@ -6077,7 +6077,7 @@ static int ntfs_attr_update_meta(ATTR_RECORD *a, ntfs_attr *na, MFT_RECORD *m,
 
 	/* Update compressed size if required. */
 	if (NAttrFullyMapped(na)
-	    && (sparse || (na->data_flags & ATTR_COMPRESSION_MASK))) {
+			&& (sparse || (na->data_flags & ATTR_COMPRESSION_MASK))) {
 		s64 new_compr_size;
 
 		new_compr_size = ntfs_rl_get_compressed_size(na->ni->vol, na->rl);
@@ -6110,7 +6110,7 @@ error:  ret = -3; goto out;
  * ntfs_attr_update_mapping_pairs_i - see ntfs_attr_update_mapping_pairs
  */
 static int ntfs_attr_update_mapping_pairs_i(ntfs_attr *na, VCN from_vcn,
-					hole_type holes)
+		hole_type holes)
 {
 	ntfs_attr_search_ctx *ctx;
 	ntfs_inode *ni, *base_ni;
@@ -6130,7 +6130,7 @@ retry:
 	}
 
 	ntfs_log_trace("Entering for inode %llu, attr 0x%x\n",
-		       (unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type));
 
 	if (!NAttrNonResident(na)) {
 		errno = EINVAL;
@@ -6139,27 +6139,27 @@ retry:
 	}
 
 #if PARTIAL_RUNLIST_UPDATING
-		/*
-		 * For a file just been made sparse, we will have
-		 * to reformat the first extent, so be sure the
-		 * runlist is fully mapped and fully processed.
-		 * Same if the file was sparse and is not any more.
-		 * Note : not needed if the full runlist is to be processed
-		 */
+	/*
+	 * For a file just been made sparse, we will have
+	 * to reformat the first extent, so be sure the
+	 * runlist is fully mapped and fully processed.
+	 * Same if the file was sparse and is not any more.
+	 * Note : not needed if the full runlist is to be processed
+	 */
 	if ((holes != HOLES_DELAY)
-	   && (!NAttrFullyMapped(na) || from_vcn)
-	   && !(na->data_flags & ATTR_IS_COMPRESSED)) {
+			&& (!NAttrFullyMapped(na) || from_vcn)
+			&& !(na->data_flags & ATTR_IS_COMPRESSED)) {
 		BOOL changed;
 
 		if (!(na->data_flags & ATTR_IS_SPARSE)) {
 			int sparse = 0;
 			runlist_element *xrl;
 
-				/*
-				 * If attribute was not sparse, we only
-				 * have to check whether there is a hole
-				 * in the updated region.
-				 */
+			/*
+			 * If attribute was not sparse, we only
+			 * have to check whether there is a hole
+			 * in the updated region.
+			 */
 			for (xrl = na->rl; xrl->length; xrl++) {
 				if (xrl->lcn < 0) {
 					if (xrl->lcn == LCN_HOLE) {
@@ -6179,14 +6179,14 @@ retry:
 			}
 			changed = sparse > 0;
 		} else {
-				/*
-				 * If attribute was sparse, the compressed
-				 * size has been maintained, and it gives
-				 * and easy way to check whether the
-				 * attribute is still sparse.
-				 */
+			/*
+			 * If attribute was sparse, the compressed
+			 * size has been maintained, and it gives
+			 * and easy way to check whether the
+			 * attribute is still sparse.
+			 */
 			changed = (((na->data_size - 1)
-					| (na->ni->vol->cluster_size - 1)) + 1)
+						| (na->ni->vol->cluster_size - 1)) + 1)
 				== na->compressed_size;
 		}
 		if (changed) {
@@ -6253,8 +6253,8 @@ retry:
 		 */
 		if (finished_build) {
 			ntfs_log_trace("Mark attr 0x%x for delete in inode "
-				"%lld.\n", (unsigned)le32_to_cpu(a->type),
-				(long long)ctx->ntfs_ino->mft_no);
+					"%lld.\n", (unsigned)le32_to_cpu(a->type),
+					(long long)ctx->ntfs_ino->mft_no);
 			a->highest_vcn = cpu_to_sle64(NTFS_VCN_DELETE_MARK);
 			ntfs_inode_mark_dirty(ctx->ntfs_ino);
 			continue;
@@ -6271,17 +6271,17 @@ retry:
 		 * if we shall *not* expand space for mapping pairs.
 		 */
 		cur_max_mp_size = le32_to_cpu(a->length) -
-				le16_to_cpu(a->mapping_pairs_offset);
+			le16_to_cpu(a->mapping_pairs_offset);
 		/*
 		 * Determine maximum possible length of mapping pairs in the
 		 * current mft record, if we shall expand space for mapping
 		 * pairs.
 		 */
 		exp_max_mp_size = le32_to_cpu(m->bytes_allocated) -
-				le32_to_cpu(m->bytes_in_use) + cur_max_mp_size;
+			le32_to_cpu(m->bytes_in_use) + cur_max_mp_size;
 		/* Get the size for the rest of mapping pairs array. */
 		mp_size = ntfs_get_size_for_mapping_pairs(na->ni->vol, stop_rl,
-						stop_vcn, exp_max_mp_size);
+				stop_vcn, exp_max_mp_size);
 		if (mp_size <= 0) {
 			ntfs_log_perror("%s: get MP size failed", __FUNCTION__);
 			goto put_err_out;
@@ -6339,7 +6339,7 @@ retry:
 		ntfs_inode_mark_dirty(ctx->ntfs_ino);
 		if ((ctx->ntfs_ino->nr_extents == -1 ||
 					NInoAttrList(ctx->ntfs_ino)) &&
-					ctx->attr->type != AT_ATTRIBUTE_LIST) {
+				ctx->attr->type != AT_ATTRIBUTE_LIST) {
 			ctx->al_entry->lowest_vcn = cpu_to_sle64(stop_vcn);
 			ntfs_attrlist_mark_dirty(ctx->ntfs_ino);
 		}
@@ -6348,9 +6348,9 @@ retry:
 		 * Generate the new mapping pairs array directly into the
 		 * correct destination, i.e. the attribute record itself.
 		 */
-		if (!ntfs_mapping_pairs_build(na->ni->vol, (u8*)a + le16_to_cpu(
-				a->mapping_pairs_offset), mp_size, na->rl,
-				stop_vcn, &stop_rl))
+		if (!ntfs_mapping_pairs_build(na->ni->vol,
+					(u8*)a + le16_to_cpu(a->mapping_pairs_offset),
+					mp_size, na->rl, stop_vcn, &stop_rl))
 			finished_build = TRUE;
 		if (stop_rl)
 			stop_vcn = stop_rl->vcn;
@@ -6367,16 +6367,16 @@ retry:
 		ntfs_log_perror("%s: Attribute lookup failed", __FUNCTION__);
 		goto put_err_out;
 	}
-		/*
-		 * If the base extent was skipped in the above process,
-		 * we still may have to update the sizes.
-		 */
+	/*
+	 * If the base extent was skipped in the above process,
+	 * we still may have to update the sizes.
+	 */
 	if (!first_updated) {
 		le16 spcomp;
 
 		ntfs_attr_reinit_search_ctx(ctx);
 		if (!ntfs_attr_lookup(na->type, na->name, na->name_len,
-				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			a = ctx->attr;
 			a->allocated_size = cpu_to_sle64(na->allocated_size);
 			spcomp = na->data_flags
@@ -6404,9 +6404,9 @@ retry:
 		ntfs_attr_reinit_search_ctx(ctx);
 		ntfs_log_trace("Deallocate marked extents.\n");
 		while (!ntfs_attr_lookup(na->type, na->name, na->name_len,
-				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			if (sle64_to_cpu(ctx->attr->highest_vcn) !=
-							NTFS_VCN_DELETE_MARK)
+					NTFS_VCN_DELETE_MARK)
 				continue;
 			/* Remove unused attribute record. */
 			if (ntfs_attr_record_rm(ctx)) {
@@ -6430,7 +6430,7 @@ retry:
 	while (1) {
 		/* Calculate size of rest mapping pairs. */
 		mp_size = ntfs_get_size_for_mapping_pairs(na->ni->vol,
-						na->rl, stop_vcn, INT_MAX);
+				na->rl, stop_vcn, INT_MAX);
 		if (mp_size <= 0) {
 			ntfs_log_perror("%s: get mp size failed", __FUNCTION__);
 			goto put_err_out;
@@ -6438,7 +6438,7 @@ retry:
 		/* Allocate new mft record, with special case for mft itself */
 		if (!na->ni->mft_no)
 			ni = ntfs_mft_rec_alloc(na->ni->vol,
-				na->type == AT_DATA);
+					na->type == AT_DATA);
 		else
 			ni = ntfs_mft_record_alloc(na->ni->vol, base_ni);
 		if (!ni) {
@@ -6451,18 +6451,18 @@ retry:
 		 * possible maximum.
 		 */
 		cur_max_mp_size = le32_to_cpu(m->bytes_allocated) -
-				le32_to_cpu(m->bytes_in_use) -
-				(offsetof(ATTR_RECORD, compressed_size) +
-				(((na->data_flags & ATTR_COMPRESSION_MASK)
-				    || NAttrSparse(na)) ?
-				sizeof(a->compressed_size) : 0)) -
-				((sizeof(ntfschar) * na->name_len + 7) & ~7);
+			le32_to_cpu(m->bytes_in_use) -
+			(offsetof(ATTR_RECORD, compressed_size) +
+			 (((na->data_flags & ATTR_COMPRESSION_MASK)
+			   || NAttrSparse(na)) ?
+			  sizeof(a->compressed_size) : 0)) -
+			((sizeof(ntfschar) * na->name_len + 7) & ~7);
 		if (mp_size > cur_max_mp_size)
 			mp_size = cur_max_mp_size;
 		/* Add attribute extent to new record. */
 		err = ntfs_non_resident_attr_record_add(ni, na->type,
-			na->name, na->name_len, stop_vcn, mp_size,
-			na->data_flags);
+				na->name, na->name_len, stop_vcn, mp_size,
+				na->data_flags);
 		if (err == -1) {
 			err = errno;
 			ntfs_log_perror("Could not add attribute extent");
@@ -6474,8 +6474,8 @@ retry:
 		a = (ATTR_RECORD*)((u8*)m + err);
 
 		err = ntfs_mapping_pairs_build(na->ni->vol, (u8*)a +
-			le16_to_cpu(a->mapping_pairs_offset), mp_size, na->rl,
-			stop_vcn, &stop_rl);
+				le16_to_cpu(a->mapping_pairs_offset), mp_size, na->rl,
+				stop_vcn, &stop_rl);
 		if (stop_rl)
 			stop_vcn = stop_rl->vcn;
 		else
@@ -6562,7 +6562,7 @@ int ntfs_non_resident_attr_shrink(ntfs_attr *na, const s64 newsize)
 	int err;
 
 	ntfs_log_trace("Inode 0x%llx attr 0x%x new size %lld\n", (unsigned long long)
-		       na->ni->mft_no, le32_to_cpu(na->type), (long long)newsize);
+			na->ni->mft_no, le32_to_cpu(na->type), (long long)newsize);
 
 	vol = na->ni->vol;
 
@@ -6588,11 +6588,11 @@ int ntfs_non_resident_attr_shrink(ntfs_attr *na, const s64 newsize)
 		 * clusters than really needed.
 		 */
 		first_free_vcn = (((newsize - 1)
-				 | (na->compression_block_size - 1)) + 1)
-				   >> vol->cluster_size_bits;
+					| (na->compression_block_size - 1)) + 1)
+			>> vol->cluster_size_bits;
 	else
 		first_free_vcn = (newsize + vol->cluster_size - 1) >>
-				vol->cluster_size_bits;
+			vol->cluster_size_bits;
 	/*
 	 * Compare the new allocation with the old one and only deallocate
 	 * clusters if there is a change.
@@ -6642,7 +6642,7 @@ int ntfs_non_resident_attr_shrink(ntfs_attr *na, const s64 newsize)
 		return -1;
 
 	if (ntfs_attr_lookup(na->type, na->name, na->name_len, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		err = errno;
 		if (err == ENOENT)
 			err = EIO;
@@ -6675,7 +6675,7 @@ int ntfs_non_resident_attr_shrink(ntfs_attr *na, const s64 newsize)
 	/* If the attribute now has zero size, make it resident. */
 	if (!newsize) {
 		if (!(na->data_flags & ATTR_IS_ENCRYPTED)
-		    && ntfs_attr_make_resident(na, ctx)) {
+				&& ntfs_attr_make_resident(na, ctx)) {
 			/* If couldn't make resident, just continue. */
 			if (errno != EPERM)
 				ntfs_log_error("Failed to make attribute "
@@ -6709,7 +6709,7 @@ put_err_out:
  *	ENOSPC - There is no enough space in base mft to resize $ATTRIBUTE_LIST.
  */
 static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
-					hole_type holes)
+		hole_type holes)
 {
 	LCN lcn_seek_from;
 	VCN first_free_vcn;
@@ -6742,7 +6742,7 @@ static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
 	org_alloc_size = na->allocated_size;
 	/* The first cluster outside the new allocation. */
 	first_free_vcn = (newsize + vol->cluster_size - 1) >>
-			vol->cluster_size_bits;
+		vol->cluster_size_bits;
 	/*
 	 * Compare the new allocation with the old one and only allocate
 	 * clusters if there is a change.
@@ -6774,7 +6774,7 @@ static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
 		 * sparse runs instead of real allocation of clusters.
 		 */
 		if ((na->type == AT_DATA) && (vol->major_ver >= 3)
-					 && (holes != HOLES_NO)) {
+				&& (holes != HOLES_NO)) {
 			rl = ntfs_malloc(0x1000);
 			if (!rl)
 				return -1;
@@ -6816,7 +6816,7 @@ static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
 			rl = ntfs_cluster_alloc(vol, na->allocated_size >>
 					vol->cluster_size_bits, first_free_vcn -
 					(na->allocated_size >>
-					vol->cluster_size_bits), lcn_seek_from,
+					 vol->cluster_size_bits), lcn_seek_from,
 					DATA_ZONE);
 			if (!rl) {
 				ntfs_log_perror("Cluster allocation failed "
@@ -6851,9 +6851,8 @@ static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
 		 * If the update is not done, we must be sure to do
 		 * it later, and to get to a clean state even on errors.
 		 */
-		if ((holes != HOLES_DELAY)
-		   && ntfs_attr_update_mapping_pairs_i(na, start_update,
-					holes)) {
+		if ((holes != HOLES_DELAY) &&
+			ntfs_attr_update_mapping_pairs_i(na, start_update, holes)) {
 #else
 		/* Write mapping pairs for new runlist. */
 		if (ntfs_attr_update_mapping_pairs(na, 0)) {
@@ -6875,7 +6874,7 @@ static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
 	}
 
 	if (ntfs_attr_lookup(na->type, na->name, na->name_len, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		err = errno;
 		ntfs_log_perror("Lookup of first attribute extent failed");
 		if (err == ENOENT)
@@ -6911,13 +6910,13 @@ static int ntfs_non_resident_attr_expand_i(ntfs_attr *na, const s64 newsize,
 rollback:
 	/* Free allocated clusters. */
 	if (ntfs_cluster_free(vol, na, org_alloc_size >>
-			vol->cluster_size_bits, -1) < 0) {
+				vol->cluster_size_bits, -1) < 0) {
 		err = EIO;
 		ntfs_log_perror("Leaking clusters");
 	}
 	/* Now, truncate the runlist itself. */
 	if (ntfs_rl_truncate(&na->rl, org_alloc_size >>
-			vol->cluster_size_bits)) {
+				vol->cluster_size_bits)) {
 		/*
 		 * Failed to truncate the runlist, so just throw it away, it
 		 * will be mapped afresh on next use.
@@ -6931,7 +6930,7 @@ rollback:
 		na->allocated_size = org_alloc_size;
 		/* Restore mapping pairs. */
 		if (ntfs_attr_update_mapping_pairs(na, 0 /*na->allocated_size >>
-					vol->cluster_size_bits*/)) {
+				   vol->cluster_size_bits*/)) {
 			ntfs_log_perror("Failed to restore old mapping pairs");
 		}
 	}
@@ -6945,7 +6944,7 @@ put_err_out:
 
 
 static int ntfs_non_resident_attr_expand(ntfs_attr *na, const s64 newsize,
-				hole_type holes)
+		hole_type holes)
 {
 	int ret;
 
@@ -6977,7 +6976,7 @@ static int ntfs_non_resident_attr_expand(ntfs_attr *na, const s64 newsize,
  * 	EACCES     - Encrypted attribute.
  */
 static int ntfs_attr_truncate_i(ntfs_attr *na, const s64 newsize,
-					hole_type holes)
+		hole_type holes)
 {
 	int ret = STATUS_ERROR;
 	s64 fullsize;
@@ -6991,8 +6990,8 @@ static int ntfs_attr_truncate_i(ntfs_attr *na, const s64 newsize,
 	}
 
 	ntfs_log_enter("Entering for inode %lld, attr 0x%x, size %lld\n",
-		       (unsigned long long)na->ni->mft_no, le32_to_cpu(na->type),
-		       (long long)newsize);
+			(unsigned long long)na->ni->mft_no, le32_to_cpu(na->type),
+			(long long)newsize);
 
 	if (na->data_size == newsize) {
 		ntfs_log_trace("Size is already ok\n");
@@ -7016,10 +7015,10 @@ static int ntfs_attr_truncate_i(ntfs_attr *na, const s64 newsize,
 	 * (important case : $INDEX_ROOT:$I30)
 	 */
 	compressed = (na->data_flags & ATTR_COMPRESSION_MASK)
-			 != const_cpu_to_le16(0);
+		!= const_cpu_to_le16(0);
 	if (compressed
-	   && NAttrNonResident(na)
-	   && ((na->data_flags & ATTR_COMPRESSION_MASK) != ATTR_IS_COMPRESSED)) {
+			&& NAttrNonResident(na)
+			&& ((na->data_flags & ATTR_COMPRESSION_MASK) != ATTR_IS_COMPRESSED)) {
 		errno = EOPNOTSUPP;
 		ntfs_log_perror("Failed to truncate compressed attribute");
 		goto out;
@@ -7038,12 +7037,12 @@ static int ntfs_attr_truncate_i(ntfs_attr *na, const s64 newsize,
 		 */
 		if (compressed && newsize && (newsize > na->data_size))
 			fullsize = (na->initialized_size
-				 | (na->compression_block_size - 1)) + 1;
+					| (na->compression_block_size - 1)) + 1;
 		else
 			fullsize = newsize;
 		if (fullsize > na->data_size)
 			ret = ntfs_non_resident_attr_expand(na, fullsize,
-								holes);
+					holes);
 		else
 			ret = ntfs_non_resident_attr_shrink(na, fullsize);
 	} else
@@ -7095,24 +7094,24 @@ static int stuff_hole(ntfs_attr *na, const s64 pos)
 	int ret;
 
 	ret = 0;
-		/*
-		 * If the attribute is resident, the compression block size
-		 * is not defined yet and we can make no decision.
-		 * So we first try resizing to the target and if the
-		 * attribute is still resident, we're done
-		 */
+	/*
+	 * If the attribute is resident, the compression block size
+	 * is not defined yet and we can make no decision.
+	 * So we first try resizing to the target and if the
+	 * attribute is still resident, we're done
+	 */
 	if (!NAttrNonResident(na)) {
 		ret = ntfs_resident_attr_resize(na, pos);
 		if (!ret && !NAttrNonResident(na))
 			na->initialized_size = na->data_size = pos;
 	}
 	if (!ret && NAttrNonResident(na)) {
-			/* does the hole span over several compression block ? */
+		/* does the hole span over several compression block ? */
 		if ((pos ^ na->initialized_size)
 				& ~(na->compression_block_size - 1)) {
 			begin_size = ((na->initialized_size - 1)
 					| (na->compression_block_size - 1))
-					+ 1 - na->initialized_size;
+				+ 1 - na->initialized_size;
 			end_size = pos & (na->compression_block_size - 1);
 			size = (begin_size > end_size ? begin_size : end_size);
 		} else {
@@ -7126,37 +7125,37 @@ static int stuff_hole(ntfs_attr *na, const s64 pos)
 			buf = (char*)NULL;
 		if (buf || !size) {
 			memset(buf,0,size);
-				/* stuff into current block */
+			/* stuff into current block */
 			if (begin_size
-			    && (ntfs_attr_pwrite(na,
-				na->initialized_size, begin_size, buf)
-				   != begin_size))
+					&& (ntfs_attr_pwrite(na,
+							na->initialized_size, begin_size, buf)
+						!= begin_size))
 				ret = -1;
-				/* create an unstuffed hole */
+			/* create an unstuffed hole */
 			if (!ret
-			    && ((na->initialized_size + end_size) < pos)
-			    && ntfs_non_resident_attr_expand(na,
-					pos - end_size, HOLES_OK))
+					&& ((na->initialized_size + end_size) < pos)
+					&& ntfs_non_resident_attr_expand(na,
+						pos - end_size, HOLES_OK))
 				ret = -1;
 			else
 				na->initialized_size
-				    = na->data_size = pos - end_size;
-				/* stuff into the target block */
+					= na->data_size = pos - end_size;
+			/* stuff into the target block */
 			if (!ret && end_size
-			    && (ntfs_attr_pwrite(na,
-				na->initialized_size, end_size, buf)
-				    != end_size))
+					&& (ntfs_attr_pwrite(na,
+							na->initialized_size, end_size, buf)
+						!= end_size))
 				ret = -1;
 			if (buf)
 				free(buf);
 		} else
 			ret = -1;
 	}
-		/* make absolutely sure we have reached the target */
+	/* make absolutely sure we have reached the target */
 	if (!ret && (na->initialized_size != pos)) {
 		ntfs_log_error("Failed to stuff a compressed file"
-			"target %lld reached %lld\n",
-			(long long)pos, (long long)na->initialized_size);
+				"target %lld reached %lld\n",
+				(long long)pos, (long long)na->initialized_size);
 		errno = EIO;
 		ret = -1;
 	}
@@ -7183,7 +7182,7 @@ static int stuff_hole(ntfs_attr *na, const s64 pos)
  * On error NULL is returned with errno set to the error code.
  */
 void *ntfs_attr_readall(ntfs_inode *ni, const ATTR_TYPES type,
-			ntfschar *name, u32 name_len, s64 *data_size)
+		ntfschar *name, u32 name_len, s64 *data_size)
 {
 	ntfs_attr *na;
 	void *data, *ret = NULL;
@@ -7197,15 +7196,15 @@ void *ntfs_attr_readall(ntfs_inode *ni, const ATTR_TYPES type,
 				(long long)ni->mft_no,(long)le32_to_cpu(type));
 		goto err_exit;
 	}
-		/*
-		 * Consistency check : restrict to 65536 bytes.
-		 *   index bitmaps may need more, but still limited by
-		 *   the number of clusters.
-		 */
+	/*
+	 * Consistency check : restrict to 65536 bytes.
+	 *   index bitmaps may need more, but still limited by
+	 *   the number of clusters.
+	 */
 	if (((u64)na->data_size > 65536)
-	    && ((type != AT_BITMAP)
-		|| ((u64)na->data_size >
-			(u64)((ni->vol->nr_clusters + 7) >> 3)))) {
+			&& ((type != AT_BITMAP)
+				|| ((u64)na->data_size >
+					(u64)((ni->vol->nr_clusters + 7) >> 3)))) {
 		ntfs_log_error("Corrupt attribute 0x%lx in inode %lld\n",
 				(long)le32_to_cpu(type),(long long)ni->mft_no);
 		errno = EOVERFLOW;
@@ -7256,9 +7255,9 @@ int ntfs_attr_data_read(ntfs_inode *ni,
 			res = ntfs_attr_pread(na, offset, size, buf + total);
 			if ((off_t)res < (off_t)size)
 				ntfs_log_perror("ntfs_attr_pread partial read "
-					"(%lld : %lld <> %d)",
-					(long long)offset,
-					(long long)size, res);
+						"(%lld : %lld <> %d)",
+						(long long)offset,
+						(long long)size, res);
 			if (res <= 0) {
 				res = -errno;
 				goto exit;
@@ -7297,8 +7296,8 @@ int ntfs_attr_data_write(ntfs_inode *ni, ntfschar *stream_name,
 		res = ntfs_attr_pwrite(na, offset, size, buf + total);
 		if (res < (s64)size)
 			ntfs_log_perror("ntfs_attr_pwrite partial write (%lld: "
-				"%lld <> %d)", (long long)offset,
-				(long long)size, res);
+					"%lld <> %d)", (long long)offset,
+					(long long)size, res);
 		if (res <= 0) {
 			res = -errno;
 			goto exit;
@@ -7336,11 +7335,11 @@ int ntfs_attr_shrink_size(ntfs_inode *ni, ntfschar *stream_name,
 	ctx = ntfs_attr_get_search_ctx(ni, NULL);
 	if (ctx) {
 		if (!ntfs_attr_lookup(AT_DATA, stream_name, stream_name_len,
-			CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			a = ctx->attr;
 
 			if (a->non_resident
-			    && (sle64_to_cpu(a->initialized_size) > offset)) {
+					&& (sle64_to_cpu(a->initialized_size) > offset)) {
 				a->initialized_size = cpu_to_sle64(offset);
 				a->data_size = a->initialized_size;
 			}
@@ -7352,7 +7351,7 @@ int ntfs_attr_shrink_size(ntfs_inode *ni, ntfschar *stream_name,
 }
 
 int ntfs_attr_exist(ntfs_inode *ni, const ATTR_TYPES type, const ntfschar *name,
-		    u32 name_len)
+		u32 name_len)
 {
 	ntfs_attr_search_ctx *ctx;
 	int ret;
@@ -7364,7 +7363,7 @@ int ntfs_attr_exist(ntfs_inode *ni, const ATTR_TYPES type, const ntfschar *name,
 		return 0;
 
 	ret = ntfs_attr_lookup(type, name, name_len, CASE_SENSITIVE, 0, NULL, 0,
-			       ctx);
+			ctx);
 
 	ntfs_attr_put_search_ctx(ctx);
 
@@ -7372,7 +7371,7 @@ int ntfs_attr_exist(ntfs_inode *ni, const ATTR_TYPES type, const ntfschar *name,
 }
 
 int ntfs_attr_remove(ntfs_inode *ni, const ATTR_TYPES type, ntfschar *name,
-		     u32 name_len)
+		u32 name_len)
 {
 	ntfs_attr *na;
 	int ret;
@@ -7387,10 +7386,10 @@ int ntfs_attr_remove(ntfs_inode *ni, const ATTR_TYPES type, ntfschar *name,
 
 	na = ntfs_attr_open(ni, type, name, name_len);
 	if (!na) {
-			/* do not log removal of non-existent stream */
+		/* do not log removal of non-existent stream */
 		if (type != AT_DATA) {
 			ntfs_log_perror("Failed to open attribute 0x%02x of inode "
-				"0x%llx", le32_to_cpu(type), (unsigned long long)ni->mft_no);
+					"0x%llx", le32_to_cpu(type), (unsigned long long)ni->mft_no);
 		}
 		return -1;
 	}
@@ -7406,8 +7405,8 @@ int ntfs_attr_remove(ntfs_inode *ni, const ATTR_TYPES type, ntfschar *name,
 
 /* Below macros are 32-bit ready. */
 #define BCX(x) ((x) - (((x) >> 1) & 0x77777777) - \
-		      (((x) >> 2) & 0x33333333) - \
-		      (((x) >> 3) & 0x11111111))
+				(((x) >> 2) & 0x33333333) - \
+				(((x) >> 3) & 0x11111111))
 #define BITCOUNT(x) (((BCX(x) + (BCX(x) >> 4)) & 0x0F0F0F0F) % 255)
 
 static u8 *ntfs_init_lut256(void)
@@ -7446,9 +7445,9 @@ s64 ntfs_attr_get_free_bits(ntfs_attr *na)
 		p = (u32 *)buf + br / 4 - 1;
 		for (; (u8 *)p >= buf; p--) {
 			nr_free += lut[ *p        & 255] +
-			           lut[(*p >>  8) & 255] +
-			           lut[(*p >> 16) & 255] +
-			           lut[(*p >> 24)      ];
+				lut[(*p >>  8) & 255] +
+				lut[(*p >> 16) & 255] +
+				lut[(*p >> 24)      ];
 		}
 		switch (br % 4) {
 			case 3:  nr_free += lut[*(buf + br - 3)];

--- a/libntfs/attrlist.c
+++ b/libntfs/attrlist.c
@@ -147,13 +147,17 @@ int ntfs_attrlist_entry_add(ntfs_inode *ni, ATTR_RECORD *attr)
 		err = errno;
 		goto err_out;
 	}
-	if (!ntfs_attr_lookup(attr->type, (attr->name_length) ? (ntfschar*)
-			((u8*)attr + le16_to_cpu(attr->name_offset)) :
-			AT_UNNAMED, attr->name_length, CASE_SENSITIVE,
-			(attr->non_resident) ? sle64_to_cpu(attr->lowest_vcn) :
-			0, (attr->non_resident) ? NULL : ((u8*)attr +
-			le16_to_cpu(attr->value_offset)), (attr->non_resident) ?
-			0 : le32_to_cpu(attr->value_length), ctx)) {
+	if (!ntfs_attr_lookup(attr->type,
+				(attr->name_length) ?
+					(ntfschar*) ((u8*)attr + le16_to_cpu(attr->name_offset)) :
+					AT_UNNAMED,
+				attr->name_length, CASE_SENSITIVE,
+				(attr->non_resident) ?
+					sle64_to_cpu(attr->lowest_vcn) : 0,
+				(attr->non_resident) ?
+					NULL : ((u8*)attr + le16_to_cpu(attr->value_offset)),
+				(attr->non_resident) ?
+					0 : le32_to_cpu(attr->value_length), ctx)) {
 		/* Found some extent, check it to be before new extent. */
 		if (ctx->al_entry->lowest_vcn == attr->lowest_vcn) {
 			err = EEXIST;
@@ -294,8 +298,9 @@ int ntfs_attrlist_entry_rm(ntfs_attr_search_ctx *ctx)
 
 	/* Copy entries from old attribute list to new. */
 	memcpy(new_al, base_ni->attr_list, (u8*)ale - base_ni->attr_list);
-	memcpy(new_al + ((u8*)ale - base_ni->attr_list), (u8*)ale + le16_to_cpu(
-		ale->length), new_al_len - ((u8*)ale - base_ni->attr_list));
+	memcpy(new_al + ((u8*)ale - base_ni->attr_list),
+			(u8*)ale + le16_to_cpu(ale->length),
+			new_al_len - ((u8*)ale - base_ni->attr_list));
 
 	/* Set new runlist. */
 	free(base_ni->attr_list);

--- a/libntfs/bitmap.c
+++ b/libntfs/bitmap.c
@@ -47,8 +47,8 @@
 
 /* GENMASK macro from linux code */
 #define GENMASK(h, l) \
-	 (((~(0UL)) - ((1UL) << (l)) + 1) & \
-	  (~(0UL) >> (BITS_PER_LONG - 1 - (h))))
+	(((~(0UL)) - ((1UL) << (l)) + 1) & \
+	 (~(0UL) >> (BITS_PER_LONG - 1 - (h))))
 
 #define BITMAP_FIRST_WORD_MASK(start) (~0UL << ((start) & (BITS_PER_LONG - 1)))
 #define BITMAP_LAST_WORD_MASK(nbits) (~0UL >> (-(nbits) & (BITS_PER_LONG - 1)))
@@ -121,7 +121,7 @@ char ntfs_bit_get_and_set(u8 *bitmap, const u64 bit, const u8 new_value)
  * On success return 0 and on error return -1 with errno set to the error code.
  */
 static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
-				       s64 count, int value)
+		s64 count, int value)
 {
 	s64 bufsize, br, tmp;
 	u8 *buf, *lastbyte_buf;
@@ -130,7 +130,7 @@ static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
 	if (!na || start_bit < 0 || count < 0) {
 		errno = EINVAL;
 		ntfs_log_perror("%s: Invalid argument (%p, %lld, %lld)",
-			__FUNCTION__, na, (long long)start_bit, (long long)count);
+				__FUNCTION__, na, (long long)start_bit, (long long)count);
 		return -1;
 	}
 
@@ -200,8 +200,8 @@ static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
 					if (br >= 0)
 						errno = EIO;
 					ntfs_log_perror("Reading of last byte "
-						"failed (%lld). Leaving inconsistent "
-						"metadata", (long long)br);
+							"failed (%lld). Leaving inconsistent "
+							"metadata", (long long)br);
 					goto free_err_out;
 				}
 				/* and set/clear the appropriate bits in it. */
@@ -226,8 +226,8 @@ static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
 			if (br >= 0)
 				errno = EIO;
 			ntfs_log_perror("Failed to write buffer to bitmap "
-				"(%lld != %lld). Leaving inconsistent metadata",
-				(long long)br, (long long)bufsize);
+					"(%lld != %lld). Leaving inconsistent metadata",
+					(long long)br, (long long)bufsize);
 			goto free_err_out;
 		}
 
@@ -249,8 +249,8 @@ static int ntfs_bitmap_set_bits_in_run(ntfs_attr *na, s64 start_bit,
 		if (lastbyte && count != 0) {
 			// FIXME: Eeek! BUG!
 			ntfs_log_error("Last buffer but count is not zero "
-				       "(%lld). Leaving inconsistent metadata.\n",
-				       (long long)count);
+					"(%lld). Leaving inconsistent metadata.\n",
+					(long long)count);
 			errno = EIO;
 			goto free_err_out;
 		}
@@ -279,7 +279,7 @@ int ntfs_bitmap_set_run(ntfs_attr *na, s64 start_bit, s64 count)
 	int ret;
 
 	ntfs_log_enter("Set from bit %lld, count %lld\n",
-		       (long long)start_bit, (long long)count);
+			(long long)start_bit, (long long)count);
 	ret = ntfs_bitmap_set_bits_in_run(na, start_bit, count, 1);
 	ntfs_log_leave("\n");
 	return ret;
@@ -301,7 +301,7 @@ int ntfs_bitmap_clear_run(ntfs_attr *na, s64 start_bit, s64 count)
 	int ret;
 
 	ntfs_log_enter("Clear from bit %lld, count %lld\n",
-		       (long long)start_bit, (long long)count);
+			(long long)start_bit, (long long)count);
 	ret = ntfs_bitmap_set_bits_in_run(na, start_bit, count, 0);
 	ntfs_log_leave("\n");
 	return ret;
@@ -434,7 +434,7 @@ unsigned long ntfs_find_first_zero_bit(const unsigned long *addr, unsigned long 
  */
 static inline
 unsigned long ntfs_find_next_zero_bit(const unsigned long *addr, unsigned long size,
-				 unsigned long offset)
+		unsigned long offset)
 {
 	if (size > 0 && size <= BITS_PER_LONG) {
 		unsigned long val;

--- a/libntfs/bootsect.c
+++ b/libntfs/bootsect.c
@@ -74,29 +74,29 @@ BOOL ntfs_boot_sector_is_ntfs(NTFS_BOOT_SECTOR *b)
 
 	ntfs_log_debug("Checking bytes per sector.\n");
 	if (le16_to_cpu(b->bpb.bytes_per_sector) <  256 ||
-	    le16_to_cpu(b->bpb.bytes_per_sector) > 4096) {
+			le16_to_cpu(b->bpb.bytes_per_sector) > 4096) {
 		ntfs_log_error("Unexpected bytes per sector value (%d).\n",
-			       le16_to_cpu(b->bpb.bytes_per_sector));
+				le16_to_cpu(b->bpb.bytes_per_sector));
 		goto not_ntfs;
 	}
 
 	ntfs_log_debug("Checking sectors per cluster.\n");
 	switch (b->bpb.sectors_per_cluster) {
-	case 1: case 2: case 4: case 8: case 16: case 32: case 64: case 128:
-		break;
-	default:
-		if ((b->bpb.sectors_per_cluster < 240)
-		    || (b->bpb.sectors_per_cluster > 253)) {
-			if (b->bpb.sectors_per_cluster > 128)
-				ntfs_log_error("Unexpected sectors"
-					" per cluster value (code 0x%x)\n",
-					b->bpb.sectors_per_cluster);
-			else
-				ntfs_log_error("Unexpected sectors"
-					" per cluster value (%d).\n",
-					b->bpb.sectors_per_cluster);
-			goto not_ntfs;
-		}
+		case 1: case 2: case 4: case 8: case 16: case 32: case 64: case 128:
+			break;
+		default:
+			if ((b->bpb.sectors_per_cluster < 240)
+					|| (b->bpb.sectors_per_cluster > 253)) {
+				if (b->bpb.sectors_per_cluster > 128)
+					ntfs_log_error("Unexpected sectors"
+							" per cluster value (code 0x%x)\n",
+							b->bpb.sectors_per_cluster);
+				else
+					ntfs_log_error("Unexpected sectors"
+							" per cluster value (%d).\n",
+							b->bpb.sectors_per_cluster);
+				goto not_ntfs;
+			}
 	}
 
 	ntfs_log_debug("Checking cluster size.\n");
@@ -112,59 +112,59 @@ BOOL ntfs_boot_sector_is_ntfs(NTFS_BOOT_SECTOR *b)
 
 	ntfs_log_debug("Checking reserved fields are zero.\n");
 	if (le16_to_cpu(b->bpb.reserved_sectors) ||
-	    le16_to_cpu(b->bpb.root_entries) ||
-	    le16_to_cpu(b->bpb.sectors) ||
-	    le16_to_cpu(b->bpb.sectors_per_fat) ||
-	    le32_to_cpu(b->bpb.large_sectors) ||
-	    b->bpb.fats) {
+			le16_to_cpu(b->bpb.root_entries) ||
+			le16_to_cpu(b->bpb.sectors) ||
+			le16_to_cpu(b->bpb.sectors_per_fat) ||
+			le32_to_cpu(b->bpb.large_sectors) ||
+			b->bpb.fats) {
 		ntfs_log_error("Reserved fields aren't zero "
-			       "(%d, %d, %d, %d, %d, %d).\n",
-			       le16_to_cpu(b->bpb.reserved_sectors),
-			       le16_to_cpu(b->bpb.root_entries),
-			       le16_to_cpu(b->bpb.sectors),
-			       le16_to_cpu(b->bpb.sectors_per_fat),
-			       le32_to_cpu(b->bpb.large_sectors),
-			       b->bpb.fats);
+				"(%d, %d, %d, %d, %d, %d).\n",
+				le16_to_cpu(b->bpb.reserved_sectors),
+				le16_to_cpu(b->bpb.root_entries),
+				le16_to_cpu(b->bpb.sectors),
+				le16_to_cpu(b->bpb.sectors_per_fat),
+				le32_to_cpu(b->bpb.large_sectors),
+				b->bpb.fats);
 		goto not_ntfs;
 	}
 
 	ntfs_log_debug("Checking clusters per mft record.\n");
 	if ((u8)b->clusters_per_mft_record < 0xe1 ||
-	    (u8)b->clusters_per_mft_record > 0xf7) {
+			(u8)b->clusters_per_mft_record > 0xf7) {
 		switch (b->clusters_per_mft_record) {
-		case 1: case 2: case 4: case 8: case 0x10: case 0x20: case 0x40:
-			break;
-		default:
-			ntfs_log_error("Unexpected clusters per mft record "
-				       "(%d).\n", b->clusters_per_mft_record);
-			goto not_ntfs;
+			case 1: case 2: case 4: case 8: case 0x10: case 0x20: case 0x40:
+				break;
+			default:
+				ntfs_log_error("Unexpected clusters per mft record "
+						"(%d).\n", b->clusters_per_mft_record);
+				goto not_ntfs;
 		}
 	}
 
 	ntfs_log_debug("Checking clusters per index block.\n");
 	if ((u8)b->clusters_per_index_record < 0xe1 ||
-	    (u8)b->clusters_per_index_record > 0xf7) {
+			(u8)b->clusters_per_index_record > 0xf7) {
 		switch (b->clusters_per_index_record) {
-		case 1: case 2: case 4: case 8: case 0x10: case 0x20: case 0x40:
-			break;
-		default:
-			ntfs_log_error("Unexpected clusters per index record "
-				       "(%d).\n", b->clusters_per_index_record);
-			goto not_ntfs;
+			case 1: case 2: case 4: case 8: case 0x10: case 0x20: case 0x40:
+				break;
+			default:
+				ntfs_log_error("Unexpected clusters per index record "
+						"(%d).\n", b->clusters_per_index_record);
+				goto not_ntfs;
 		}
 	}
 
 	/* MFT and MFTMirr may not overlap the boot sector or be the same */
 	if (((s64)sle64_to_cpu(b->mft_lcn) <= 0)
-	    || ((s64)sle64_to_cpu(b->mftmirr_lcn) <= 0)
-	    || (b->mft_lcn == b->mftmirr_lcn)) {
+			|| ((s64)sle64_to_cpu(b->mftmirr_lcn) <= 0)
+			|| (b->mft_lcn == b->mftmirr_lcn)) {
 		ntfs_log_error("Invalid location of MFT or MFTMirr.\n");
 		goto not_ntfs;
 	}
 
 	if (b->end_of_sector_marker != const_cpu_to_le16(0xaa55))
 		ntfs_log_debug("Warning: Bootsector has invalid end of sector "
-			       "marker.\n");
+				"marker.\n");
 
 	ntfs_log_debug("Bootsector check completed successfully.\n");
 
@@ -215,7 +215,7 @@ int ntfs_boot_sector_parse(ntfs_volume *vol, const NTFS_BOOT_SECTOR *bs)
 	ntfs_log_debug("SectorsPerCluster = 0x%x\n", sectors_per_cluster);
 	if (sectors_per_cluster & (sectors_per_cluster - 1)) {
 		ntfs_log_error("sectors_per_cluster (%d) is not a power of 2."
-			       "\n", sectors_per_cluster);
+				"\n", sectors_per_cluster);
 		return -1;
 	}
 
@@ -226,10 +226,10 @@ int ntfs_boot_sector_parse(ntfs_volume *vol, const NTFS_BOOT_SECTOR *bs)
 		return -1;
 	}
 	if (vol->dev->d_ops->seek(vol->dev,
-				  (sectors - 1) << vol->sector_size_bits,
-				  SEEK_SET) == -1) {
+				(sectors - 1) << vol->sector_size_bits,
+				SEEK_SET) == -1) {
 		ntfs_log_perror("Failed to read last sector (%lld)",
-			       	(long long)(sectors - 1));
+				(long long)(sectors - 1));
 		ntfs_log_error("%s", last_sector_error);
 		return -1;
 	}
@@ -241,19 +241,19 @@ int ntfs_boot_sector_parse(ntfs_volume *vol, const NTFS_BOOT_SECTOR *bs)
 	vol->mftmirr_lcn = sle64_to_cpu(bs->mftmirr_lcn);
 	ntfs_log_debug("MFT LCN = %lld\n", (long long)vol->mft_lcn);
 	ntfs_log_debug("MFTMirr LCN = %lld\n", (long long)vol->mftmirr_lcn);
-	if ((vol->mft_lcn     < 0 || vol->mft_lcn     > vol->nr_clusters) ||
-	    (vol->mftmirr_lcn < 0 || vol->mftmirr_lcn > vol->nr_clusters)) {
+	if ((vol->mft_lcn < 0 || vol->mft_lcn > vol->nr_clusters) ||
+			(vol->mftmirr_lcn < 0 || vol->mftmirr_lcn > vol->nr_clusters)) {
 		ntfs_log_error("$MFT LCN (%lld) or $MFTMirr LCN (%lld) is "
-			      "greater than the number of clusters (%lld).\n",
-			      (long long)vol->mft_lcn, (long long)vol->mftmirr_lcn,
-			      (long long)vol->nr_clusters);
+				"greater than the number of clusters (%lld).\n",
+				(long long)vol->mft_lcn, (long long)vol->mftmirr_lcn,
+				(long long)vol->nr_clusters);
 		return -1;
 	}
 
 	vol->cluster_size = sectors_per_cluster * vol->sector_size;
 	if (vol->cluster_size & (vol->cluster_size - 1)) {
 		ntfs_log_error("cluster_size (%d) is not a power of 2.\n",
-			       vol->cluster_size);
+				vol->cluster_size);
 		return -1;
 	}
 	vol->cluster_size_bits = ffs(vol->cluster_size) - 1;
@@ -280,7 +280,7 @@ int ntfs_boot_sector_parse(ntfs_volume *vol, const NTFS_BOOT_SECTOR *bs)
 	if (!vol->mft_record_size ||
 			vol->mft_record_size & (vol->mft_record_size - 1)) {
 		ntfs_log_error("mft_record_size (%d) is not a power of 2.\n",
-			       vol->mft_record_size);
+				vol->mft_record_size);
 		return -1;
 	}
 	vol->mft_record_size_bits = ffs(vol->mft_record_size) - 1;

--- a/libntfs/cache.c
+++ b/libntfs/cache.c
@@ -61,7 +61,7 @@
  */
 
 static void inserthashindex(struct CACHE_HEADER *cache,
-			struct CACHED_GENERIC *current)
+		struct CACHED_GENERIC *current)
 {
 	int h;
 	struct HASH_ENTRY *link;
@@ -89,8 +89,8 @@ static void inserthashindex(struct CACHE_HEADER *cache,
 			}
 		} else {
 			ntfs_log_error("Illegal hash value,"
-						" cache %s hashing dropped\n",
-						cache->name);
+					" cache %s hashing dropped\n",
+					cache->name);
 			cache->dohash = (cache_hash)NULL;
 		}
 	}
@@ -101,7 +101,7 @@ static void inserthashindex(struct CACHE_HEADER *cache,
  */
 
 static void drophashindex(struct CACHE_HEADER *cache,
-			const struct CACHED_GENERIC *current, int hash)
+		const struct CACHED_GENERIC *current, int hash)
 {
 	struct HASH_ENTRY *link;
 	struct HASH_ENTRY *previous;
@@ -160,7 +160,7 @@ struct CACHED_GENERIC *ntfs_fetch_cache(struct CACHE_HEADER *cache,
 			 * locate the entry if present
 			 */
 			h = cache->dohash(wanted);
-		        link = cache->first_hash[h];
+			link = cache->first_hash[h];
 			while (link && compare(link->entry, wanted))
 				link = link->next;
 			if (link)
@@ -173,18 +173,18 @@ struct CACHED_GENERIC *ntfs_fetch_cache(struct CACHE_HEADER *cache,
 			 */
 			current = cache->most_recent_entry;
 			while (current
-				   && compare(current, wanted)) {
+					&& compare(current, wanted)) {
 				current = current->next;
-				}
+			}
 		}
 		if (current) {
 			previous = current->previous;
 			cache->hits++;
 			if (previous) {
-			/*
-			 * found and not at head of list, unlink from current
-			 * position and relink as head of list
-			 */
+				/*
+				 * found and not at head of list, unlink from current
+				 * position and relink as head of list
+				 */
 				previous->next = current->next;
 				if (current->next)
 					current->next->previous
@@ -194,7 +194,7 @@ struct CACHED_GENERIC *ntfs_fetch_cache(struct CACHE_HEADER *cache,
 						= current->previous;
 				current->next = cache->most_recent_entry;
 				current->previous
-						= (struct CACHED_GENERIC*)NULL;
+					= (struct CACHED_GENERIC*)NULL;
 				cache->most_recent_entry->previous = current;
 				cache->most_recent_entry = current;
 			}
@@ -210,8 +210,8 @@ struct CACHED_GENERIC *ntfs_fetch_cache(struct CACHE_HEADER *cache,
  */
 
 struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
-			const struct CACHED_GENERIC *item,
-			cache_compare compare)
+		const struct CACHED_GENERIC *item,
+		cache_compare compare)
 {
 	struct CACHED_GENERIC *current;
 	struct CACHED_GENERIC *before;
@@ -226,7 +226,7 @@ struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
 			 * find out whether the entry if present
 			 */
 			h = cache->dohash(item);
-		        link = cache->first_hash[h];
+			link = cache->first_hash[h];
 			while (link && compare(link->entry, item))
 				link = link->next;
 			if (link) {
@@ -239,12 +239,12 @@ struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
 			 * and find out whether the entry is already in list
 			 * As we normally go to the end, no statistics is
 			 * kept.
-		 	 */
+			 */
 			current = cache->most_recent_entry;
 			while (current
-			   && compare(current, item)) {
+					&& compare(current, item)) {
 				current = current->next;
-				}
+			}
 		}
 
 		if (!current) {
@@ -260,8 +260,7 @@ struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
 				current = cache->free_entry;
 				cache->free_entry = cache->free_entry->next;
 				if (item->varsize) {
-					current->variable = ntfs_malloc(
-						item->varsize);
+					current->variable = ntfs_malloc(item->varsize);
 				} else
 					current->variable = (void*)NULL;
 				current->varsize = item->varsize;
@@ -274,18 +273,18 @@ struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
 				before->next = (struct CACHED_GENERIC*)NULL;
 				if (cache->dohash)
 					drophashindex(cache,current,
-						cache->dohash(current));
+							cache->dohash(current));
 				if (cache->dofree)
 					cache->dofree(current);
 				cache->oldest_entry = current->previous;
 				if (item->varsize) {
 					if (current->varsize)
 						current->variable = realloc(
-							current->variable,
-							item->varsize);
+								current->variable,
+								item->varsize);
 					else
 						current->variable = ntfs_malloc(
-							item->varsize);
+								item->varsize);
 				} else {
 					if (current->varsize)
 						free(current->variable);
@@ -302,7 +301,7 @@ struct CACHED_GENERIC *ntfs_enter_cache(struct CACHE_HEADER *cache,
 			if (item->varsize) {
 				if (current->variable) {
 					memcpy(current->variable,
-						item->variable, item->varsize);
+							item->variable, item->varsize);
 				} else {
 					/*
 					 * no more memory for variable part
@@ -360,7 +359,7 @@ static void do_invalidate(struct CACHE_HEADER *cache,
 	if (current->variable)
 		free(current->variable);
 	current->varsize = 0;
-   }
+}
 
 
 /*
@@ -394,7 +393,7 @@ int ntfs_invalidate_cache(struct CACHE_HEADER *cache,
 			 * find out whether the entry if present
 			 */
 			h = cache->dohash(item);
-		        link = cache->first_hash[h];
+			link = cache->first_hash[h];
 			while (link) {
 				if (compare(link->entry, item))
 					link = link->next;
@@ -404,23 +403,23 @@ int ntfs_invalidate_cache(struct CACHE_HEADER *cache,
 					if (current) {
 						drophashindex(cache,current,h);
 						do_invalidate(cache,
-							current,flags);
+								current,flags);
 						count++;
 					}
 				}
 			}
 		}
 		if ((flags & CACHE_NOHASH) || !cache->dohash) {
-				/*
-				 * Search sequentially in LRU list
-				 */
+			/*
+			 * Search sequentially in LRU list
+			 */
 			current = cache->most_recent_entry;
 			while (current) {
 				if (!compare(current, item)) {
 					next = current->next;
 					if (cache->dohash)
 						drophashindex(cache,current,
-						    cache->dohash(current));
+								cache->dohash(current));
 					do_invalidate(cache,current,flags);
 					current = next;
 					count++;
@@ -474,9 +473,9 @@ static void ntfs_free_cache(struct CACHE_HEADER *cache)
  */
 
 static struct CACHE_HEADER *ntfs_create_cache(const char *name,
-			cache_free dofree, cache_hash dohash,
-			int full_item_size,
-			int item_count, int max_hash)
+		cache_free dofree, cache_hash dohash,
+		int full_item_size,
+		int item_count, int max_hash)
 {
 	struct CACHE_HEADER *cache;
 	struct CACHED_GENERIC *pc;
@@ -490,10 +489,10 @@ static struct CACHE_HEADER *ntfs_create_cache(const char *name,
 	size = sizeof(struct CACHE_HEADER) + item_count*full_item_size;
 	if (max_hash)
 		size += item_count*sizeof(struct HASH_ENTRY)
-			 + max_hash*sizeof(struct HASH_ENTRY*);
+			+ max_hash*sizeof(struct HASH_ENTRY*);
 	cache = (struct CACHE_HEADER*)ntfs_malloc(size);
 	if (cache) {
-				/* header */
+		/* header */
 		cache->name = name;
 		cache->dofree = dofree;
 		if (dohash && max_hash) {
@@ -514,19 +513,19 @@ static struct CACHE_HEADER *ntfs_create_cache(const char *name,
 		pc = &cache->entry[0];
 		for (i=0; i<(item_count - 1); i++) {
 			qc = (struct CACHED_GENERIC*)((char*)pc
-							 + full_item_size);
+					+ full_item_size);
 			pc->next = qc;
 			pc->variable = (void*)NULL;
 			pc->varsize = 0;
 			pc = qc;
 		}
-			/* special for the last entry */
+		/* special for the last entry */
 		pc->next =  (struct CACHED_GENERIC*)NULL;
 		pc->variable = (void*)NULL;
 		pc->varsize = 0;
 
 		if (max_hash) {
-				/* chain the hash entries */
+			/* chain the hash entries */
 			ph = (struct HASH_ENTRY*)(((char*)pc) + full_item_size);
 			cache->free_hash = ph;
 			for (i=0; i<(item_count - 1); i++) {
@@ -534,11 +533,11 @@ static struct CACHE_HEADER *ntfs_create_cache(const char *name,
 				ph->next = qh;
 				ph = qh;
 			}
-				/* special for the last entry */
+			/* special for the last entry */
 			if (item_count) {
 				ph->next =  (struct HASH_ENTRY*)NULL;
 			}
-				/* create and initialize the hash indexes */
+			/* create and initialize the hash indexes */
 			px = (struct HASH_ENTRY**)&ph[1];
 			cache->first_hash = px;
 			for (i=0; i<max_hash; i++)
@@ -561,30 +560,30 @@ static struct CACHE_HEADER *ntfs_create_cache(const char *name,
 void ntfs_create_lru_caches(ntfs_volume *vol)
 {
 #if CACHE_INODE_SIZE
-		 /* inode cache */
+	/* inode cache */
 	vol->xinode_cache = ntfs_create_cache("inode",(cache_free)NULL,
-		ntfs_dir_inode_hash, sizeof(struct CACHED_INODE),
-		CACHE_INODE_SIZE, 2*CACHE_INODE_SIZE);
+			ntfs_dir_inode_hash, sizeof(struct CACHED_INODE),
+			CACHE_INODE_SIZE, 2*CACHE_INODE_SIZE);
 #endif
 #if CACHE_NIDATA_SIZE
-		 /* idata cache */
+	/* idata cache */
 	vol->nidata_cache = ntfs_create_cache("nidata",
-		ntfs_inode_nidata_free, ntfs_inode_nidata_hash,
-		sizeof(struct CACHED_NIDATA),
-		CACHE_NIDATA_SIZE, 2*CACHE_NIDATA_SIZE);
+			ntfs_inode_nidata_free, ntfs_inode_nidata_hash,
+			sizeof(struct CACHED_NIDATA),
+			CACHE_NIDATA_SIZE, 2*CACHE_NIDATA_SIZE);
 #endif
 #if CACHE_LOOKUP_SIZE
-		 /* lookup cache */
+	/* lookup cache */
 	vol->lookup_cache = ntfs_create_cache("lookup",
-		(cache_free)NULL, ntfs_dir_lookup_hash,
-		sizeof(struct CACHED_LOOKUP),
-		CACHE_LOOKUP_SIZE, 2*CACHE_LOOKUP_SIZE);
+			(cache_free)NULL, ntfs_dir_lookup_hash,
+			sizeof(struct CACHED_LOOKUP),
+			CACHE_LOOKUP_SIZE, 2*CACHE_LOOKUP_SIZE);
 #endif
 	vol->securid_cache = ntfs_create_cache("securid",(cache_free)NULL,
-		(cache_hash)NULL,sizeof(struct CACHED_SECURID), CACHE_SECURID_SIZE, 0);
+			(cache_hash)NULL,sizeof(struct CACHED_SECURID), CACHE_SECURID_SIZE, 0);
 #if CACHE_LEGACY_SIZE
 	vol->legacy_cache = ntfs_create_cache("legacy",(cache_free)NULL,
-		(cache_hash)NULL, sizeof(struct CACHED_PERMISSIONS_LEGACY), CACHE_LEGACY_SIZE, 0);
+			(cache_hash)NULL, sizeof(struct CACHED_PERMISSIONS_LEGACY), CACHE_LEGACY_SIZE, 0);
 #endif
 }
 

--- a/libntfs/collate.c
+++ b/libntfs/collate.c
@@ -247,25 +247,25 @@ COLLATE ntfs_get_collate_function(COLLATION_RULES cr)
 	COLLATE collate;
 
 	switch (cr) {
-	case COLLATION_BINARY :
-		collate = ntfs_collate_binary;
-		break;
-	case COLLATION_FILE_NAME :
-		collate = ntfs_collate_file_name;
-		break;
-	case COLLATION_NTOFS_SECURITY_HASH :
-		collate = ntfs_collate_ntofs_security_hash;
-		break;
-	case COLLATION_NTOFS_ULONG :
-		collate = ntfs_collate_ntofs_ulong;
-		break;
-	case COLLATION_NTOFS_ULONGS :
-		collate = ntfs_collate_ntofs_ulongs;
-		break;
-	default :
-		errno = EOPNOTSUPP;
-		collate = (COLLATE)NULL;
-		break;
+		case COLLATION_BINARY :
+			collate = ntfs_collate_binary;
+			break;
+		case COLLATION_FILE_NAME :
+			collate = ntfs_collate_file_name;
+			break;
+		case COLLATION_NTOFS_SECURITY_HASH :
+			collate = ntfs_collate_ntofs_security_hash;
+			break;
+		case COLLATION_NTOFS_ULONG :
+			collate = ntfs_collate_ntofs_ulong;
+			break;
+		case COLLATION_NTOFS_ULONGS :
+			collate = ntfs_collate_ntofs_ulongs;
+			break;
+		default :
+			errno = EOPNOTSUPP;
+			collate = (COLLATE)NULL;
+			break;
 	}
 	return (collate);
 }

--- a/libntfs/compat.c
+++ b/libntfs/compat.c
@@ -124,12 +124,12 @@ int daemon(int nochdir, int noclose) {
 	int fd;
 
 	switch (fork()) {
-	case -1:
-		return (-1);
-	case 0:
-		break;
-	default:
-		_exit(0);
+		case -1:
+			return (-1);
+		case 0:
+			break;
+		default:
+			_exit(0);
 	}
 
 	if (setsid() == -1)

--- a/libntfs/compress.c
+++ b/libntfs/compress.c
@@ -147,7 +147,7 @@ static inline unsigned int ntfs_hash(const u8 *p)
  *	    This saves a lot of time on degenerate inputs.
  */
 static void ntfs_best_match(struct COMPRESS_CONTEXT *pctx, const int i,
-			    int best_len)
+		int best_len)
 {
 	const u8 * const inbuf = pctx->inbuf;
 	const u8 * const strptr = &inbuf[i]; /* String we're matching against */
@@ -179,7 +179,7 @@ static void ntfs_best_match(struct COMPRESS_CONTEXT *pctx, const int i,
 	/* Search the appropriate hash chain for matches.  */
 
 	for (; cur_match >= 0 && depth_remaining--;
-		cur_match = prev[cur_match])
+			cur_match = prev[cur_match])
 	{
 
 		matchptr = &inbuf[cur_match];
@@ -197,8 +197,8 @@ static void ntfs_best_match(struct COMPRESS_CONTEXT *pctx, const int i,
 		 * independently of the branches in the main comparison loops.
 		 */
 		if (matchptr[best_len] != strptr[best_len] ||
-		    matchptr[best_len - 1] != strptr[best_len - 1] ||
-		    matchptr[0] != strptr[0])
+				matchptr[best_len - 1] != strptr[best_len - 1] ||
+				matchptr[0] != strptr[0])
 			goto next_match;
 
 		for (len = 1; len < best_len - 1; len++)
@@ -217,8 +217,8 @@ static void ntfs_best_match(struct COMPRESS_CONTEXT *pctx, const int i,
 				 * match as far as possible and terminate the
 				 * search.  */
 				while (best_len < max_len &&
-					(best_matchptr[best_len] ==
-						strptr[best_len]))
+						(best_matchptr[best_len] ==
+						 strptr[best_len]))
 				{
 					best_len++;
 				}
@@ -228,7 +228,7 @@ static void ntfs_best_match(struct COMPRESS_CONTEXT *pctx, const int i,
 
 		/* Found a longer match, but 'nice_len' not yet reached.  */
 
-	next_match:
+next_match:
 		/* Continue to next match in the chain.  */
 		;
 	}
@@ -274,7 +274,7 @@ static void ntfs_skip_position(struct COMPRESS_CONTEXT *pctx, const int i)
  */
 
 static unsigned int ntfs_compress_block(const char *inbuf, const int bufsize,
-				char *outbuf)
+		char *outbuf)
 {
 	struct COMPRESS_CONTEXT *pctx;
 	int i; /* current position */
@@ -386,7 +386,7 @@ static unsigned int ntfs_compress_block(const char *inbuf, const int bufsize,
 					/* Next match isn't longer.
 					 * Output the current match.  */
 					q = (~offs << (16 - bp_cur)) +
-							(j - i - 3);
+						(j - i - 3);
 					outbuf[xout++] = q & 255;
 					outbuf[xout++] = (q >> 8) & 255;
 					tag |= (1 << (8 - ntag));
@@ -508,7 +508,7 @@ do_next_sb:
 	/* Setup the current sub-block source pointers and validate range. */
 	cb_sb_start = cb;
 	cb_sb_end = cb_sb_start + (le16_to_cpup((le16*)cb) & NTFS_SB_SIZE_MASK)
-			+ 3;
+		+ 3;
 	if (cb_sb_end > cb_end)
 		goto return_overflow;
 	/* Now, we are ready to process the current sub-block (sb). */
@@ -648,7 +648,7 @@ return_overflow:
  * errors coming from here.
  */
 static BOOL ntfs_is_cb_compressed(ntfs_attr *na, runlist_element *rl,
-				  VCN cb_start_vcn, int cb_clusters)
+		VCN cb_start_vcn, int cb_clusters)
 {
 	/*
 	 * The simplest case: the run starting at @cb_start_vcn contains
@@ -797,10 +797,10 @@ s64 ntfs_compressed_attr_pread(ntfs_attr *na, s64 pos, s64 count, void *b)
 	 * decompress.
 	 */
 	end_vcn = ((pos + count + cb_size - 1) & ~cb_size_mask) >>
-			vol->cluster_size_bits;
+		vol->cluster_size_bits;
 	/* Number of compression blocks (cbs) in the wanted vcn range. */
 	nr_cbs = (end_vcn - start_vcn) << vol->cluster_size_bits >>
-			na->compression_block_size_bits;
+		na->compression_block_size_bits;
 	cb_end = cb + cb_size;
 do_next_cb:
 	nr_cbs--;
@@ -855,10 +855,10 @@ do_next_cb:
 			if (br <= 0) {
 				if (!br) {
 					ntfs_log_error("Failed to read an"
-						" uncompressed cluster,"
-						" inode %lld offs 0x%llx\n",
-						(long long)na->ni->mft_no,
-						(long long)ofs);
+							" uncompressed cluster,"
+							" inode %lld offs 0x%llx\n",
+							(long long)na->ni->mft_no,
+							(long long)ofs);
 					errno = EIO;
 				}
 				err = errno;
@@ -915,10 +915,10 @@ do_next_cb:
 			if (br <= 0) {
 				if (!br) {
 					ntfs_log_error("Failed to read a"
-						" compressed cluster, "
-						" inode %lld offs 0x%llx\n",
-						(long long)na->ni->mft_no,
-						(long long)(vcn << vol->cluster_size_bits));
+							" compressed cluster, "
+							" inode %lld offs 0x%llx\n",
+							(long long)na->ni->mft_no,
+							(long long)(vcn << vol->cluster_size_bits));
 					errno = EIO;
 				}
 				err = errno;
@@ -979,7 +979,7 @@ do_next_cb:
  */
 
 static u32 read_clusters(ntfs_volume *vol, const runlist_element *rl,
-			s64 offs, u32 to_read, char *inbuf)
+		s64 offs, u32 to_read, char *inbuf)
 {
 	u32 count;
 	int xgot;
@@ -1021,7 +1021,7 @@ static u32 read_clusters(ntfs_volume *vol, const runlist_element *rl,
  */
 
 static s32 write_clusters(ntfs_volume *vol, const runlist_element *rl,
-			s64 offs, s32 to_write, const char *outbuf)
+		s64 offs, s32 to_write, const char *outbuf)
 {
 	s32 count;
 	s32 put, xput;
@@ -1066,7 +1066,7 @@ static s32 write_clusters(ntfs_volume *vol, const runlist_element *rl,
  */
 
 static s32 ntfs_comp_set(ntfs_attr *na, runlist_element *rl,
-			s64 offs, u32 insz, const char *inbuf)
+		s64 offs, u32 insz, const char *inbuf)
 {
 	ntfs_volume *vol;
 	char *outbuf;
@@ -1080,17 +1080,17 @@ static s32 ntfs_comp_set(ntfs_attr *na, runlist_element *rl,
 	unsigned int bsz;
 	BOOL fail;
 	BOOL allzeroes;
-		/* a single compressed zero */
+	/* a single compressed zero */
 	static char onezero[] = { 0x01, 0xb0, 0x00, 0x00 } ;
-		/* a couple of compressed zeroes */
+	/* a couple of compressed zeroes */
 	static char twozeroes[] = { 0x02, 0xb0, 0x00, 0x00, 0x00 } ;
-		/* more compressed zeroes, to be followed by some count */
+	/* more compressed zeroes, to be followed by some count */
 	static char morezeroes[] = { 0x03, 0xb0, 0x02, 0x00 } ;
 
 	vol = na->ni->vol;
 	written = -1; /* default return */
 	clsz = 1 << vol->cluster_size_bits;
-		/* may need 2 extra bytes per block and 2 more bytes */
+	/* may need 2 extra bytes per block and 2 more bytes */
 	outbuf = (char*)ntfs_malloc(na->compression_block_size
 			+ 2*(na->compression_block_size/NTFS_SB_SIZE)
 			+ 2);
@@ -1107,30 +1107,30 @@ static s32 ntfs_comp_set(ntfs_attr *na, runlist_element *rl,
 			sz = ntfs_compress_block(&inbuf[p],bsz,pbuf);
 			/* fail if all the clusters (or more) are needed */
 			if (!sz || ((compsz + sz + clsz + 2)
-					 > na->compression_block_size))
+						> na->compression_block_size))
 				fail = TRUE;
 			else {
 				if (allzeroes) {
-				/* check whether this is all zeroes */
+					/* check whether this is all zeroes */
 					switch (sz) {
-					case 4 :
-						allzeroes = !memcmp(
-							pbuf,onezero,4);
-						break;
-					case 5 :
-						allzeroes = !memcmp(
-							pbuf,twozeroes,5);
-						break;
-					case 6 :
-						allzeroes = !memcmp(
-							pbuf,morezeroes,4);
-						break;
-					default :
-						allzeroes = FALSE;
-						break;
+						case 4 :
+							allzeroes = !memcmp(
+									pbuf,onezero,4);
+							break;
+						case 5 :
+							allzeroes = !memcmp(
+									pbuf,twozeroes,5);
+							break;
+						case 6 :
+							allzeroes = !memcmp(
+									pbuf,morezeroes,4);
+							break;
+						default :
+							allzeroes = FALSE;
+							break;
 					}
 				}
-			compsz += sz;
+				compsz += sz;
 			}
 		}
 		if (!fail && !allzeroes) {
@@ -1166,7 +1166,7 @@ static s32 ntfs_comp_set(ntfs_attr *na, runlist_element *rl,
  */
 
 static BOOL valid_compressed_run(ntfs_attr *na, runlist_element *rl,
-			BOOL fullcheck, const char *text)
+		BOOL fullcheck, const char *text)
 {
 	runlist_element *xrl;
 	const char *err;
@@ -1181,7 +1181,7 @@ static BOOL valid_compressed_run(ntfs_attr *na, runlist_element *rl,
 			err = "Runs not adjacent";
 		if (xrl->lcn == LCN_HOLE) {
 			if ((xrl->vcn + xrl->length)
-			    & (na->compression_block_clusters - 1)) {
+					& (na->compression_block_clusters - 1)) {
 				err = "Invalid hole";
 			}
 			if (fullcheck && (xrl[1].lcn == LCN_HOLE)) {
@@ -1190,8 +1190,8 @@ static BOOL valid_compressed_run(ntfs_attr *na, runlist_element *rl,
 		}
 		if (err) {
 			ntfs_log_error("%s at %s index %ld inode %lld\n",
-				err, text, (long)(xrl - na->rl),
-				(long long)na->ni->mft_no);
+					err, text, (long)(xrl - na->rl),
+					(long long)na->ni->mft_no);
 			errno = EIO;
 			ok = FALSE;
 			err = (const char*)NULL;
@@ -1230,7 +1230,7 @@ static BOOL valid_compressed_run(ntfs_attr *na, runlist_element *rl,
  */
 
 static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
-			s32 usedcnt, s32 freecnt, VCN *update_from)
+		s32 usedcnt, s32 freecnt, VCN *update_from)
 {
 	BOOL beginhole;
 	BOOL mergeholes;
@@ -1249,15 +1249,15 @@ static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
 	freevcn = rl->vcn + usedcnt;
 	freelength = rl->length - usedcnt;
 	beginhole = !usedcnt && !rl->vcn;
-		/* can merge with hole before ? */
+	/* can merge with hole before ? */
 	mergeholes = !usedcnt
-			&& rl[0].vcn
-			&& (rl[-1].lcn == LCN_HOLE);
-		/* truncate current run, carry to subsequent hole */
+		&& rl[0].vcn
+		&& (rl[-1].lcn == LCN_HOLE);
+	/* truncate current run, carry to subsequent hole */
 	carry = freelength;
 	oldlength = rl->length;
 	if (mergeholes) {
-			/* merging with a hole before */
+		/* merging with a hole before */
 		freerl = rl;
 	} else {
 		rl->length -= freelength; /* warning : can be zero */
@@ -1275,8 +1275,8 @@ static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
 		freed = 0;
 		frl = freerl;
 		if (freelength) {
-      			res = ntfs_cluster_free_basic(vol,freelcn,
-				(threeparts ? freecnt : freelength));
+			res = ntfs_cluster_free_basic(vol,freelcn,
+					(threeparts ? freecnt : freelength));
 			if (!res)
 				freed += (threeparts ? freecnt : freelength);
 			if (!usedcnt) {
@@ -1287,105 +1287,105 @@ static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
 				if (freerl->vcn < *update_from)
 					*update_from = freerl->vcn;
 			}
-   		}
-   		while (!res && frl->length && (freed < freecnt)) {
-      			if (frl->length <= (freecnt - freed)) {
-         			res = ntfs_cluster_free_basic(vol, frl->lcn,
+		}
+		while (!res && frl->length && (freed < freecnt)) {
+			if (frl->length <= (freecnt - freed)) {
+				res = ntfs_cluster_free_basic(vol, frl->lcn,
 						frl->length);
 				if (!res) {
-         				freed += frl->length;
-         				frl->lcn = LCN_HOLE;
+					freed += frl->length;
+					frl->lcn = LCN_HOLE;
 					frl->length += carry;
 					carry = 0;
-         				holes++;
+					holes++;
 				}
-      			} else {
-         			res = ntfs_cluster_free_basic(vol, frl->lcn,
+			} else {
+				res = ntfs_cluster_free_basic(vol, frl->lcn,
 						freecnt - freed);
 				if (!res) {
-         				frl->lcn += freecnt - freed;
-         				frl->vcn += freecnt - freed;
-         				frl->length -= freecnt - freed;
-         				freed = freecnt;
+					frl->lcn += freecnt - freed;
+					frl->vcn += freecnt - freed;
+					frl->length -= freecnt - freed;
+					freed = freecnt;
 				}
-      			}
-      			frl++;
-   		}
+			}
+			frl++;
+		}
 		na->compressed_size -= freed << vol->cluster_size_bits;
 		switch (holes) {
-		case 0 :
-			/* there are no hole, must insert one */
-			/* space for hole has been prereserved */
-			if (freerl->lcn == LCN_HOLE) {
-				if (threeparts) {
+			case 0 :
+				/* there are no hole, must insert one */
+				/* space for hole has been prereserved */
+				if (freerl->lcn == LCN_HOLE) {
+					if (threeparts) {
+						erl = freerl;
+						while (erl->length)
+							erl++;
+						do {
+							erl[2] = *erl;
+						} while (erl-- != freerl);
+
+						freerl[1].length = freelength - freecnt;
+						freerl->length = freecnt;
+						freerl[1].lcn = freelcn + freecnt;
+						freerl[1].vcn = freevcn + freecnt;
+						freerl[2].lcn = LCN_HOLE;
+						freerl[2].vcn = freerl[1].vcn
+							+ freerl[1].length;
+						freerl->vcn = freevcn;
+					} else {
+						freerl->vcn = freevcn;
+						freerl->length += freelength;
+					}
+				} else {
 					erl = freerl;
 					while (erl->length)
 						erl++;
-					do {
-						erl[2] = *erl;
-					} while (erl-- != freerl);
-
-					freerl[1].length = freelength - freecnt;
+					if (threeparts) {
+						do {
+							erl[2] = *erl;
+						} while (erl-- != freerl);
+						freerl[1].lcn = freelcn + freecnt;
+						freerl[1].vcn = freevcn + freecnt;
+						freerl[1].length = oldlength - usedcnt - freecnt;
+					} else {
+						do {
+							erl[1] = *erl;
+						} while (erl-- != freerl);
+					}
+					freerl->lcn = LCN_HOLE;
+					freerl->vcn = freevcn;
 					freerl->length = freecnt;
-					freerl[1].lcn = freelcn + freecnt;
-					freerl[1].vcn = freevcn + freecnt;
-					freerl[2].lcn = LCN_HOLE;
-					freerl[2].vcn = freerl[1].vcn
-							+ freerl[1].length;
-					freerl->vcn = freevcn;
-				} else {
-					freerl->vcn = freevcn;
-					freerl->length += freelength;
 				}
-			} else {
-				erl = freerl;
-				while (erl->length)
-					erl++;
-				if (threeparts) {
+				break;
+			case 1 :
+				/* there is a single hole, may have to merge */
+				freerl->vcn = freevcn;
+				freerl->length = freecnt;
+				if (freerl[1].lcn == LCN_HOLE) {
+					freerl->length += freerl[1].length;
+					erl = freerl;
 					do {
-						erl[2] = *erl;
-					} while (erl-- != freerl);
-					freerl[1].lcn = freelcn + freecnt;
-					freerl[1].vcn = freevcn + freecnt;
-					freerl[1].length = oldlength - usedcnt - freecnt;
-				} else {
-					do {
-						erl[1] = *erl;
-					} while (erl-- != freerl);
+						erl++;
+						*erl = erl[1];
+					} while (erl->length);
 				}
+				break;
+			default :
+				/* there were several holes, must merge them */
 				freerl->lcn = LCN_HOLE;
 				freerl->vcn = freevcn;
 				freerl->length = freecnt;
-			}
-			break;
-		case 1 :
-			/* there is a single hole, may have to merge */
-			freerl->vcn = freevcn;
-			freerl->length = freecnt;
-			if (freerl[1].lcn == LCN_HOLE) {
-				freerl->length += freerl[1].length;
+				if (freerl[holes].lcn == LCN_HOLE) {
+					freerl->length += freerl[holes].length;
+					holes++;
+				}
 				erl = freerl;
 				do {
 					erl++;
-					*erl = erl[1];
+					*erl = erl[holes - 1];
 				} while (erl->length);
-			}
-			break;
-		default :
-			/* there were several holes, must merge them */
-			freerl->lcn = LCN_HOLE;
-			freerl->vcn = freevcn;
-			freerl->length = freecnt;
-			if (freerl[holes].lcn == LCN_HOLE) {
-				freerl->length += freerl[holes].length;
-				holes++;
-			}
-			erl = freerl;
-			do {
-				erl++;
-				*erl = erl[holes - 1];
-			} while (erl->length);
-			break;
+				break;
 		}
 	} else {
 		s32 freed;
@@ -1413,9 +1413,9 @@ static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
 				freed = freecnt;
 			}
 		}
-			/* remove unneded runlist entries */
+		/* remove unneded runlist entries */
 		xrl = freerl;
-			/* group with next run if also a hole */
+		/* group with next run if also a hole */
 		if (frl->length && (frl->lcn == LCN_HOLE)) {
 			xrl->length += frl->length;
 			frl++;
@@ -1424,7 +1424,7 @@ static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
 			*++xrl = *frl++;
 		}
 		*++xrl = *frl; /* terminator */
-	na->compressed_size -= freed << vol->cluster_size_bits;
+		na->compressed_size -= freed << vol->cluster_size_bits;
 	}
 	return (res);
 }
@@ -1442,8 +1442,8 @@ static int ntfs_compress_overwr_free(ntfs_attr *na, runlist_element *rl,
  */
 
 static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
-				s64 used, s64 reserved, BOOL appending,
-				VCN *update_from)
+		s64 used, s64 reserved, BOOL appending,
+		VCN *update_from)
 {
 	s32 freecnt;
 	s32 usedcnt;
@@ -1462,7 +1462,7 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
 	usedcnt = (reserved >> vol->cluster_size_bits) - freecnt;
 	if (rl->vcn < *update_from)
 		*update_from = rl->vcn;
-		/* skip entries fully used, if any */
+	/* skip entries fully used, if any */
 	while (rl->length && (rl->length < usedcnt)) {
 		usedcnt -= rl->length; /* must be > 0 */
 		rl++;
@@ -1474,12 +1474,12 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
 		 * The required entry has been prereserved when
 		 * mapping the runlist.
 		 */
-			/* get the free part in initial run */
+		/* get the free part in initial run */
 		freelcn = rl->lcn + usedcnt;
 		freevcn = rl->vcn + usedcnt;
-			/* new count of allocated clusters */
+		/* new count of allocated clusters */
 		if (!((freevcn + freecnt)
-			    & (na->compression_block_clusters - 1))) {
+					& (na->compression_block_clusters - 1))) {
 			if (!appending)
 				res = ntfs_compress_overwr_free(na,rl,
 						usedcnt,freecnt,update_from);
@@ -1487,12 +1487,12 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
 				freelength = rl->length - usedcnt;
 				beginhole = !usedcnt && !rl->vcn;
 				mergeholes = !usedcnt
-						&& rl[0].vcn
-						&& (rl[-1].lcn == LCN_HOLE);
+					&& rl[0].vcn
+					&& (rl[-1].lcn == LCN_HOLE);
 				if (mergeholes) {
 					s32 carry;
 
-				/* shorten the runs which have free space */
+					/* shorten the runs which have free space */
 					carry = freecnt;
 					freerl = rl;
 					while (freerl->length < carry) {
@@ -1506,14 +1506,14 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
 					freerl = ++rl;
 				}
 				if ((freelength > 0)
-				    && !mergeholes
-				    && (usedcnt || beginhole)) {
-				/*
-				 * move the unused part to the end. Doing so,
-				 * the vcn will be out of order. This does
-				 * not harm, the vcn are meaningless now, and
-				 * only the lcn are meaningful for freeing.
-				 */
+						&& !mergeholes
+						&& (usedcnt || beginhole)) {
+					/*
+					 * move the unused part to the end. Doing so,
+					 * the vcn will be out of order. This does
+					 * not harm, the vcn are meaningless now, and
+					 * only the lcn are meaningful for freeing.
+					 */
 					/* locate current end */
 					while (rl->length)
 						rl++;
@@ -1526,10 +1526,10 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
 					rl->lcn = freelcn;
 					rl->length = freelength;
 				} else {
-	/* why is this different from the begin hole case ? */
+					/* why is this different from the begin hole case ? */
 					if ((freelength > 0)
-					    && !mergeholes
-					    && !usedcnt) {
+							&& !mergeholes
+							&& !usedcnt) {
 						freerl--;
 						freerl->length = freelength;
 						if (freerl->vcn < *update_from)
@@ -1556,7 +1556,7 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
 					}
 					if (freerl->vcn < *update_from)
 						*update_from = freerl->vcn;
-						/* and set up the new end */
+					/* and set up the new end */
 					freerl[1].lcn = LCN_ENOENT;
 					freerl[1].vcn = freevcn + freecnt;
 					freerl[1].length = 0;
@@ -1580,8 +1580,8 @@ static int ntfs_compress_free(ntfs_attr *na, runlist_element *rl,
  */
 
 static int ntfs_read_append(ntfs_attr *na, const runlist_element *rl,
-			s64 offs, u32 compsz, s32 pos, BOOL appending,
-			char *outbuf, s64 to_write, const void *b)
+		s64 offs, u32 compsz, s32 pos, BOOL appending,
+		char *outbuf, s64 to_write, const void *b)
 {
 	int fail = 1;
 	char *compbuf;
@@ -1589,7 +1589,7 @@ static int ntfs_read_append(ntfs_attr *na, const runlist_element *rl,
 	u32 got;
 
 	if (compsz == na->compression_block_size) {
-			/* if the full block was requested, it was a hole */
+		/* if the full block was requested, it was a hole */
 		memset(outbuf,0,compsz);
 		memcpy(&outbuf[pos],b,to_write);
 		fail = 0;
@@ -1604,8 +1604,8 @@ static int ntfs_read_append(ntfs_attr *na, const runlist_element *rl,
 			got = read_clusters(na->ni->vol, rl, offs,
 					compsz, compbuf);
 			if ((got == compsz)
-			    && !ntfs_decompress((u8*)outbuf,decompsz,
-					(u8*)compbuf,compsz)) {
+					&& !ntfs_decompress((u8*)outbuf,decompsz,
+						(u8*)compbuf,compsz)) {
 				memcpy(&outbuf[pos],b,to_write);
 				fail = 0;
 			}
@@ -1624,8 +1624,8 @@ static int ntfs_read_append(ntfs_attr *na, const runlist_element *rl,
  */
 
 static s32 ntfs_flush(ntfs_attr *na, runlist_element *rl, s64 offs,
-			char *outbuf, s32 count, BOOL compress,
-			BOOL appending, VCN *update_from)
+		char *outbuf, s32 count, BOOL compress,
+		BOOL appending, VCN *update_from)
 {
 	s32 rounded;
 	s32 written;
@@ -1636,9 +1636,9 @@ static s32 ntfs_flush(ntfs_attr *na, runlist_element *rl, s64 offs,
 		if (written == -1)
 			compress = FALSE;
 		if ((written >= 0)
-		   && ntfs_compress_free(na,rl,offs + written,
-				offs + na->compression_block_size, appending,
-				update_from))
+				&& ntfs_compress_free(na,rl,offs + written,
+					offs + na->compression_block_size, appending,
+					update_from))
 			written = -1;
 	} else
 		written = 0;
@@ -1668,9 +1668,9 @@ static s32 ntfs_flush(ntfs_attr *na, runlist_element *rl, s64 offs,
  */
 
 s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
-				s64 offs, s64 to_write, s64 rounded,
-				const void *b, int compressed_part,
-				VCN *update_from)
+		s64 offs, s64 to_write, s64 rounded,
+		const void *b, int compressed_part,
+		VCN *update_from)
 {
 	ntfs_volume *vol;
 	runlist_element *brl; /* entry containing the beginning of block */
@@ -1695,14 +1695,14 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
 		return (-1);
 	}
 	if ((*update_from < 0)
-	    || (compressed_part < 0)
-	    || (compressed_part > (int)na->compression_block_clusters)) {
+			|| (compressed_part < 0)
+			|| (compressed_part > (int)na->compression_block_clusters)) {
 		ntfs_log_error("Bad update vcn or compressed_part %d for compressed write\n",
-			compressed_part);
+				compressed_part);
 		errno = EIO;
 		return (-1);
 	}
-		/* make sure there are two unused entries in runlist */
+	/* make sure there are two unused entries in runlist */
 	if (na->unused_runs < 2) {
 		ntfs_log_error("No unused runs for compressed write\n");
 		errno = EIO;
@@ -1721,22 +1721,22 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
 	compression_length = na->compression_block_clusters;
 	compress = FALSE;
 	done = FALSE;
-		/*
-		 * Cannot accept writing beyond the current compression set
-		 * because when compression occurs, clusters are freed
-		 * and have to be reallocated.
-		 * (cannot happen with standard fuse 4K buffers)
-		 * Caller has to avoid this situation, or face consequences.
-		 */
+	/*
+	 * Cannot accept writing beyond the current compression set
+	 * because when compression occurs, clusters are freed
+	 * and have to be reallocated.
+	 * (cannot happen with standard fuse 4K buffers)
+	 * Caller has to avoid this situation, or face consequences.
+	 */
 	nextblock = ((offs + (wrl->vcn << vol->cluster_size_bits))
 			| (na->compression_block_size - 1)) + 1;
-		/* determine whether we are appending to file */
+	/* determine whether we are appending to file */
 	endwrite = offs + to_write + (wrl->vcn << vol->cluster_size_bits);
 	appending = endwrite >= na->initialized_size;
 	if (endwrite >= nextblock) {
-			/* it is time to compress */
+		/* it is time to compress */
 		compress = TRUE;
-			/* only process what we can */
+		/* only process what we can */
 		to_write = rounded = nextblock
 			- (offs + (wrl->vcn << vol->cluster_size_bits));
 	}
@@ -1744,16 +1744,16 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
 	fail = FALSE;
 	brl = wrl;
 	roffs = 0;
-		/*
-		 * If we are about to compress or we need to decompress
-		 * existing data, we have to process a full set of blocks.
-		 * So relocate the parameters to the beginning of allocation
-		 * containing the first byte of the set of blocks.
-		 */
+	/*
+	 * If we are about to compress or we need to decompress
+	 * existing data, we have to process a full set of blocks.
+	 * So relocate the parameters to the beginning of allocation
+	 * containing the first byte of the set of blocks.
+	 */
 	if (compress || compressed_part) {
 		/* find the beginning of block */
 		start_vcn = (wrl->vcn + (offs >> vol->cluster_size_bits))
-				& -compression_length;
+			& -compression_length;
 		if (start_vcn < *update_from)
 			*update_from = start_vcn;
 		while (brl->vcn && (brl->vcn > start_vcn)) {
@@ -1788,24 +1788,24 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
 				to_flush = to_read;
 			}
 			if (!ntfs_read_append(na, brl, roffs, compsz,
-					(s32)(offs - roffs), appending,
-					outbuf, to_write, b)) {
+						(s32)(offs - roffs), appending,
+						outbuf, to_write, b)) {
 				written = ntfs_flush(na, brl, roffs,
-					outbuf, to_flush, compress, appending,
-					update_from);
+						outbuf, to_flush, compress, appending,
+						update_from);
 				if (written >= 0) {
 					written = to_write;
 					done = TRUE;
 				}
 			}
-		free(outbuf);
+			free(outbuf);
 		}
 	} else {
 		if (compress && !fail) {
 			/*
 			 * we are filling up a block, read the full set
 			 * of blocks and compress it
-		 	 */
+			 */
 			inbuf = (char*)ntfs_malloc(na->compression_block_size);
 			if (inbuf) {
 				to_read = offs - roffs;
@@ -1817,18 +1817,18 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
 				if (got == to_read) {
 					memcpy(&inbuf[to_read],b,to_write);
 					written = ntfs_comp_set(na, brl, roffs,
-						to_read + to_write, inbuf);
-				/*
-				 * if compression was not successful,
-				 * only write the part which was requested
-				 */
+							to_read + to_write, inbuf);
+					/*
+					 * if compression was not successful,
+					 * only write the part which was requested
+					 */
 					if ((written >= 0)
-						/* free the unused clusters */
-				  	  && !ntfs_compress_free(na,brl,
-						    written + roffs,
-						    na->compression_block_size
-						         + roffs,
-						    appending, update_from)) {
+							/* free the unused clusters */
+							&& !ntfs_compress_free(na,brl,
+								written + roffs,
+								na->compression_block_size
+								+ roffs,
+								appending, update_from)) {
 						done = TRUE;
 						written = to_write;
 					}
@@ -1840,24 +1840,24 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
 			/*
 			 * if the compression block is not full, or
 			 * if compression failed for whatever reason,
-		 	 * write uncompressed
+			 * write uncompressed
 			 */
 			/* check we are not overflowing current allocation */
 			if ((wpos + rounded)
-			    > ((wrl->lcn + wrl->length)
-				 << vol->cluster_size_bits)) {
+					> ((wrl->lcn + wrl->length)
+						<< vol->cluster_size_bits)) {
 				ntfs_log_error("writing on unallocated clusters\n");
 				errno = EIO;
 			} else {
 				written = ntfs_pwrite(vol->dev, wpos,
-					rounded, b);
+						rounded, b);
 				if (written == rounded)
 					written = to_write;
 			}
 		}
 	}
 	if ((written >= 0)
-	    && !valid_compressed_run(na,wrl,TRUE,"end compressed write"))
+			&& !valid_compressed_run(na,wrl,TRUE,"end compressed write"))
 		written = -1;
 	return (written);
 }
@@ -1871,7 +1871,7 @@ s64 ntfs_compressed_pwrite(ntfs_attr *na, runlist_element *wrl, s64 wpos,
  */
 
 int ntfs_compressed_close(ntfs_attr *na, runlist_element *wrl, s64 offs,
-			VCN *update_from)
+		VCN *update_from)
 {
 	ntfs_volume *vol;
 	runlist_element *brl; /* entry containing the beginning of block */
@@ -1906,18 +1906,18 @@ int ntfs_compressed_close(ntfs_attr *na, runlist_element *wrl, s64 offs,
 	vol = na->ni->vol;
 	compression_length = na->compression_block_clusters;
 	done = FALSE;
-		/*
-		 * There generally is an uncompressed block at end of file,
-		 * read the full block and compress it
-		 */
+	/*
+	 * There generally is an uncompressed block at end of file,
+	 * read the full block and compress it
+	 */
 	inbuf = (char*)ntfs_malloc(na->compression_block_size);
 	if (inbuf) {
 		start_vcn = (wrl->vcn + (offs >> vol->cluster_size_bits))
-				& -compression_length;
+			& -compression_length;
 		if (start_vcn < *update_from)
 			*update_from = start_vcn;
 		to_read = offs + ((wrl->vcn - start_vcn)
-					<< vol->cluster_size_bits);
+				<< vol->cluster_size_bits);
 		brl = wrl;
 		fail = FALSE;
 		while (brl->vcn && (brl->vcn > start_vcn)) {
@@ -1931,22 +1931,22 @@ int ntfs_compressed_close(ntfs_attr *na, runlist_element *wrl, s64 offs,
 		if (!fail) {
 			/* roffs can be an offset from another uncomp block */
 			roffs = (start_vcn - brl->vcn)
-						<< vol->cluster_size_bits;
+				<< vol->cluster_size_bits;
 			if (to_read) {
 				got = read_clusters(vol, brl, roffs, to_read,
-						 inbuf);
+						inbuf);
 				if (got == to_read) {
 					written = ntfs_comp_set(na, brl, roffs,
 							to_read, inbuf);
 					if ((written >= 0)
-					/* free the unused clusters */
-					    && !ntfs_compress_free(na,brl,
-							written + roffs,
-							na->compression_block_size + roffs,
-							TRUE, update_from)) {
+							/* free the unused clusters */
+							&& !ntfs_compress_free(na,brl,
+								written + roffs,
+								na->compression_block_size + roffs,
+								TRUE, update_from)) {
 						done = TRUE;
 					} else
-				/* if compression failed, leave uncompressed */
+						/* if compression failed, leave uncompressed */
 						if (written == -1)
 							done = TRUE;
 				}

--- a/libntfs/debug.c
+++ b/libntfs/debug.c
@@ -46,8 +46,8 @@ void ntfs_debug_runlist_dump(const runlist_element *rl)
 {
 	int i = 0;
 	const char *lcn_str[5] = { "LCN_HOLE         ", "LCN_RL_NOT_MAPPED",
-				   "LCN_ENOENT       ", "LCN_EINVAL       ",
-				   "LCN_unknown      " };
+		"LCN_ENOENT       ", "LCN_EINVAL       ",
+		"LCN_unknown      " };
 
 	ntfs_log_debug("NTFS-fs DEBUG: Dumping runlist (values in hex):\n");
 	if (!rl) {
@@ -64,14 +64,14 @@ void ntfs_debug_runlist_dump(const runlist_element *rl)
 			if (idx > -LCN_EINVAL - 1)
 				idx = 4;
 			ntfs_log_debug("%-16lld %s %-16lld%s\n",
-				       (long long)rl[i].vcn, lcn_str[idx],
-				       (long long)rl[i].length,
-				       rl[i].length ? "" : " (runlist end)");
+					(long long)rl[i].vcn, lcn_str[idx],
+					(long long)rl[i].length,
+					rl[i].length ? "" : " (runlist end)");
 		} else
 			ntfs_log_debug("%-16lld %-16lld  %-16lld%s\n",
-				       (long long)rl[i].vcn, (long long)rl[i].lcn,
-				       (long long)rl[i].length,
-				       rl[i].length ? "" : " (runlist end)");
+					(long long)rl[i].vcn, (long long)rl[i].lcn,
+					(long long)rl[i].length,
+					rl[i].length ? "" : " (runlist end)");
 	} while (rl[i++].length);
 }
 

--- a/libntfs/device.c
+++ b/libntfs/device.c
@@ -276,7 +276,7 @@ s64 ntfs_pwrite(struct ntfs_device *dev, const s64 pos, s64 count,
 	NDevSetDirty(dev);
 	for (total = 0; count; count -= written, total += written) {
 		written = dops->pwrite(dev, (const char*)b + total, count,
-				       pos + total);
+				pos + total);
 		/* If everything ok, continue. */
 		if (written > 0)
 			continue;
@@ -443,7 +443,7 @@ s64 ntfs_cluster_read(const ntfs_volume *vol, const s64 lcn, const s64 count,
 		errno = ESPIPE;
 		ntfs_log_perror("Trying to read outside of volume "
 				"(%lld < %lld)", (long long)vol->nr_clusters,
-			        (long long)lcn + count);
+				(long long)lcn + count);
 		return -1;
 	}
 	br = ntfs_pread(vol->dev, lcn << vol->cluster_size_bits,
@@ -479,7 +479,7 @@ s64 ntfs_cluster_write(const ntfs_volume *vol, const s64 lcn,
 		errno = ESPIPE;
 		ntfs_log_perror("Trying to write outside of volume "
 				"(%lld < %lld)", (long long)vol->nr_clusters,
-			        (long long)lcn + count);
+				(long long)lcn + count);
 		return -1;
 	}
 	if (!NVolReadOnly(vol))
@@ -587,11 +587,11 @@ s64 ntfs_device_size_get(struct ntfs_device *dev, int block_size)
 
 		sector_size = ntfs_device_sector_size_get(dev);
 		if (sector_size >= 0 && dev->d_ops->ioctl(dev,
-			DKIOCGETBLOCKCOUNT, &blocks) >= 0)
+					DKIOCGETBLOCKCOUNT, &blocks) >= 0)
 		{
 			ntfs_log_debug("DKIOCGETBLOCKCOUNT nr blocks = %llu (0x%llx)\n",
-				(unsigned long long) blocks,
-				(unsigned long long) blocks);
+					(unsigned long long) blocks,
+					(unsigned long long) blocks);
 			return blocks * sector_size / block_size;
 		}
 	}
@@ -684,15 +684,15 @@ static int ntfs_device_get_geo(struct ntfs_device *dev)
 		 */
 		for (hd = devlist; hd; hd = hd->next) {
 			if (hd->unix_dev_name && !strncmp(dev->d_name,
-					hd->unix_dev_name, d_name_len))
+						hd->unix_dev_name, d_name_len))
 				goto got_hd;
 			if (hd->unix_dev_name2 && !strncmp(dev->d_name,
-					hd->unix_dev_name2, d_name_len))
+						hd->unix_dev_name2, d_name_len))
 				goto got_hd;
 			for (names = hd->unix_dev_names; names;
 					names = names->next) {
 				if (names->str && !strncmp(dev->d_name,
-						names->str, d_name_len))
+							names->str, d_name_len))
 					goto got_hd;
 			}
 		}
@@ -704,15 +704,15 @@ static int ntfs_device_get_geo(struct ntfs_device *dev)
 		partlist = hd_list(hddata, hw_partition, 1, NULL);
 		for (hd = partlist; hd; hd = hd->next) {
 			if (hd->unix_dev_name && !strncmp(dev->d_name,
-					hd->unix_dev_name, d_name_len))
+						hd->unix_dev_name, d_name_len))
 				goto got_part_hd;
 			if (hd->unix_dev_name2 && !strncmp(dev->d_name,
-					hd->unix_dev_name2, d_name_len))
+						hd->unix_dev_name2, d_name_len))
 				goto got_part_hd;
 			for (names = hd->unix_dev_names; names;
 					names = names->next) {
 				if (names->str && !strncmp(dev->d_name,
-						names->str, d_name_len))
+							names->str, d_name_len))
 					goto got_part_hd;
 			}
 		}

--- a/libntfs/dir.c
+++ b/libntfs/dir.c
@@ -75,20 +75,20 @@
  *  and "$Q" as global constants.
  */
 ntfschar NTFS_INDEX_I30[5] = { const_cpu_to_le16('$'), const_cpu_to_le16('I'),
-		const_cpu_to_le16('3'), const_cpu_to_le16('0'),
-		const_cpu_to_le16('\0') };
+	const_cpu_to_le16('3'), const_cpu_to_le16('0'),
+	const_cpu_to_le16('\0') };
 ntfschar NTFS_INDEX_SII[5] = { const_cpu_to_le16('$'), const_cpu_to_le16('S'),
-		const_cpu_to_le16('I'), const_cpu_to_le16('I'),
-		const_cpu_to_le16('\0') };
+	const_cpu_to_le16('I'), const_cpu_to_le16('I'),
+	const_cpu_to_le16('\0') };
 ntfschar NTFS_INDEX_SDH[5] = { const_cpu_to_le16('$'), const_cpu_to_le16('S'),
-		const_cpu_to_le16('D'), const_cpu_to_le16('H'),
-		const_cpu_to_le16('\0') };
+	const_cpu_to_le16('D'), const_cpu_to_le16('H'),
+	const_cpu_to_le16('\0') };
 ntfschar NTFS_INDEX_O[3] = { const_cpu_to_le16('$'), const_cpu_to_le16('O'),
-		const_cpu_to_le16('\0') };
+	const_cpu_to_le16('\0') };
 ntfschar NTFS_INDEX_Q[3] = { const_cpu_to_le16('$'), const_cpu_to_le16('Q'),
-		const_cpu_to_le16('\0') };
+	const_cpu_to_le16('\0') };
 ntfschar NTFS_INDEX_R[3] = { const_cpu_to_le16('$'), const_cpu_to_le16('R'),
-		const_cpu_to_le16('\0') };
+	const_cpu_to_le16('\0') };
 
 #if CACHE_INODE_SIZE
 
@@ -112,7 +112,7 @@ int ntfs_dir_inode_hash(const struct CACHED_GENERIC *cached)
 	if (!name)
 		name = (const unsigned char*)path;
 	return (((name[0] << 1) + name[1] + strlen((const char*)name))
-				% (2*CACHE_INODE_SIZE));
+			% (2*CACHE_INODE_SIZE));
 }
 
 /*
@@ -120,10 +120,10 @@ int ntfs_dir_inode_hash(const struct CACHED_GENERIC *cached)
  */
 
 static int inode_cache_compare(const struct CACHED_GENERIC *cached,
-			const struct CACHED_GENERIC *wanted)
+		const struct CACHED_GENERIC *wanted)
 {
 	return (!cached->variable
-		    || strcmp(cached->variable, wanted->variable));
+			|| strcmp(cached->variable, wanted->variable));
 }
 
 /*
@@ -138,7 +138,7 @@ static int inode_cache_compare(const struct CACHED_GENERIC *cached,
  */
 
 static int inode_cache_inv_compare(const struct CACHED_GENERIC *cached,
-			const struct CACHED_GENERIC *wanted)
+		const struct CACHED_GENERIC *wanted)
 {
 	int len;
 	BOOL different;
@@ -151,9 +151,9 @@ static int inode_cache_inv_compare(const struct CACHED_GENERIC *cached,
 		len = strlen(w->pathname);
 		different = !cached->variable
 			|| ((w->inum != MREF(c->inum))
-			   && (strncmp(c->pathname, w->pathname, len)
-				|| ((c->pathname[len] != '\0')
-				   && (c->pathname[len] != '/'))));
+					&& (strncmp(c->pathname, w->pathname, len)
+						|| ((c->pathname[len] != '\0')
+							&& (c->pathname[len] != '/'))));
 	} else
 		different = !c->pathname
 			|| (w->inum != MREF(c->inum));
@@ -169,14 +169,14 @@ static int inode_cache_inv_compare(const struct CACHED_GENERIC *cached,
  */
 
 static int lookup_cache_compare(const struct CACHED_GENERIC *cached,
-			const struct CACHED_GENERIC *wanted)
+		const struct CACHED_GENERIC *wanted)
 {
 	const struct CACHED_LOOKUP *c = (const struct CACHED_LOOKUP*) cached;
 	const struct CACHED_LOOKUP *w = (const struct CACHED_LOOKUP*) wanted;
 	return (!c->name
-		    || (c->parent != w->parent)
-		    || (c->namesize != w->namesize)
-		    || memcmp(c->name, w->name, c->namesize));
+			|| (c->parent != w->parent)
+			|| (c->namesize != w->namesize)
+			|| memcmp(c->name, w->name, c->namesize));
 }
 
 /*
@@ -188,13 +188,13 @@ static int lookup_cache_compare(const struct CACHED_GENERIC *cached,
  */
 
 static int lookup_cache_inv_compare(const struct CACHED_GENERIC *cached,
-			const struct CACHED_GENERIC *wanted)
+		const struct CACHED_GENERIC *wanted)
 {
 	const struct CACHED_LOOKUP *c = (const struct CACHED_LOOKUP*) cached;
 	const struct CACHED_LOOKUP *w = (const struct CACHED_LOOKUP*) wanted;
 	return (!c->name
-		    || (c->parent != w->parent)
-		    || (MREF(c->inum) != MREF(w->inum)));
+			|| (c->parent != w->parent)
+			|| (MREF(c->inum) != MREF(w->inum)));
 }
 
 /*
@@ -259,7 +259,7 @@ INDEX_ENTRY * __ntfs_inode_lookup_by_name(ntfs_inode *dir_ni,
 
 	/* Find the index root attribute in the mft record. */
 	if (ntfs_attr_lookup(AT_INDEX_ROOT, NTFS_INDEX_I30, 4, CASE_SENSITIVE, 0, NULL,
-			0, ctx)) {
+				0, ctx)) {
 		ntfs_log_perror("Index root attribute missing in directory inode "
 				"%lld", (unsigned long long)dir_ni->mft_no);
 		goto put_err_out;
@@ -295,8 +295,8 @@ INDEX_ENTRY * __ntfs_inode_lookup_by_name(ntfs_inode *dir_ni,
 				(u8*)ie + le16_to_cpu(ie->length) >
 				index_end) {
 			ntfs_log_error("Index root entry out of bounds in"
-				" inode %lld\n",
-				(unsigned long long)dir_ni->mft_no);
+					" inode %lld\n",
+					(unsigned long long)dir_ni->mft_no);
 			goto put_err_out;
 		}
 		/*
@@ -414,8 +414,8 @@ descend_into_child_node:
 				(u8*)ie + le16_to_cpu(ie->length) >
 				index_end) {
 			ntfs_log_error("Index entry out of bounds in directory "
-				       "inode %lld.\n",
-				       (unsigned long long)dir_ni->mft_no);
+					"inode %lld.\n",
+					(unsigned long long)dir_ni->mft_no);
 			errno = EIO;
 			goto close_err_out;
 		}
@@ -474,7 +474,7 @@ descend_into_child_node:
 		if (vcn >= 0)
 			goto descend_into_child_node;
 		ntfs_log_error("Negative child node vcn in directory inode "
-			       "0x%llx.\n", (unsigned long long)dir_ni->mft_no);
+				"0x%llx.\n", (unsigned long long)dir_ni->mft_no);
 		errno = EIO;
 		goto close_err_out;
 	}
@@ -569,7 +569,7 @@ u64 ntfs_inode_lookup_by_mbsname(ntfs_inode *dir_ni, const char *name)
 
 	if (!NVolCaseSensitive(dir_ni->vol)) {
 		cached_name = ntfs_uppercase_mbs(name,
-			dir_ni->vol->upcase, dir_ni->vol->upcase_len);
+				dir_ni->vol->upcase, dir_ni->vol->upcase_len);
 		const_name = cached_name;
 	} else {
 		cached_name = (char*)NULL;
@@ -603,7 +603,7 @@ u64 ntfs_inode_lookup_by_mbsname(ntfs_inode *dir_ni, const char *name)
 					inum = ntfs_inode_lookup_by_name(dir_ni,
 							uname, uname_len);
 					item.inum = inum;
-				/* enter into cache, even if not found */
+					/* enter into cache, even if not found */
 					ntfs_enter_cache(dir_ni->vol->lookup_cache,
 							GENERIC(&item),
 							lookup_cache_compare);
@@ -613,8 +613,8 @@ u64 ntfs_inode_lookup_by_mbsname(ntfs_inode *dir_ni, const char *name)
 			}
 		} else
 #endif
-			{
-				/* Generate unicode name. */
+		{
+			/* Generate unicode name. */
 			uname_len = ntfs_mbstoucs(cached_name, &uname);
 			if (uname_len >= 0) {
 				inum = ntfs_inode_lookup_by_name(dir_ni,
@@ -647,7 +647,7 @@ void ntfs_inode_update_mbsname(ntfs_inode *dir_ni, const char *name, u64 inum)
 	if (dir_ni->vol->lookup_cache) {
 		if (!NVolCaseSensitive(dir_ni->vol)) {
 			cached_name = ntfs_uppercase_mbs(name,
-				dir_ni->vol->upcase, dir_ni->vol->upcase_len);
+					dir_ni->vol->upcase, dir_ni->vol->upcase_len);
 			item.name = cached_name;
 		} else {
 			cached_name = (char*)NULL;
@@ -725,15 +725,15 @@ ntfs_inode *ntfs_pathname_to_inode(ntfs_volume *vol, ntfs_inode *parent,
 		ni = parent;
 	} else {
 #if CACHE_INODE_SIZE
-			/*
-			 * fetch inode for full path from cache
-			 */
+		/*
+		 * fetch inode for full path from cache
+		 */
 		if (*fullname) {
 			item.pathname = fullname;
 			item.varsize = strlen(fullname) + 1;
 			cached = (struct CACHED_INODE*)ntfs_fetch_cache(
-				vol->xinode_cache, GENERIC(&item),
-				inode_cache_compare);
+					vol->xinode_cache, GENERIC(&item),
+					inode_cache_compare);
 		} else
 			cached = (struct CACHED_INODE*)NULL;
 		if (cached) {
@@ -768,9 +768,9 @@ ntfs_inode *ntfs_pathname_to_inode(ntfs_volume *vol, ntfs_inode *parent,
 			*q = '\0';
 		}
 #if CACHE_INODE_SIZE
-			/*
-			 * fetch inode for partial path from cache
-			 */
+		/*
+		 * fetch inode for partial path from cache
+		 */
 		cached = (struct CACHED_INODE*)NULL;
 		if (!parent) {
 			item.pathname = fullname;
@@ -782,15 +782,15 @@ ntfs_inode *ntfs_pathname_to_inode(ntfs_volume *vol, ntfs_inode *parent,
 				inum = cached->inum;
 			}
 		}
-			/*
-			 * if not in cache, translate, search, then
-			 * insert into cache if found
-			 */
+		/*
+		 * if not in cache, translate, search, then
+		 * insert into cache if found
+		 */
 		if (!cached) {
 			len = ntfs_mbstoucs(p, &unicode);
 			if (len < 0) {
 				ntfs_log_perror("Could not convert filename to Unicode:"
-					" '%s'", p);
+						" '%s'", p);
 				err = errno;
 				goto close;
 			} else if (len > NTFS_MAX_NAME_LEN) {
@@ -867,8 +867,8 @@ out:
  * The little endian Unicode string ".." for ntfs_readdir().
  */
 static const ntfschar dotdot[3] = { const_cpu_to_le16('.'),
-				   const_cpu_to_le16('.'),
-				   const_cpu_to_le16('\0') };
+	const_cpu_to_le16('.'),
+	const_cpu_to_le16('\0') };
 
 /*
  * union index_union -
@@ -919,8 +919,8 @@ u32 ntfs_interix_types(ntfs_inode *ni)
 						NTFS_DT_SOCK : NTFS_DT_FIFO);
 		} else {
 			if ((na->data_size >= (s64)sizeof(magic))
-			    && (ntfs_attr_pread(na, 0, sizeof(magic), &magic)
-				== sizeof(magic))) {
+					&& (ntfs_attr_pread(na, 0, sizeof(magic), &magic)
+						== sizeof(magic))) {
 				if (magic == INTX_SYMBOLIC_LINK)
 					dt_type = NTFS_DT_LNK;
 				else if (magic == INTX_BLOCK_DEVICE)
@@ -944,7 +944,7 @@ u32 ntfs_interix_types(ntfs_inode *ni)
  */
 
 static u32 ntfs_dir_entry_type(ntfs_inode *dir_ni, MFT_REF mref,
-					FILE_ATTR_FLAGS attributes)
+		FILE_ATTR_FLAGS attributes)
 {
 	ntfs_inode *ni;
 	u32 dt_type;
@@ -954,19 +954,19 @@ static u32 ntfs_dir_entry_type(ntfs_inode *dir_ni, MFT_REF mref,
 	if (ni) {
 		if (attributes & FILE_ATTR_REPARSE_POINT)
 			dt_type = (ntfs_possible_symlink(ni)
-				? NTFS_DT_LNK : NTFS_DT_REPARSE);
+					? NTFS_DT_LNK : NTFS_DT_REPARSE);
 		else
 			if ((attributes & FILE_ATTR_SYSTEM)
-			   && !(attributes & FILE_ATTR_I30_INDEX_PRESENT))
+					&& !(attributes & FILE_ATTR_I30_INDEX_PRESENT))
 				dt_type = ntfs_interix_types(ni);
 			else
 				dt_type = (attributes
 						& FILE_ATTR_I30_INDEX_PRESENT
-					? NTFS_DT_DIR : NTFS_DT_REG);
+						? NTFS_DT_DIR : NTFS_DT_REG);
 		if (ntfs_inode_close(ni)) {
-				 /* anything special worth doing ? */
+			/* anything special worth doing ? */
 			ntfs_log_error("Failed to close inode %lld\n",
-				(long long)MREF(mref));
+					(long long)MREF(mref));
 		}
 	}
 	if (dt_type == NTFS_DT_UNKNOWN)
@@ -1005,8 +1005,8 @@ static int ntfs_filldir(ntfs_inode *dir_ni, s64 *pos, u8 ivcn_bits,
 	/* Advance the position even if going to skip the entry. */
 	if (index_type == INDEX_TYPE_ALLOCATION)
 		*pos = (u8*)ie - (u8*)iu.ia + (sle64_to_cpu(
-				iu.ia->index_block_vcn) << ivcn_bits) +
-				dir_ni->vol->mft_record_size;
+					iu.ia->index_block_vcn) << ivcn_bits) +
+			dir_ni->vol->mft_record_size;
 	else /* if (index_type == INDEX_TYPE_ROOT) */
 		*pos = (u8*)ie - (u8*)iu.ir;
 	mref = le64_to_cpu(ie->indexed_file);
@@ -1015,21 +1015,21 @@ static int ntfs_filldir(ntfs_inode *dir_ni, s64 *pos, u8 ivcn_bits,
 	if (MREF_LE(ie->indexed_file) == FILE_root)
 		return 0;
 	if ((ie->key.file_name.file_attributes
-		     & (FILE_ATTR_REPARSE_POINT | FILE_ATTR_SYSTEM))
-	    && !metadata)
+				& (FILE_ATTR_REPARSE_POINT | FILE_ATTR_SYSTEM))
+			&& !metadata)
 		dt_type = ntfs_dir_entry_type(dir_ni, mref,
-					ie->key.file_name.file_attributes);
+				ie->key.file_name.file_attributes);
 	else if (ie->key.file_name.file_attributes
-		     & FILE_ATTR_I30_INDEX_PRESENT)
+			& FILE_ATTR_I30_INDEX_PRESENT)
 		dt_type = NTFS_DT_DIR;
 	else
 		dt_type = NTFS_DT_REG;
 
-		/* return metadata files and hidden files if requested */
-        if ((!metadata && (NVolShowHidFiles(dir_ni->vol)
-				|| !(fn->file_attributes & FILE_ATTR_HIDDEN)))
-            || (NVolShowSysFiles(dir_ni->vol) && (NVolShowHidFiles(dir_ni->vol)
-				|| metadata))) {
+	/* return metadata files and hidden files if requested */
+	if ((!metadata && (NVolShowHidFiles(dir_ni->vol)
+					|| !(fn->file_attributes & FILE_ATTR_HIDDEN)))
+			|| (NVolShowSysFiles(dir_ni->vol) && (NVolShowHidFiles(dir_ni->vol)
+					|| metadata))) {
 		if (NVolCaseSensitive(dir_ni->vol)) {
 			res = filldir(dirent, fn->file_name,
 					fn->file_name_length,
@@ -1039,14 +1039,14 @@ static int ntfs_filldir(ntfs_inode *dir_ni, s64 *pos, u8 ivcn_bits,
 			loname = (ntfschar*)ntfs_malloc(2*fn->file_name_length);
 			if (loname) {
 				memcpy(loname, fn->file_name,
-					2*fn->file_name_length);
+						2*fn->file_name_length);
 				ntfs_name_locase(loname, fn->file_name_length,
-					dir_ni->vol->locase,
-					dir_ni->vol->upcase_len);
+						dir_ni->vol->locase,
+						dir_ni->vol->upcase_len);
 				res = filldir(dirent, loname,
-					fn->file_name_length,
-					fn->file_name_type, *pos,
-					mref, dt_type);
+						fn->file_name_length,
+						fn->file_name_type, *pos,
+						mref, dt_type);
 				free(loname);
 			} else
 				res = -1;
@@ -1093,12 +1093,12 @@ static MFT_REF ntfs_mft_get_parent_ref(ntfs_inode *ni)
 		return ERR_MREF(-1);
 	if (ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0, 0, 0, NULL, 0, ctx)) {
 		ntfs_log_error("No file name found in inode %lld\n",
-			       (unsigned long long)ni->mft_no);
+				(unsigned long long)ni->mft_no);
 		goto err_out;
 	}
 	if (ctx->attr->non_resident) {
 		ntfs_log_error("File name attribute must be resident (inode "
-			       "%lld)\n", (unsigned long long)ni->mft_no);
+				"%lld)\n", (unsigned long long)ni->mft_no);
 		goto io_err_out;
 	}
 	fn = (FILE_NAME_ATTR*)((u8*)ctx->attr +
@@ -1168,8 +1168,8 @@ int ntfs_readdir(ntfs_inode *dir_ni, s64 *pos,
 	if (!ia_na) {
 		if (errno != ENOENT) {
 			ntfs_log_perror("Failed to open index allocation attribute. "
-				"Directory inode %lld is corrupt or bug",
-				(unsigned long long)dir_ni->mft_no);
+					"Directory inode %lld is corrupt or bug",
+					(unsigned long long)dir_ni->mft_no);
 			return -1;
 		}
 		i_size = 0;
@@ -1186,7 +1186,7 @@ int ntfs_readdir(ntfs_inode *dir_ni, s64 *pos,
 	if (!*pos) {
 		rc = filldir(dirent, dotdot, 1, FILE_NAME_POSIX, *pos,
 				MK_MREF(dir_ni->mft_no,
-				le16_to_cpu(dir_ni->mrec->sequence_number)),
+					le16_to_cpu(dir_ni->mrec->sequence_number)),
 				NTFS_DT_DIR);
 		if (rc)
 			goto err_out;
@@ -1216,7 +1216,7 @@ int ntfs_readdir(ntfs_inode *dir_ni, s64 *pos,
 	ir_pos = (int)*pos;
 	/* Find the index root attribute in the mft record. */
 	if (ntfs_attr_lookup(AT_INDEX_ROOT, NTFS_INDEX_I30, 4, CASE_SENSITIVE, 0, NULL,
-			0, ctx)) {
+				0, ctx)) {
 		ntfs_log_perror("Index root attribute missing in directory inode "
 				"%lld", (unsigned long long)dir_ni->mft_no);
 		goto dir_err_out;
@@ -1386,7 +1386,7 @@ find_next_index_buffer:
 
 	ia_start = ia_pos & ~(s64)(index_block_size - 1);
 	if (ntfs_index_block_inconsistent(vol, ia_na, (INDEX_BLOCK*)ia, index_block_size,
-			ia_na->ni->mft_no, ia_start >> index_vcn_size_bits)) {
+				ia_na->ni->mft_no, ia_start >> index_vcn_size_bits)) {
 		goto dir_err_out;
 	}
 	index_end = (u8*)&ia->index + le32_to_cpu(ia->index.index_length);
@@ -1408,7 +1408,7 @@ find_next_index_buffer:
 				(u8*)ie + le16_to_cpu(ie->length) >
 				index_end) {
 			ntfs_log_error("Index entry out of bounds in directory inode "
-				"%lld.\n", (unsigned long long)dir_ni->mft_no);
+					"%lld.\n", (unsigned long long)dir_ni->mft_no);
 			goto dir_err_out;
 		}
 		/* The last entry cannot contain a name. */
@@ -1557,39 +1557,39 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 		clear_nino_flag(ni, v3_Extensions);
 	if (!S_ISREG(type) && !S_ISDIR(type)) {
 		switch (special_files) {
-		case NTFS_FILES_WSL :
-			if (!S_ISLNK(type)) {
-				si->file_attributes
-					= FILE_ATTRIBUTE_RECALL_ON_OPEN;
-				ni->flags = FILE_ATTRIBUTE_RECALL_ON_OPEN;
-			}
-			break;
-		default :
-			si->file_attributes = FILE_ATTR_SYSTEM;
-			ni->flags = FILE_ATTR_SYSTEM;
-			break;
+			case NTFS_FILES_WSL :
+				if (!S_ISLNK(type)) {
+					si->file_attributes
+						= FILE_ATTRIBUTE_RECALL_ON_OPEN;
+					ni->flags = FILE_ATTRIBUTE_RECALL_ON_OPEN;
+				}
+				break;
+			default :
+				si->file_attributes = FILE_ATTR_SYSTEM;
+				ni->flags = FILE_ATTR_SYSTEM;
+				break;
 		}
 	}
 	ni->flags |= FILE_ATTR_ARCHIVE;
 	if (NVolHideDotFiles(dir_ni->vol)
-	    && (name_len > 1)
-	    && (name[0] == const_cpu_to_le16('.'))
-	    && (name[1] != const_cpu_to_le16('.')))
+			&& (name_len > 1)
+			&& (name[0] == const_cpu_to_le16('.'))
+			&& (name[1] != const_cpu_to_le16('.')))
 		ni->flags |= FILE_ATTR_HIDDEN;
-		/*
-		 * Set compression flag according to parent directory
-		 * unless NTFS version < 3.0 or cluster size > 4K
-		 * or compression has been disabled
-		 */
+	/*
+	 * Set compression flag according to parent directory
+	 * unless NTFS version < 3.0 or cluster size > 4K
+	 * or compression has been disabled
+	 */
 	if ((dir_ni->flags & FILE_ATTR_COMPRESSED)
-	   && (dir_ni->vol->major_ver >= 3)
-	   && NVolCompression(dir_ni->vol)
-	   && (dir_ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE)
-	   && (S_ISREG(type) || S_ISDIR(type)))
+			&& (dir_ni->vol->major_ver >= 3)
+			&& NVolCompression(dir_ni->vol)
+			&& (dir_ni->vol->cluster_size <= MAX_COMPRESSION_CLUSTER_SIZE)
+			&& (S_ISREG(type) || S_ISDIR(type)))
 		ni->flags |= FILE_ATTR_COMPRESSED;
 	/* Add STANDARD_INFORMATION to inode. */
 	if (ntfs_attr_add(ni, AT_STANDARD_INFORMATION, AT_UNNAMED, 0,
-			(u8*)si, si_len)) {
+				(u8*)si, si_len)) {
 		err = errno;
 		ntfs_log_error("Failed to add STANDARD_INFORMATION "
 				"attribute.\n");
@@ -1622,12 +1622,12 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 		ir->index_block_size = cpu_to_le32(ni->vol->indx_record_size);
 		if (ni->vol->cluster_size <= ni->vol->indx_record_size)
 			ir->clusters_per_index_block =
-					ni->vol->indx_record_size >>
-					ni->vol->cluster_size_bits;
+				ni->vol->indx_record_size >>
+				ni->vol->cluster_size_bits;
 		else
 			ir->clusters_per_index_block =
-					ni->vol->indx_record_size >>
-					NTFS_BLOCK_SIZE_BITS;
+				ni->vol->indx_record_size >>
+				NTFS_BLOCK_SIZE_BITS;
 		ir->index.entries_offset = const_cpu_to_le32(sizeof(INDEX_HEADER));
 		ir->index.index_length = cpu_to_le32(index_len);
 		ir->index.allocated_size = cpu_to_le32(index_len);
@@ -1637,7 +1637,7 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 		ie->ie_flags = INDEX_ENTRY_END;
 		/* Add INDEX_ROOT attribute to inode. */
 		if (ntfs_attr_add(ni, AT_INDEX_ROOT, NTFS_INDEX_I30, 4,
-				(u8*)ir, ir_len)) {
+					(u8*)ir, ir_len)) {
 			err = errno;
 			free(ir);
 			ntfs_log_error("Failed to add INDEX_ROOT attribute.\n");
@@ -1652,49 +1652,49 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 			case S_IFBLK:
 			case S_IFCHR:
 				switch (special_files) {
-				case NTFS_FILES_WSL :
-					data_len = 0;
-					data = (INTX_FILE*)NULL;
-					break;
-				default :
-					data_len = offsetof(INTX_FILE,
+					case NTFS_FILES_WSL :
+						data_len = 0;
+						data = (INTX_FILE*)NULL;
+						break;
+					default :
+						data_len = offsetof(INTX_FILE,
 								device_end);
-					data = (INTX_FILE*)ntfs_malloc(
+						data = (INTX_FILE*)ntfs_malloc(
 								data_len);
-					if (!data) {
-						err = errno;
-						goto err_out;
-					}
-					data->major = cpu_to_le64(major(dev));
-					data->minor = cpu_to_le64(minor(dev));
-					if (type == S_IFBLK)
-						data->magic
-							= INTX_BLOCK_DEVICE;
-					if (type == S_IFCHR)
-						data->magic
-							= INTX_CHARACTER_DEVICE;
-					break;
+						if (!data) {
+							err = errno;
+							goto err_out;
+						}
+						data->major = cpu_to_le64(major(dev));
+						data->minor = cpu_to_le64(minor(dev));
+						if (type == S_IFBLK)
+							data->magic
+								= INTX_BLOCK_DEVICE;
+						if (type == S_IFCHR)
+							data->magic
+								= INTX_CHARACTER_DEVICE;
+						break;
 				}
 				break;
 			case S_IFLNK:
 				switch (special_files) {
-				case NTFS_FILES_WSL :
-					data_len = 0;
-					data = (INTX_FILE*)NULL;
-					break;
-				default :
-					data_len = sizeof(INTX_FILE_TYPES) +
-						target_len * sizeof(ntfschar);
-					data = (INTX_FILE*)ntfs_malloc(
+					case NTFS_FILES_WSL :
+						data_len = 0;
+						data = (INTX_FILE*)NULL;
+						break;
+					default :
+						data_len = sizeof(INTX_FILE_TYPES) +
+							target_len * sizeof(ntfschar);
+						data = (INTX_FILE*)ntfs_malloc(
 								data_len);
-					if (!data) {
-						err = errno;
-						goto err_out;
-					}
-					data->magic = INTX_SYMBOLIC_LINK;
-					memcpy(data->target, target,
-						target_len * sizeof(ntfschar));
-					break;
+						if (!data) {
+							err = errno;
+							goto err_out;
+						}
+						data->magic = INTX_SYMBOLIC_LINK;
+						memcpy(data->target, target,
+								target_len * sizeof(ntfschar));
+						break;
 				}
 				break;
 			case S_IFSOCK:
@@ -1711,7 +1711,7 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 		}
 		/* Add DATA attribute to inode. */
 		if (ntfs_attr_add(ni, AT_DATA, AT_UNNAMED, 0, (u8*)data,
-				data_len)) {
+					data_len)) {
 			err = errno;
 			ntfs_log_error("Failed to add DATA attribute.\n");
 			free(data);
@@ -1759,7 +1759,7 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 	}
 	/* Add FILE_NAME attribute to index. */
 	if (ntfs_index_add_filename(dir_ni, fn, MK_MREF(ni->mft_no,
-			le16_to_cpu(ni->mrec->sequence_number)))) {
+					le16_to_cpu(ni->mrec->sequence_number)))) {
 		err = errno;
 		ntfs_log_perror("Failed to add entry to the index");
 		goto err_out;
@@ -1772,26 +1772,26 @@ static ntfs_inode *__ntfs_create(ntfs_inode *dir_ni, le32 securid,
 	/* Add reparse data */
 	if (special_files == NTFS_FILES_WSL) {
 		switch (type) {
-		case S_IFLNK :
-			err = ntfs_reparse_set_wsl_symlink(ni, target,
-					target_len);
-			break;
-		case S_IFIFO :
-		case S_IFSOCK :
-		case S_IFCHR :
-		case S_IFBLK :
-			err = ntfs_reparse_set_wsl_not_symlink(ni,
-					type);
-			if (!err) {
-				err = ntfs_ea_set_wsl_not_symlink(ni,
-						type, dev);
-				if (err)
-					ntfs_remove_ntfs_reparse_data(ni);
-			}
-			break;
-		default :
-			err = 0;
-			break;
+			case S_IFLNK :
+				err = ntfs_reparse_set_wsl_symlink(ni, target,
+						target_len);
+				break;
+			case S_IFIFO :
+			case S_IFSOCK :
+			case S_IFCHR :
+			case S_IFBLK :
+				err = ntfs_reparse_set_wsl_not_symlink(ni,
+						type);
+				if (!err) {
+					err = ntfs_ea_set_wsl_not_symlink(ni,
+							type, dev);
+					if (err)
+						ntfs_remove_ntfs_reparse_data(ni);
+				}
+				break;
+			default :
+				err = 0;
+				break;
 		}
 		if (err) {
 			err = errno;
@@ -1866,7 +1866,7 @@ ntfs_inode *ntfs_create_symlink(ntfs_inode *dir_ni, le32 securid,
 {
 	if (!target || !target_len) {
 		ntfs_log_error("%s: Invalid argument (%p, %d)\n", __FUNCTION__,
-			       target, target_len);
+				target, target_len);
 		return NULL;
 	}
 	return __ntfs_create(dir_ni, securid, name, name_len, S_IFLNK, 0,
@@ -1913,7 +1913,7 @@ static int ntfs_check_unlinkable_dir(ntfs_inode *ni, FILE_NAME_ATTR *fn)
 	 * one "real" hard link, i.e. links aren't different DOS and WIN32 names
 	 */
 	if ((link_count == 1) ||
-	    (link_count == 2 && fn->file_name_type == FILE_NAME_DOS)) {
+			(link_count == 2 && fn->file_name_type == FILE_NAME_DOS)) {
 		errno = ENOTEMPTY;
 		ntfs_log_debug("Non-empty directory without hard links\n");
 		goto no_hardlink;
@@ -1981,21 +1981,21 @@ int ntfs_delete(ntfs_volume *vol, const char *pathname,
 search:
 	while (!(err = ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
 					CASE_SENSITIVE, 0, NULL, 0, actx))) {
-	#ifdef DEBUG
+#ifdef DEBUG
 		char *s;
-	#endif
+#endif
 		IGNORE_CASE_BOOL case_sensitive = IGNORE_CASE;
 
 		fn = (FILE_NAME_ATTR*)((u8*)actx->attr +
 				le16_to_cpu(actx->attr->value_offset));
-	#ifdef DEBUG
+#ifdef DEBUG
 		s = ntfs_attr_name_get(fn->file_name, fn->file_name_length);
 		ntfs_log_trace("name: '%s'  type: %d  dos: %d  win32: %d  "
-			       "case: %d\n", s, fn->file_name_type,
-			       looking_for_dos_name, looking_for_win32_name,
-			       case_sensitive_match);
+				"case: %d\n", s, fn->file_name_type,
+				looking_for_dos_name, looking_for_win32_name,
+				case_sensitive_match);
 		ntfs_attr_name_free(&s);
-	#endif
+#endif
 		if (looking_for_dos_name) {
 			if (fn->file_name_type == FILE_NAME_DOS)
 				break;
@@ -2012,19 +2012,19 @@ search:
 		/* Ignore hard links from other directories */
 		if (dir_ni->mft_no != MREF_LE(fn->parent_directory)) {
 			ntfs_log_debug("MFT record numbers don't match "
-				       "(%llu != %llu)\n",
-				       (long long unsigned)dir_ni->mft_no,
-				       (long long unsigned)MREF_LE(fn->parent_directory));
+					"(%llu != %llu)\n",
+					(long long unsigned)dir_ni->mft_no,
+					(long long unsigned)MREF_LE(fn->parent_directory));
 			continue;
 		}
 		if (case_sensitive_match
-		    || ((fn->file_name_type == FILE_NAME_POSIX)
-			&& NVolCaseSensitive(ni->vol)))
+				|| ((fn->file_name_type == FILE_NAME_POSIX)
+					&& NVolCaseSensitive(ni->vol)))
 			case_sensitive = CASE_SENSITIVE;
 
 		if (ntfs_names_are_equal(fn->file_name, fn->file_name_length,
-					 name, name_len, case_sensitive,
-					 ni->vol->upcase, ni->vol->upcase_len)){
+					name, name_len, case_sensitive,
+					ni->vol->upcase, ni->vol->upcase_len)){
 
 			if (fn->file_name_type == FILE_NAME_WIN32) {
 				looking_for_dos_name = TRUE;
@@ -2061,7 +2061,7 @@ search:
 	 * in an extent, to avoid leaving an attribute list.
 	 */
 	if ((ni->mrec->link_count == const_cpu_to_le16(1)) && !actx->base_ntfs_ino) {
-			/* make sure to not loop to another search */
+		/* make sure to not loop to another search */
 		looking_for_dos_name = FALSE;
 	} else {
 		if (ntfs_attr_record_rm(actx))
@@ -2069,7 +2069,7 @@ search:
 	}
 
 	ni->mrec->link_count = cpu_to_le16(le16_to_cpu(
-			ni->mrec->link_count) - 1);
+				ni->mrec->link_count) - 1);
 
 	ntfs_inode_mark_dirty(ni);
 	if (looking_for_dos_name) {
@@ -2085,7 +2085,7 @@ search:
 	 * non-resident attributes and mark all MFT record as not in use.
 	 */
 #if CACHE_LOOKUP_SIZE
-			/* invalidate entry in lookup cache */
+	/* invalidate entry in lookup cache */
 	lkitem.name = (const char*)NULL;
 	lkitem.namesize = 0;
 	lkitem.inum = ni->mft_no;
@@ -2096,7 +2096,7 @@ search:
 #if CACHE_INODE_SIZE
 	inum = ni->mft_no;
 	if (pathname) {
-			/* invalide cache entry, even if there was an error */
+		/* invalide cache entry, even if there was an error */
 		/* Remove leading /'s. */
 		p = pathname;
 		while (*p == PATH_SEP)
@@ -2111,10 +2111,10 @@ search:
 	}
 	item.inum = inum;
 	count = ntfs_invalidate_cache(vol->xinode_cache, GENERIC(&item),
-				inode_cache_inv_compare, CACHE_NOHASH);
+			inode_cache_inv_compare, CACHE_NOHASH);
 	if (pathname && !count)
 		ntfs_log_error("Could not delete inode cache entry for %s\n",
-			pathname);
+				pathname);
 #endif
 	if (ni->mrec->link_count) {
 		ntfs_inode_update_times(ni, NTFS_UPDATE_CTIME);
@@ -2165,10 +2165,10 @@ search:
 	}
 	/* All extents should be attached after attribute walk. */
 #if CACHE_NIDATA_SIZE
-		/*
-		 * Disconnect extents before deleting them, so they are
-		 * not wrongly moved to cache through the chainings
-		 */
+	/*
+	 * Disconnect extents before deleting them, so they are
+	 * not wrongly moved to cache through the chainings
+	 */
 	for (i=ni->nr_extents-1; i>=0; i--) {
 		ni->extent_nis[i]->base_ni = (ntfs_inode*)NULL;
 		ni->extent_nis[i]->nr_extents = 0;
@@ -2233,7 +2233,7 @@ err_out:
  * Return 0 on success or -1 on error with errno set to the error code.
  */
 static int ntfs_link_i(ntfs_inode *ni, ntfs_inode *dir_ni, const ntfschar *name,
-			 u8 name_len, FILE_NAME_TYPE_FLAGS nametype)
+		u8 name_len, FILE_NAME_TYPE_FLAGS nametype)
 {
 	FILE_NAME_ATTR *fn = NULL;
 	int fn_len, err;
@@ -2250,8 +2250,8 @@ static int ntfs_link_i(ntfs_inode *ni, ntfs_inode *dir_ni, const ntfschar *name,
 	if (NVolHideDotFiles(dir_ni->vol)) {
 		/* Set hidden flag according to the latest name */
 		if ((name_len > 1)
-		    && (name[0] == const_cpu_to_le16('.'))
-		    && (name[1] != const_cpu_to_le16('.')))
+				&& (name[0] == const_cpu_to_le16('.'))
+				&& (name[1] != const_cpu_to_le16('.')))
 			ni->flags |= FILE_ATTR_HIDDEN;
 		else
 			ni->flags &= ~FILE_ATTR_HIDDEN;
@@ -2283,7 +2283,7 @@ static int ntfs_link_i(ntfs_inode *ni, ntfs_inode *dir_ni, const ntfschar *name,
 	memcpy(fn->file_name, name, name_len * sizeof(ntfschar));
 	/* Add FILE_NAME attribute to index. */
 	if (ntfs_index_add_filename(dir_ni, fn, MK_MREF(ni->mft_no,
-			le16_to_cpu(ni->mrec->sequence_number)))) {
+					le16_to_cpu(ni->mrec->sequence_number)))) {
 		err = errno;
 		ntfs_log_perror("Failed to add filename to the index");
 		goto err_out;
@@ -2299,7 +2299,7 @@ static int ntfs_link_i(ntfs_inode *ni, ntfs_inode *dir_ni, const ntfschar *name,
 	}
 	/* Increment hard links count. */
 	ni->mrec->link_count = cpu_to_le16(le16_to_cpu(
-			ni->mrec->link_count) + 1);
+				ni->mrec->link_count) + 1);
 	/* Done! */
 	ntfs_inode_mark_dirty(ni);
 	free(fn);
@@ -2338,13 +2338,13 @@ ntfs_inode *ntfs_dir_parent_inode(ntfs_inode *ni)
 	ntfs_attr_search_ctx *ctx;
 
 	if (ni->mft_no != FILE_root) {
-			/* find the name in the attributes */
+		/* find the name in the attributes */
 		ctx = ntfs_attr_get_search_ctx(ni, NULL);
 		if (!ctx)
 			return ((ntfs_inode*)NULL);
 
 		if (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
-				CASE_SENSITIVE,	0, NULL, 0, ctx)) {
+					CASE_SENSITIVE,	0, NULL, 0, ctx)) {
 			/* We know this will always be resident. */
 			fn = (FILE_NAME_ATTR*)((u8*)ctx->attr +
 					le16_to_cpu(ctx->attr->value_offset));
@@ -2377,13 +2377,13 @@ static int get_dos_name(ntfs_inode *ni, u64 dnum, ntfschar *dosname)
 	FILE_NAME_ATTR *fn;
 	ntfs_attr_search_ctx *ctx;
 
-		/* find the name in the attributes */
+	/* find the name in the attributes */
 	ctx = ntfs_attr_get_search_ctx(ni, NULL);
 	if (!ctx)
 		return -1;
 
 	while (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		/* We know this will always be resident. */
 		fn = (FILE_NAME_ATTR*)((u8*)ctx->attr +
 				le16_to_cpu(ctx->attr->value_offset));
@@ -2391,13 +2391,13 @@ static int get_dos_name(ntfs_inode *ni, u64 dnum, ntfschar *dosname)
 		if (fn->file_name_type != FILE_NAME_DOS)
 			namecount++;
 		if ((fn->file_name_type & FILE_NAME_DOS)
-		    && (MREF_LE(fn->parent_directory) == dnum)) {
-				/*
-				 * Found a DOS or WIN32+DOS name for the entry
-				 * copy name, after truncation for safety
-				 */
+				&& (MREF_LE(fn->parent_directory) == dnum)) {
+			/*
+			 * Found a DOS or WIN32+DOS name for the entry
+			 * copy name, after truncation for safety
+			 */
 			outsize = fn->file_name_length;
-/* TODO : reject if name is too long ? */
+			/* TODO : reject if name is too long ? */
 			if (outsize > MAX_DOS_NAME_LENGTH)
 				outsize = MAX_DOS_NAME_LENGTH;
 			memcpy(dosname,fn->file_name,outsize*sizeof(ntfschar));
@@ -2429,14 +2429,14 @@ static int get_long_name(ntfs_inode *ni, u64 dnum, ntfschar *longname)
 	FILE_NAME_ATTR *fn;
 	ntfs_attr_search_ctx *ctx;
 
-		/* find the name in the attributes */
+	/* find the name in the attributes */
 	ctx = ntfs_attr_get_search_ctx(ni, NULL);
 	if (!ctx)
 		return -1;
 
-		/* first search for WIN32 or DOS+WIN32 names */
+	/* first search for WIN32 or DOS+WIN32 names */
 	while (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		/* We know this will always be resident. */
 		fn = (FILE_NAME_ATTR*)((u8*)ctx->attr +
 				le16_to_cpu(ctx->attr->value_offset));
@@ -2444,11 +2444,11 @@ static int get_long_name(ntfs_inode *ni, u64 dnum, ntfschar *longname)
 		if (fn->file_name_type != FILE_NAME_DOS)
 			namecount++;
 		if ((fn->file_name_type & FILE_NAME_WIN32)
-		    && (MREF_LE(fn->parent_directory) == dnum)) {
-				/*
-				 * Found a WIN32 or WIN32+DOS name for the entry
-				 * copy name
-				 */
+				&& (MREF_LE(fn->parent_directory) == dnum)) {
+			/*
+			 * Found a WIN32 or WIN32+DOS name for the entry
+			 * copy name
+			 */
 			outsize = fn->file_name_length;
 			memcpy(longname,fn->file_name,outsize*sizeof(ntfschar));
 		}
@@ -2458,25 +2458,25 @@ static int get_long_name(ntfs_inode *ni, u64 dnum, ntfschar *longname)
 		errno = EMLINK;
 		return -1;
 	}
-		/* if not found search for POSIX names */
+	/* if not found search for POSIX names */
 	if (!outsize) {
 		ntfs_attr_reinit_search_ctx(ctx);
-	while (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
-		/* We know this will always be resident. */
-		fn = (FILE_NAME_ATTR*)((u8*)ctx->attr +
-				le16_to_cpu(ctx->attr->value_offset));
+		while (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0, CASE_SENSITIVE,
+					0, NULL, 0, ctx)) {
+			/* We know this will always be resident. */
+			fn = (FILE_NAME_ATTR*)((u8*)ctx->attr +
+					le16_to_cpu(ctx->attr->value_offset));
 
-		if ((fn->file_name_type == FILE_NAME_POSIX)
-		    && (MREF_LE(fn->parent_directory) == dnum)) {
+			if ((fn->file_name_type == FILE_NAME_POSIX)
+					&& (MREF_LE(fn->parent_directory) == dnum)) {
 				/*
 				 * Found a POSIX name for the entry
 				 * copy name
 				 */
-			outsize = fn->file_name_length;
-			memcpy(longname,fn->file_name,outsize*sizeof(ntfschar));
+				outsize = fn->file_name_length;
+				memcpy(longname,fn->file_name,outsize*sizeof(ntfschar));
+			}
 		}
-	}
 	}
 	ntfs_attr_put_search_ctx(ctx);
 	return (outsize);
@@ -2488,7 +2488,7 @@ static int get_long_name(ntfs_inode *ni, u64 dnum, ntfschar *longname)
  */
 
 int ntfs_get_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
-			char *value, size_t size)
+		char *value, size_t size)
 {
 	int outsize = 0;
 	char *outname = (char*)NULL;
@@ -2499,11 +2499,11 @@ int ntfs_get_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 	dnum = dir_ni->mft_no;
 	doslen = get_dos_name(ni, dnum, dosname);
 	if (doslen > 0) {
-			/*
-			 * Found a DOS name for the entry, make
-			 * uppercase and encode into the buffer
-			 * if there is enough space
-			 */
+		/*
+		 * Found a DOS name for the entry, make
+		 * uppercase and encode into the buffer
+		 * if there is enough space
+		 */
 		ntfs_name_upcase(dosname, doslen,
 				ni->vol->upcase, ni->vol->upcase_len);
 		outsize = ntfs_ucstombs(dosname, doslen, &outname, 0);
@@ -2534,8 +2534,8 @@ int ntfs_get_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
  */
 
 static int set_namespace(ntfs_inode *ni, ntfs_inode *dir_ni,
-			const ntfschar *name, int len,
-			FILE_NAME_TYPE_FLAGS nametype)
+		const ntfschar *name, int len,
+		FILE_NAME_TYPE_FLAGS nametype)
 {
 	ntfs_attr_search_ctx *actx;
 	ntfs_index_context *icx;
@@ -2551,14 +2551,14 @@ static int set_namespace(ntfs_inode *ni, ntfs_inode *dir_ni,
 		found = FALSE;
 		do {
 			lkup = ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
-	                        CASE_SENSITIVE, 0, NULL, 0, actx);
+					CASE_SENSITIVE, 0, NULL, 0, actx);
 			if (!lkup) {
 				fn = (FILE_NAME_ATTR*)((u8*)actx->attr +
-				     le16_to_cpu(actx->attr->value_offset));
+						le16_to_cpu(actx->attr->value_offset));
 				found = (MREF_LE(fn->parent_directory)
 						== dir_ni->mft_no)
 					&& !memcmp(fn->file_name, name,
-						len*sizeof(ntfschar));
+							len*sizeof(ntfschar));
 			}
 		} while (!lkup && !found);
 		if (found) {
@@ -2573,7 +2573,7 @@ static int set_namespace(ntfs_inode *ni, ntfs_inode *dir_ni,
 					ntfs_inode_mark_dirty(ni);
 					ntfs_index_entry_mark_dirty(icx);
 				}
-			ntfs_index_ctx_put(icx);
+				ntfs_index_ctx_put(icx);
 			}
 		}
 		ntfs_attr_put_search_ctx(actx);
@@ -2608,9 +2608,9 @@ static int set_namespace(ntfs_inode *ni, ntfs_inode *dir_ni,
  */
 
 static int set_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
-			const ntfschar *shortname, int shortlen,
-			const ntfschar *longname, int longlen,
-			const ntfschar *deletename, int deletelen, BOOL existed)
+		const ntfschar *shortname, int shortlen,
+		const ntfschar *longname, int longlen,
+		const ntfschar *deletename, int deletelen, BOOL existed)
 {
 	unsigned int linkcount;
 	ntfs_volume *vol;
@@ -2626,12 +2626,12 @@ static int set_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 	vol = ni->vol;
 	dnum = dir_ni->mft_no;
 	fnum = ni->mft_no;
-				/* save initial link count */
+	/* save initial link count */
 	linkcount = le16_to_cpu(ni->mrec->link_count);
 
-		/* check whether the same name may be used as DOS and WIN32 */
+	/* check whether the same name may be used as DOS and WIN32 */
 	collapsible = ntfs_collapsible_chars(ni->vol, shortname, shortlen,
-						longname, longlen);
+			longname, longlen);
 	if (collapsible) {
 		deleted = FALSE;
 		done = FALSE;
@@ -2640,10 +2640,10 @@ static int set_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 					deletelen, FILE_NAME_POSIX);
 			if (oldnametype == FILE_NAME_DOS) {
 				if (set_namespace(ni, dir_ni, longname, longlen,
-						FILE_NAME_WIN32_AND_DOS) >= 0) {
+							FILE_NAME_WIN32_AND_DOS) >= 0) {
 					if (!ntfs_delete(vol,
-						(const char*)NULL, ni, dir_ni,
-						deletename, deletelen))
+								(const char*)NULL, ni, dir_ni,
+								deletename, deletelen))
 						res = 0;
 					deleted = TRUE;
 				} else
@@ -2652,8 +2652,8 @@ static int set_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 		}
 		if (!deleted) {
 			if (!done && (set_namespace(ni, dir_ni,
-					longname, longlen,
-					FILE_NAME_WIN32_AND_DOS) >= 0))
+							longname, longlen,
+							FILE_NAME_WIN32_AND_DOS) >= 0))
 				res = 0;
 			ntfs_inode_update_times(ni, NTFS_UPDATE_CTIME);
 			ntfs_inode_update_times(dir_ni, NTFS_UPDATE_MCTIME);
@@ -2664,29 +2664,29 @@ static int set_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 		}
 	} else {
 		if (!ntfs_link_i(ni, dir_ni, shortname, shortlen,
-				FILE_NAME_DOS)
-			/* make sure a new link was recorded */
-		    && (le16_to_cpu(ni->mrec->link_count) > linkcount)) {
+					FILE_NAME_DOS)
+				/* make sure a new link was recorded */
+				&& (le16_to_cpu(ni->mrec->link_count) > linkcount)) {
 			/* delete the existing long name or short name */
-// is it ok to not provide the path ?
+			// is it ok to not provide the path ?
 			if (!ntfs_delete(vol, (char*)NULL, ni, dir_ni,
-				 deletename, deletelen)) {
-			/* delete closes the inodes, so have to open again */
+						deletename, deletelen)) {
+				/* delete closes the inodes, so have to open again */
 				dir_ni = ntfs_inode_open(vol, dnum);
 				if (dir_ni) {
 					ni = ntfs_inode_open(vol, fnum);
 					if (ni) {
 						if (!ntfs_link_i(ni, dir_ni,
-							longname, longlen,
-							FILE_NAME_WIN32))
+									longname, longlen,
+									FILE_NAME_WIN32))
 							res = 0;
 						if (ntfs_inode_close_in_dir(ni,
-							dir_ni)
-						    && !res)
+									dir_ni)
+								&& !res)
 							res = -1;
 					}
-				if (ntfs_inode_close(dir_ni) && !res)
-					res = -1;
+					if (ntfs_inode_close(dir_ni) && !res)
+						res = -1;
 				}
 			}
 		} else {
@@ -2705,11 +2705,11 @@ static int set_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
  *  using the existing file name information from the original
  *  name or overwriting the DOS Name if one exists.
  *
- *  	The inode of the file is always closed
+ *	The inode of the file is always closed
  */
 
 int ntfs_set_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
-			const char *value, size_t size,	int flags)
+		const char *value, size_t size,	int flags)
 {
 	int res = 0;
 	int longlen = 0;
@@ -2722,13 +2722,13 @@ int ntfs_set_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 	ntfschar *shortname = NULL;
 	ntfschar longname[NTFS_MAX_NAME_LEN];
 
-		/* copy the string to insert a null char, and truncate */
+	/* copy the string to insert a null char, and truncate */
 	if (size > 3*MAX_DOS_NAME_LENGTH)
 		size = 3*MAX_DOS_NAME_LENGTH;
 	strncpy(newname, value, size);
-		/* a long name may be truncated badly and be untranslatable */
+	/* a long name may be truncated badly and be untranslatable */
 	newname[size] = 0;
-		/* convert the string to the NTFS wide chars, and truncate */
+	/* convert the string to the NTFS wide chars, and truncate */
 	shortlen = ntfs_mbstoucs(newname, &shortname);
 	if (shortlen > MAX_DOS_NAME_LENGTH)
 		shortlen = MAX_DOS_NAME_LENGTH;
@@ -2737,7 +2737,7 @@ int ntfs_set_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 	 * Note: the short name cannot end with dot or space, but the
 	 * corresponding long name can. */
 	if ((shortlen < 0)
-	    || ntfs_forbidden_names(ni->vol,shortname,shortlen,TRUE)) {
+			|| ntfs_forbidden_names(ni->vol,shortname,shortlen,TRUE)) {
 		ntfs_inode_close_in_dir(ni,dir_ni);
 		ntfs_inode_close(dir_ni);
 		res = -errno;
@@ -2748,23 +2748,23 @@ int ntfs_set_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 	if (longlen > 0) {
 		oldlen = get_dos_name(ni, dnum, oldname);
 		if ((oldlen >= 0)
-		    && !ntfs_forbidden_names(ni->vol, longname, longlen,
-					     FALSE)) {
+				&& !ntfs_forbidden_names(ni->vol, longname, longlen,
+					FALSE)) {
 			if (oldlen > 0) {
 				if (flags & XATTR_CREATE) {
 					res = -1;
 					errno = EEXIST;
 				} else
 					if ((shortlen == oldlen)
-					    && !memcmp(shortname,oldname,
-						     oldlen*sizeof(ntfschar)))
+							&& !memcmp(shortname,oldname,
+								oldlen*sizeof(ntfschar)))
 						/* already set, done */
 						res = 0;
 					else {
 						res = set_dos_name(ni, dir_ni,
-							shortname, shortlen,
-							longname, longlen,
-							oldname, oldlen, TRUE);
+								shortname, shortlen,
+								longname, longlen,
+								oldname, oldlen, TRUE);
 						closed = TRUE;
 					}
 			} else {
@@ -2773,9 +2773,9 @@ int ntfs_set_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni,
 					errno = ENODATA;
 				} else {
 					res = set_dos_name(ni, dir_ni,
-						shortname, shortlen,
-						longname, longlen,
-						longname, longlen, FALSE);
+							shortname, shortlen,
+							longname, longlen,
+							longname, longlen, FALSE);
 					closed = TRUE;
 				}
 			}
@@ -2817,46 +2817,46 @@ int ntfs_remove_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 	if (longlen > 0) {
 		shortlen = get_dos_name(ni, dnum, shortname);
 		if (shortlen >= 0) {
-				/* migrate the long name as Posix */
+			/* migrate the long name as Posix */
 			oldnametype = set_namespace(ni,dir_ni,longname,longlen,
 					FILE_NAME_POSIX);
 			switch (oldnametype) {
-			case FILE_NAME_WIN32_AND_DOS :
-				/* name was Win32+DOS : done */
-				res = 0;
-				break;
-			case FILE_NAME_DOS :
-				/* name was DOS, make it back to DOS */
-				set_namespace(ni,dir_ni,longname,longlen,
-						FILE_NAME_DOS);
-				errno = ENOENT;
-				break;
-			case FILE_NAME_WIN32 :
-				/* name was Win32, make it Posix and delete */
-				if (set_namespace(ni,dir_ni,shortname,shortlen,
-						FILE_NAME_POSIX) >= 0) {
-					if (!ntfs_delete(vol,
-							(const char*)NULL, ni,
-							dir_ni, shortname,
-							shortlen))
-						res = 0;
-					deleted = TRUE;
-				} else {
-					/*
-					 * DOS name has been found, but cannot
-					 * migrate to Posix : something bad
-					 * has happened
-					 */
-					errno = EIO;
-					ntfs_log_error("Could not change"
-						" DOS name of inode %lld to Posix\n",
-						(long long)ni->mft_no);
-				}
-				break;
-			default :
-				/* name was Posix or not found : error */
-				errno = ENOENT;
-				break;
+				case FILE_NAME_WIN32_AND_DOS :
+					/* name was Win32+DOS : done */
+					res = 0;
+					break;
+				case FILE_NAME_DOS :
+					/* name was DOS, make it back to DOS */
+					set_namespace(ni,dir_ni,longname,longlen,
+							FILE_NAME_DOS);
+					errno = ENOENT;
+					break;
+				case FILE_NAME_WIN32 :
+					/* name was Win32, make it Posix and delete */
+					if (set_namespace(ni,dir_ni,shortname,shortlen,
+								FILE_NAME_POSIX) >= 0) {
+						if (!ntfs_delete(vol,
+									(const char*)NULL, ni,
+									dir_ni, shortname,
+									shortlen))
+							res = 0;
+						deleted = TRUE;
+					} else {
+						/*
+						 * DOS name has been found, but cannot
+						 * migrate to Posix : something bad
+						 * has happened
+						 */
+						errno = EIO;
+						ntfs_log_error("Could not change"
+								" DOS name of inode %lld to Posix\n",
+								(long long)ni->mft_no);
+					}
+					break;
+				default :
+					/* name was Posix or not found : error */
+					errno = ENOENT;
+					break;
 			}
 		}
 	} else {
@@ -2877,12 +2877,12 @@ int ntfs_remove_ntfs_dos_name(ntfs_inode *ni, ntfs_inode *dir_ni)
  */
 
 static int nlink_increment(void *nlink_ptr,
-			const ntfschar *name __attribute__((unused)),
-			const int len __attribute__((unused)),
-			const int type,
-			const s64 pos __attribute__((unused)),
-			const MFT_REF mref __attribute__((unused)),
-			const unsigned int dt_type)
+		const ntfschar *name __attribute__((unused)),
+		const int len __attribute__((unused)),
+		const int type,
+		const s64 pos __attribute__((unused)),
+		const MFT_REF mref __attribute__((unused)),
+		const unsigned int dt_type)
 {
 	if ((dt_type == NTFS_DT_DIR) && (type != FILE_NAME_DOS))
 		(*((int*)nlink_ptr))++;
@@ -2933,7 +2933,7 @@ int ntfs_dir_link_cnt(ntfs_inode *ni)
 		if (!actx)
 			goto err_out;
 		while (!(err = ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
-					CASE_SENSITIVE, 0, NULL, 0, actx))) {
+						CASE_SENSITIVE, 0, NULL, 0, actx))) {
 			fn = (FILE_NAME_ATTR*)((u8*)actx->attr +
 					le16_to_cpu(actx->attr->value_offset));
 			if (fn->file_name_type != FILE_NAME_DOS)
@@ -2945,7 +2945,7 @@ int ntfs_dir_link_cnt(ntfs_inode *ni)
 	}
 	if (!nlink)
 		ntfs_log_perror("Failed to compute nlink of inode %lld",
-			(long long)ni->mft_no);
+				(long long)ni->mft_no);
 err_out :
 	return (nlink);
 }

--- a/libntfs/ea.c
+++ b/libntfs/ea.c
@@ -87,9 +87,9 @@ static int ntfs_need_ea(ntfs_inode *ni, ATTR_TYPES type, int size, int flags)
 			 */
 			if (ni->vol->major_ver >= 3) {
 				res = ntfs_attr_add(ni,	type,
-					AT_UNNAMED,0,&dummy,(s64)size);
+						AT_UNNAMED,0,&dummy,(s64)size);
 				if (!res) {
-					    NInoFileNameSetDirty(ni);
+					NInoFileNameSetDirty(ni);
 				}
 				NInoSetDirty(ni);
 			} else {
@@ -125,14 +125,14 @@ static void restore_ea_info(ntfs_attr *nai, const EA_INFORMATION *old_ea_info)
 				old_ea_info);
 		if ((size_t)written != sizeof(EA_INFORMATION)) {
 			ntfs_log_error("Could not restore the EA_INFORMATION,"
-				" possible inconsistency in inode %lld\n",
-				(long long)nai->ni->mft_no);
+					" possible inconsistency in inode %lld\n",
+					(long long)nai->ni->mft_no);
 		}
 	} else {
 		if (ntfs_attr_rm(nai)) {
 			ntfs_log_error("Could not delete the EA_INFORMATION,"
-				" possible inconsistency in inode %lld\n",
-				(long long)nai->ni->mft_no);
+					" possible inconsistency in inode %lld\n",
+					(long long)nai->ni->mft_no);
 		}
 	}
 	errno = olderrno;
@@ -143,8 +143,8 @@ static void restore_ea_info(ntfs_attr *nai, const EA_INFORMATION *old_ea_info)
  */
 
 static int ntfs_update_ea(ntfs_inode *ni, const char *value, size_t size,
-			const EA_INFORMATION *ea_info,
-			const EA_INFORMATION *old_ea_info)
+		const EA_INFORMATION *ea_info,
+		const EA_INFORMATION *old_ea_info)
 {
 	ntfs_attr *na;
 	ntfs_attr *nai;
@@ -155,23 +155,23 @@ static int ntfs_update_ea(ntfs_inode *ni, const char *value, size_t size,
 	if (nai) {
 		na = ntfs_attr_open(ni, AT_EA, AT_UNNAMED, 0);
 		if (na) {
-				/*
-				 * Set EA_INFORMATION first, it is easier to
-				 * restore the old value, if setting EA fails.
-				 */
+			/*
+			 * Set EA_INFORMATION first, it is easier to
+			 * restore the old value, if setting EA fails.
+			 */
 			if (ntfs_attr_pwrite(nai, 0, sizeof(EA_INFORMATION),
 						ea_info)
 					!= (s64)sizeof(EA_INFORMATION)) {
 				res = -errno;
 			} else {
 				if (((na->data_size > (s64)size)
-					&& ntfs_attr_truncate(na, size))
-				    || (ntfs_attr_pwrite(na, 0, size, value)
+							&& ntfs_attr_truncate(na, size))
+						|| (ntfs_attr_pwrite(na, 0, size, value)
 							!= (s64)size)) {
 					res = -errno;
-                                        if (old_ea_info)
+					if (old_ea_info)
 						restore_ea_info(nai,
-							old_ea_info);
+								old_ea_info);
 				}
 			}
 			ntfs_attr_close(na);
@@ -205,7 +205,7 @@ int ntfs_get_ntfs_ea(ntfs_inode *ni, char *value, size_t size)
 
 	if (ntfs_attr_exist(ni, AT_EA, AT_UNNAMED, 0)) {
 		ea_buf = ntfs_attr_readall(ni, AT_EA, (ntfschar*)NULL, 0,
-					&ea_size);
+				&ea_size);
 		if (ea_buf) {
 			if (value && (ea_size <= (s64)size))
 				memcpy(value, ea_buf, ea_size);
@@ -254,7 +254,7 @@ int ntfs_set_ntfs_ea(ntfs_inode *ni, const char *value, size_t size, int flags)
 
 	res = -1;
 	if (value && (size > 0)) {
-					/* do consistency checks */
+		/* do consistency checks */
 		offs = 0;
 		ok = TRUE;
 		ea_count = 0;
@@ -263,21 +263,21 @@ int ntfs_set_ntfs_ea(ntfs_inode *ni, const char *value, size_t size, int flags)
 		while (ok && (offs < size)) {
 			p_ea = (const EA_ATTR*)&value[offs];
 			nextoffs = offs + le32_to_cpu(p_ea->next_entry_offset);
-				/* null offset to next not allowed */
+			/* null offset to next not allowed */
 			ok = (nextoffs > offs)
-			    && (nextoffs <= size)
-			    && !(nextoffs & 3)
-			    && p_ea->name_length
+				&& (nextoffs <= size)
+				&& !(nextoffs & 3)
+				&& p_ea->name_length
 				/* zero sized value are allowed */
-			    && ((offs + offsetof(EA_ATTR,name)
-				+ p_ea->name_length + 1
-				+ le16_to_cpu(p_ea->value_length))
-				    <= nextoffs)
-			    && ((offs + offsetof(EA_ATTR,name)
-				+ p_ea->name_length + 1
-				+ le16_to_cpu(p_ea->value_length))
-				    >= (nextoffs - 3))
-			    && !p_ea->name[p_ea->name_length];
+				&& ((offs + offsetof(EA_ATTR,name)
+							+ p_ea->name_length + 1
+							+ le16_to_cpu(p_ea->value_length))
+						<= nextoffs)
+				&& ((offs + offsetof(EA_ATTR,name)
+							+ p_ea->name_length + 1
+							+ le16_to_cpu(p_ea->value_length))
+						>= (nextoffs - 3))
+				&& !p_ea->name[p_ea->name_length];
 			/* name not checked, as chkdsk accepts any chars */
 			if (ok) {
 				if (p_ea->flags & NEED_EA)
@@ -305,19 +305,19 @@ int ntfs_set_ntfs_ea(ntfs_inode *ni, const char *value, size_t size, int flags)
 
 			old_ea_size = 0;
 			old_ea_info = NULL;
-				/* Try to save the old EA_INFORMATION */
+			/* Try to save the old EA_INFORMATION */
 			if (ntfs_attr_exist(ni, AT_EA_INFORMATION,
-							AT_UNNAMED, 0)) {
+						AT_UNNAMED, 0)) {
 				old_ea_info = ntfs_attr_readall(ni,
-					AT_EA_INFORMATION,
-					(ntfschar*)NULL, 0, &old_ea_size);
+						AT_EA_INFORMATION,
+						(ntfschar*)NULL, 0, &old_ea_size);
 			}
 			/*
 			 * no EA or EA_INFORMATION : add them
 			 */
 			if (!ntfs_need_ea(ni, AT_EA_INFORMATION,
-					sizeof(EA_INFORMATION), flags)
-			    && !ntfs_need_ea(ni, AT_EA, 0, flags)) {
+						sizeof(EA_INFORMATION), flags)
+					&& !ntfs_need_ea(ni, AT_EA, 0, flags)) {
 				res = ntfs_update_ea(ni, value, size,
 						&ea_info, old_ea_info);
 			} else {
@@ -364,24 +364,24 @@ int ntfs_remove_ntfs_ea(ntfs_inode *ni)
 			if (na) {
 				/* Try to save the old EA_INFORMATION */
 				old_ea_info = ntfs_attr_readall(ni,
-					 AT_EA_INFORMATION,
-					 (ntfschar*)NULL, 0, &old_ea_size);
+						AT_EA_INFORMATION,
+						(ntfschar*)NULL, 0, &old_ea_size);
 				res = ntfs_attr_rm(na);
 				NInoFileNameSetDirty(ni);
 				if (!res) {
 					res = ntfs_attr_rm(nai);
 					if (res && old_ea_info) {
-					/*
-					 * Failed to remove the EA, try to
-					 * restore the EA_INFORMATION
-					 */
+						/*
+						 * Failed to remove the EA, try to
+						 * restore the EA_INFORMATION
+						 */
 						restore_ea_info(nai,
-							old_ea_info);
+								old_ea_info);
 					}
 				} else {
 					ntfs_log_error("Failed to remove the"
-						" EA_INFORMATION from inode %lld\n",
-						(long long)ni->mft_no);
+							" EA_INFORMATION from inode %lld\n",
+							(long long)ni->mft_no);
 				}
 				free(old_ea_info);
 				ntfs_attr_close(na);
@@ -435,7 +435,7 @@ int ntfs_ea_check_wsldev(ntfs_inode *ni, dev_t *rdevp)
 	}
 
 	lth = ntfs_get_ntfs_ea(ni, buf, bufsize);
-		/* retry if short buf */
+	/* retry if short buf */
 
 	if (lth > bufsize) {
 		free(buf);
@@ -452,15 +452,15 @@ int ntfs_ea_check_wsldev(ntfs_inode *ni, dev_t *rdevp)
 			p_ea = (const EA_ATTR*)&buf[offset];
 			next = le32_to_cpu(p_ea->next_entry_offset);
 			found = ((next > (int)(sizeof(lxdev) + sizeof(device)))
-				&& (p_ea->name_length == (sizeof(lxdev) - 1))
-				&& (p_ea->value_length
-					== const_cpu_to_le16(sizeof(device)))
-				&& !memcmp(p_ea->name, lxdev, sizeof(lxdev)));
+					&& (p_ea->name_length == (sizeof(lxdev) - 1))
+					&& (p_ea->value_length
+						== const_cpu_to_le16(sizeof(device)))
+					&& !memcmp(p_ea->name, lxdev, sizeof(lxdev)));
 			if (!found)
 				offset += next;
 		} while (!found && (next > 0) && (offset < lth));
 		if (found) {
-				/* beware of alignment */
+			/* beware of alignment */
 			memcpy(&device, &p_ea->name[p_ea->name_length + 1],
 					sizeof(device));
 			*rdevp = makedev(le32_to_cpu(device.major),
@@ -499,7 +499,7 @@ int ntfs_ea_set_wsl_not_symlink(ntfs_inode *ni, mode_t type, dev_t dev)
 	memset(&attr, 0, sizeof(attr));
 	mode = cpu_to_le32((u32)(type | 0644));
 	attr.mod.base.next_entry_offset
-			= const_cpu_to_le32(sizeof(attr.mod));
+		= const_cpu_to_le32(sizeof(attr.mod));
 	attr.mod.base.flags = 0;
 	attr.mod.base.name_length = sizeof(lxmod) - 1;
 	attr.mod.base.value_length = const_cpu_to_le16(sizeof(mode));
@@ -518,7 +518,7 @@ int ntfs_ea_set_wsl_not_symlink(ntfs_inode *ni, mode_t type, dev_t dev)
 		memcpy(attr.dev.name, lxdev, sizeof(lxdev));
 		memcpy(attr.dev.value, &device, sizeof(device));
 		len += sizeof(attr.dev);
-		}
+	}
 	res = ntfs_set_ntfs_ea(ni, (char*)&attr, len, 0);
 	return (res);
 }

--- a/libntfs/efs.c
+++ b/libntfs/efs.c
@@ -76,10 +76,10 @@ int ntfs_get_efs_info(ntfs_inode *ni, char *value, size_t size)
 	if (ni) {
 		if (ni->flags & FILE_ATTR_ENCRYPTED) {
 			efs_info = (EFS_ATTR_HEADER*)ntfs_attr_readall(ni,
-				AT_LOGGED_UTILITY_STREAM,(ntfschar*)NULL, 0,
-				&attr_size);
+					AT_LOGGED_UTILITY_STREAM,(ntfschar*)NULL, 0,
+					&attr_size);
 			if (efs_info
-			    && (le32_to_cpu(efs_info->length) == attr_size)) {
+					&& (le32_to_cpu(efs_info->length) == attr_size)) {
 				if (attr_size <= (s64)size) {
 					if (value)
 						memcpy(value,efs_info,attr_size);
@@ -97,11 +97,11 @@ int ntfs_get_efs_info(ntfs_inode *ni, char *value, size_t size)
 				if (efs_info) {
 					free(efs_info);
 					ntfs_log_error("Bad efs_info for inode %lld\n",
-						(long long)ni->mft_no);
+							(long long)ni->mft_no);
 				} else {
 					ntfs_log_error("Could not get efsinfo"
-						" for inode %lld\n",
-						(long long)ni->mft_no);
+							" for inode %lld\n",
+							(long long)ni->mft_no);
 				}
 				errno = EIO;
 				attr_size = 0;
@@ -109,7 +109,7 @@ int ntfs_get_efs_info(ntfs_inode *ni, char *value, size_t size)
 		} else {
 			errno = ENODATA;
 			ntfs_log_trace("Inode %lld is not encrypted\n",
-				(long long)ni->mft_no);
+					(long long)ni->mft_no);
 		}
 	}
 	return (attr_size ? (int)attr_size : -errno);
@@ -148,34 +148,34 @@ static int fixup_loop(ntfs_inode *ni)
 		}
 		cnt = 0;
 		while (!restart && !res
-			&& !ntfs_attr_lookup(AT_DATA, NULL, 0,
-				   CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+				&& !ntfs_attr_lookup(AT_DATA, NULL, 0,
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			cnt++;
 			a = ctx->attr;
 			na = ntfs_attr_open(ctx->ntfs_ino, AT_DATA,
-				(ntfschar*)((u8*)a + le16_to_cpu(a->name_offset)),
-				a->name_length);
+					(ntfschar*)((u8*)a + le16_to_cpu(a->name_offset)),
+					a->name_length);
 			if (!na) {
 				ntfs_log_error("can't open DATA Attribute\n");
 				res = -1;
 			}
 			if (na && !(ctx->attr->flags & ATTR_IS_ENCRYPTED)) {
 				if (!NAttrNonResident(na)
-				   && ntfs_attr_make_non_resident(na, ctx)) {
-				/*
-				 * ntfs_attr_make_non_resident fails if there
-				 * is not enough space in the MFT record.
-				 * When this happens, force making non-resident
-				 * so that some other attribute is expelled.
-				 */
+						&& ntfs_attr_make_non_resident(na, ctx)) {
+					/*
+					 * ntfs_attr_make_non_resident fails if there
+					 * is not enough space in the MFT record.
+					 * When this happens, force making non-resident
+					 * so that some other attribute is expelled.
+					 */
 					if (ntfs_attr_force_non_resident(na)) {
 						res = -1;
 					} else {
-					/* make sure there is some progress */
+						/* make sure there is some progress */
 						if (cnt <= maxcnt) {
 							errno = EIO;
 							ntfs_log_error("Multiple failure"
-								" making non resident\n");
+									" making non resident\n");
 							res = -1;
 						} else {
 							ntfs_attr_put_search_ctx(ctx);
@@ -186,13 +186,13 @@ static int fixup_loop(ntfs_inode *ni)
 					}
 				}
 				if (!restart && !res
-				    && ntfs_efs_fixup_attribute(ctx, na)) {
+						&& ntfs_efs_fixup_attribute(ctx, na)) {
 					ntfs_log_error("Error in efs fixup of AT_DATA Attribute\n");
 					res = -1;
 				}
 			}
-		if (na)
-			ntfs_attr_close(na);
+			if (na)
+				ntfs_attr_close(na);
 		}
 	} while (restart && !res);
 	if (ctx)
@@ -207,7 +207,7 @@ static int fixup_loop(ntfs_inode *ni)
  */
 
 int ntfs_set_efs_info(ntfs_inode *ni, const char *value, size_t size,
-			int flags)
+		int flags)
 
 {
 	int res;
@@ -230,27 +230,27 @@ int ntfs_set_efs_info(ntfs_inode *ni, const char *value, size_t size,
 				 * TODO : decompress first.
 				 */
 				ntfs_log_error("Inode %lld cannot be encrypted and compressed\n",
-					(long long)ni->mft_no);
+						(long long)ni->mft_no);
 				errno = EIO;
 			}
 			return -1;
 		}
 		info_header = (const EFS_ATTR_HEADER*)value;
-			/* make sure we get a likely efsinfo */
+		/* make sure we get a likely efsinfo */
 		if (le32_to_cpu(info_header->length) != size) {
 			errno = EINVAL;
 			return (-1);
 		}
 		if (!ntfs_attr_exist(ni,AT_LOGGED_UTILITY_STREAM,
-				(ntfschar*)NULL,0)) {
+					(ntfschar*)NULL,0)) {
 			if (!(flags & XATTR_REPLACE)) {
-			/*
-			 * no logged_utility_stream attribute : add one,
-			 * apparently, this does not feed the new value in
-			 */
+				/*
+				 * no logged_utility_stream attribute : add one,
+				 * apparently, this does not feed the new value in
+				 */
 				res = ntfs_attr_add(ni,AT_LOGGED_UTILITY_STREAM,
-					logged_utility_stream_name,4,
-					(u8*)NULL,(s64)size);
+						logged_utility_stream_name,4,
+						(u8*)NULL,(s64)size);
 			} else {
 				errno = ENODATA;
 				res = -1;
@@ -264,17 +264,17 @@ int ntfs_set_efs_info(ntfs_inode *ni, const char *value, size_t size,
 			 * open and update the existing efs data
 			 */
 			na = ntfs_attr_open(ni, AT_LOGGED_UTILITY_STREAM,
-				logged_utility_stream_name, 4);
+					logged_utility_stream_name, 4);
 			if (na) {
 				/* resize attribute */
 				res = ntfs_attr_truncate(na, (s64)size);
 				/* overwrite value if any */
 				if (!res && value) {
 					written = (int)ntfs_attr_pwrite(na,
-						 (s64)0, (s64)size, value);
+							(s64)0, (s64)size, value);
 					if (written != (s64)size) {
 						ntfs_log_error("Failed to "
-							"update efs data\n");
+								"update efs data\n");
 						errno = EIO;
 						res = -1;
 					}
@@ -287,10 +287,10 @@ int ntfs_set_efs_info(ntfs_inode *ni, const char *value, size_t size,
 			/* Don't handle AT_DATA Attribute(s) if inode is a directory */
 			if (!(ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)) {
 				/* iterate over AT_DATA attributes */
-                        	/* set encrypted flag, truncate attribute to match padding bytes */
+				/* set encrypted flag, truncate attribute to match padding bytes */
 
-			if (fixup_loop(ni))
-				return -1;
+				if (fixup_loop(ni))
+					return -1;
 			}
 			ni->flags |= FILE_ATTR_ENCRYPTED;
 			NInoSetDirty(ni);
@@ -335,19 +335,19 @@ int ntfs_efs_fixup_attribute(ntfs_attr_search_ctx *ctx, ntfs_attr *na)
 		}
 		close_ctx = TRUE;
 		if (ntfs_attr_lookup(AT_DATA, na->name, na->name_len,
-				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			ntfs_log_error("attr lookup for AT_DATA attribute failed in efs fixup\n");
 			goto err_out;
 		}
 	} else {
 		if (!NAttrNonResident(na)) {
 			ntfs_log_error("Cannot make non resident"
-				" when a context has been allocated\n");
+					" when a context has been allocated\n");
 			goto err_out;
 		}
 	}
 
-		/* no extra bytes are added to void attributes */
+	/* no extra bytes are added to void attributes */
 	oldsize = na->data_size;
 	if (oldsize) {
 		/* make sure size is valid for a raw encrypted stream */
@@ -364,7 +364,7 @@ int ntfs_efs_fixup_attribute(ntfs_attr_search_ctx *ctx, ntfs_attr *na)
 		if (padding_length > 511 || padding_length > na->data_size-2) {
 			errno = EINVAL;
 			ntfs_log_error("invalid padding length %d for data_size %lld\n",
-				 padding_length, (long long)oldsize);
+					padding_length, (long long)oldsize);
 			goto err_out;
 		}
 		newsize = oldsize - padding_length - 2;
@@ -387,9 +387,9 @@ int ntfs_efs_fixup_attribute(ntfs_attr_search_ctx *ctx, ntfs_attr *na)
 	 * resident.
 	 */
 	if (!NAttrNonResident(na)
-	    && ntfs_attr_make_non_resident(na, ctx)) {
+			&& ntfs_attr_make_non_resident(na, ctx)) {
 		if (!close_ctx
-		    || ntfs_attr_force_non_resident(na)) {
+				|| ntfs_attr_force_non_resident(na)) {
 			ntfs_log_error("Error making DATA attribute non-resident\n");
 			goto err_out;
 		} else {
@@ -401,7 +401,7 @@ int ntfs_efs_fixup_attribute(ntfs_attr_search_ctx *ctx, ntfs_attr *na)
 			 */
 			ntfs_attr_reinit_search_ctx(ctx);
 			if (ntfs_attr_lookup(AT_DATA, na->name, na->name_len,
-					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+						CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 				ntfs_log_error("attr lookup for AT_DATA attribute failed in efs fixup\n");
 				goto err_out;
 			}

--- a/libntfs/fsck.c
+++ b/libntfs/fsck.c
@@ -501,7 +501,7 @@ ntfs_volume *ntfs_fsck_mount(const char *path __attribute__((unused)),
 
 	/* Initialize fsck mft bitmap buffer array */
 	vol->max_fmb_cnt = FB_ROUND_DOWN((vol->mft_na->initialized_size >>
-			      vol->mft_record_size_bits) >> NTFSCK_BYTE_TO_BITS) + 1;
+				vol->mft_record_size_bits) >> NTFSCK_BYTE_TO_BITS) + 1;
 	vol->fsck_mft_bitmap = (u8 **)ntfs_calloc(sizeof(u8 *) * vol->max_fmb_cnt);
 	if (!vol->fsck_mft_bitmap) {
 		free(vol->fsck_lcn_bitmap);

--- a/libntfs/index.c
+++ b/libntfs/index.c
@@ -88,10 +88,10 @@ int ntfs_ib_write(ntfs_index_context *icx, INDEX_BLOCK *ib)
 	ntfs_log_trace("vcn: %lld\n", (long long)vcn);
 
 	ret = ntfs_attr_mst_pwrite(icx->ia_na, ntfs_ib_vcn_to_pos(icx, vcn),
-				   1, icx->block_size, ib);
+			1, icx->block_size, ib);
 	if (ret != 1) {
 		ntfs_log_perror("Failed to write index block %lld, inode %llu",
-			(long long)vcn, (unsigned long long)icx->ni->mft_no);
+				(long long)vcn, (unsigned long long)icx->ni->mft_no);
 		return STATUS_ERROR;
 	}
 
@@ -100,12 +100,12 @@ int ntfs_ib_write(ntfs_index_context *icx, INDEX_BLOCK *ib)
 
 static int ntfs_icx_ib_write(ntfs_index_context *icx)
 {
-		if (ntfs_ib_write(icx, icx->ib))
-			return STATUS_ERROR;
+	if (ntfs_ib_write(icx, icx->ib))
+		return STATUS_ERROR;
 
-		icx->ib_dirty = FALSE;
+	icx->ib_dirty = FALSE;
 
-		return STATUS_OK;
+	return STATUS_OK;
 }
 
 /**
@@ -118,7 +118,7 @@ static int ntfs_icx_ib_write(ntfs_index_context *icx)
  * Return NULL if allocation failed.
  */
 ntfs_index_context *ntfs_index_ctx_get(ntfs_inode *ni,
-				       ntfschar *name, u32 name_len)
+		ntfschar *name, u32 name_len)
 {
 	ntfs_index_context *icx;
 
@@ -134,8 +134,8 @@ ntfs_index_context *ntfs_index_ctx_get(ntfs_inode *ni,
 	if (icx)
 		*icx = (ntfs_index_context) {
 			.ni = ni,
-			.name = name,
-			.name_len = name_len,
+				.name = name,
+				.name_len = name_len,
 		};
 	return icx;
 }
@@ -198,8 +198,8 @@ void ntfs_index_ctx_reinit(ntfs_index_context *icx)
 
 	*icx = (ntfs_index_context) {
 		.ni = icx->ni,
-		.name = icx->name,
-		.name_len = icx->name_len,
+			.name = icx->name,
+			.name_len = icx->name_len,
 	};
 }
 
@@ -345,7 +345,7 @@ static void ntfs_ie_delete(INDEX_HEADER *ih, INDEX_ENTRY *ie)
 	new_size = le32_to_cpu(ih->index_length) - le16_to_cpu(ie->length);
 	ih->index_length = cpu_to_le32(new_size);
 	memmove(ie, (u8 *)ie + le16_to_cpu(ie->length),
-		new_size - ((u8 *)ie - (u8 *)ih));
+			new_size - ((u8 *)ie - (u8 *)ih));
 }
 
 static void ntfs_ie_set_vcn(INDEX_ENTRY *ie, VCN vcn)
@@ -364,7 +364,7 @@ static void ntfs_ie_insert(INDEX_HEADER *ih, INDEX_ENTRY *ie, INDEX_ENTRY *pos)
 
 	ih->index_length = cpu_to_le32(le32_to_cpu(ih->index_length) + ie_size);
 	memmove((u8 *)pos + ie_size, pos,
-		le32_to_cpu(ih->index_length) - ((u8 *)pos - (u8 *)ih) - ie_size);
+			le32_to_cpu(ih->index_length) - ((u8 *)pos - (u8 *)ih) - ie_size);
 	memcpy(pos, ie, ie_size);
 }
 
@@ -401,7 +401,7 @@ static INDEX_ENTRY *ntfs_ie_dup_novcn(INDEX_ENTRY *ie)
 }
 
 INDEX_ROOT *ntfs_ir_lookup(ntfs_inode *ni, ntfschar *name,
-				  u32 name_len, ntfs_attr_search_ctx **ctx)
+		u32 name_len, ntfs_attr_search_ctx **ctx)
 {
 	ATTR_RECORD *a;
 	INDEX_ROOT *ir = NULL;
@@ -413,7 +413,7 @@ INDEX_ROOT *ntfs_ir_lookup(ntfs_inode *ni, ntfschar *name,
 		return NULL;
 
 	if (ntfs_attr_lookup(AT_INDEX_ROOT, name, name_len, CASE_SENSITIVE,
-			     0, NULL, 0, *ctx)) {
+				0, NULL, 0, *ctx)) {
 		ntfs_log_perror("Failed to lookup $INDEX_ROOT");
 		goto err_out;
 	}
@@ -474,7 +474,7 @@ int ntfs_index_block_inconsistent(ntfs_volume *vol, ntfs_attr *ia_na,
 {
 	INDEX_HEADER *ih = &ib->index;
 	u32 ib_size = (unsigned)le32_to_cpu(ih->allocated_size)
-			+ offsetof(INDEX_BLOCK, index);
+		+ offsetof(INDEX_BLOCK, index);
 	BOOL fixed = FALSE;
 	problem_context_t pctx = {0, };
 
@@ -487,22 +487,22 @@ int ntfs_index_block_inconsistent(ntfs_volume *vol, ntfs_attr *ia_na,
 
 	if (sle64_to_cpu(ib->index_block_vcn) != vcn) {
 		ntfs_log_error("%sCorrupt index block: VCN (%lld) is different "
-			       "from expected VCN (%lld) in inode %llu\n",
-			       fixed == TRUE ? "\n" : "",
-			       (long long)sle64_to_cpu(ib->index_block_vcn),
-			       (long long)vcn,
-			       (unsigned long long)inum);
+				"from expected VCN (%lld) in inode %llu\n",
+				fixed == TRUE ? "\n" : "",
+				(long long)sle64_to_cpu(ib->index_block_vcn),
+				(long long)vcn,
+				(unsigned long long)inum);
 		return -1;
 	}
 
 	if (ib_size != block_size) {
 		ntfs_log_error("%sCorrupt index block : VCN (%lld) of inode %llu "
-			       "has a size (%u) differing from the index "
-			       "specified size (%u)\n",
-			       fixed == TRUE ? "\n" : "",
-			       (long long)vcn,
-			       (unsigned long long)inum, ib_size,
-			       (unsigned int)block_size);
+				"has a size (%u) differing from the index "
+				"specified size (%u)\n",
+				fixed == TRUE ? "\n" : "",
+				(long long)vcn,
+				(unsigned long long)inum, ib_size,
+				(unsigned int)block_size);
 		return -1;
 	}
 
@@ -582,8 +582,8 @@ static ntfs_attr *ntfs_ia_open(ntfs_index_context *icx, ntfs_inode *ni)
  */
 
 int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
-			COLLATION_RULES collation_rule, u64 inum,
-			ntfs_index_context *ictx)
+		COLLATION_RULES collation_rule, u64 inum,
+		ntfs_index_context *ictx)
 {
 	int ret = 0;
 	problem_context_t pctx = {0, };
@@ -609,7 +609,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 	}
 
 	if (ie->length == cpu_to_le16(sizeof(INDEX_ENTRY_HEADER)) &&
-	    !ie->ie_flags) {
+			!ie->ie_flags) {
 		fsck_err_found();
 		if (ntfs_fix_problem(vol, PR_IE_END_FLAG_CORRUPTED, &pctx)) {
 			ie->ie_flags = INDEX_ENTRY_END;
@@ -638,7 +638,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 
 	if (ie->ie_flags & INDEX_ENTRY_NODE) {
 		if (((le16_to_cpu(ie->key_length) + offsetof(INDEX_ENTRY, key) + 7) & ~7) !=
-		    (le16_to_cpu(ie->length) - 8)) {
+				(le16_to_cpu(ie->length) - 8)) {
 			/* TODO: need to fix it */
 			ntfs_log_error("there is no vcn space in index node\n");
 			return -1;
@@ -646,7 +646,7 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 	}
 
 	if (((le16_to_cpu(ie->key_length) + offsetof(INDEX_ENTRY, key) + 7) & ~7) ==
-	    (le16_to_cpu(ie->length) - 8)) {
+			(le16_to_cpu(ie->length) - 8)) {
 		if (!(ie->ie_flags & INDEX_ENTRY_NODE)) {
 			fsck_err_found();
 			if (ntfs_fix_problem(vol, PR_IE_FLAG_SUB_NODE_CORRUPTED, &pctx)) {
@@ -662,30 +662,30 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
 		return 0;
 
 	if (ie->key_length &&
-	    ((le16_to_cpu(ie->key_length) + offsetof(INDEX_ENTRY, key)) >
-	     le16_to_cpu(ie->length))) {
+			((le16_to_cpu(ie->key_length) + offsetof(INDEX_ENTRY, key)) >
+			 le16_to_cpu(ie->length))) {
 		ntfs_log_error("Overflow from index entry in inode %lld",
 				(long long)inum);
 		ret = -1;
 	} else {
 		if (collation_rule == COLLATION_FILE_NAME) {
 			if ((offsetof(INDEX_ENTRY, key.file_name.file_name)
-				    + ie->key.file_name.file_name_length
+						+ ie->key.file_name.file_name_length
 						* sizeof(ntfschar))
-				> le16_to_cpu(ie->length)) {
+					> le16_to_cpu(ie->length)) {
 				ntfs_log_error("File name overflow from index"
-					" entry in inode %lld",
-					(long long)inum);
+						" entry in inode %lld",
+						(long long)inum);
 				ret = -1;
 			}
 		} else {
 			if (ie->data_length
-				&& ((le16_to_cpu(ie->data_offset)
-				    + le16_to_cpu(ie->data_length))
-				    > le16_to_cpu(ie->length))) {
+					&& ((le16_to_cpu(ie->data_offset)
+							+ le16_to_cpu(ie->data_length))
+						> le16_to_cpu(ie->length))) {
 				ntfs_log_error("Data overflow from index"
-					" entry in inode %lld",
-					(long long)inum);
+						" entry in inode %lld",
+						(long long)inum);
 				ret = -1;
 			}
 		}
@@ -706,8 +706,8 @@ int ntfs_index_entry_inconsistent(ntfs_volume *vol, INDEX_ENTRY *ie,
  *   STATUS_ERROR with errno set if on unexpected error during lookup.
  */
 static int ntfs_ie_lookup(const void *key, const int key_len,
-			  ntfs_index_context *icx, INDEX_HEADER *ih,
-			  VCN *vcn, INDEX_ENTRY **ie_out)
+		ntfs_index_context *icx, INDEX_HEADER *ih,
+		VCN *vcn, INDEX_ENTRY **ie_out)
 {
 	INDEX_ENTRY *ie;
 	u8 *index_end;
@@ -724,11 +724,11 @@ static int ntfs_ie_lookup(const void *key, const int key_len,
 	for (ie = ntfs_ie_get_first(ih); ; ie = ntfs_ie_get_next(ie)) {
 		/* Bounds checks. */
 		if ((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end ||
-		    (u8 *)ie + le16_to_cpu(ie->length) > index_end) {
+				(u8 *)ie + le16_to_cpu(ie->length) > index_end) {
 			errno = ERANGE;
 			ntfs_log_error("Index entry out of bounds in inode "
-				       "%llu.\n",
-				       (unsigned long long)icx->ni->mft_no);
+					"%llu.\n",
+					(unsigned long long)icx->ni->mft_no);
 			return STATUS_ERROR;
 		}
 
@@ -757,10 +757,10 @@ static int ntfs_ie_lookup(const void *key, const int key_len,
 		}
 
 		rc = icx->collate(icx->ni->vol, key, key_len,
-					&ie->key, le16_to_cpu(ie->key_length));
+				&ie->key, le16_to_cpu(ie->key_length));
 		if (rc == NTFS_COLLATION_ERROR) {
 			ntfs_log_error("Collation error. Perhaps a filename "
-				       "contains invalid characters?\n");
+					"contains invalid characters?\n");
 			errno = ERANGE;
 			return STATUS_ERROR;
 		}
@@ -798,7 +798,7 @@ static int ntfs_ie_lookup(const void *key, const int key_len,
 	if (*vcn < 0) {
 		errno = EINVAL;
 		ntfs_log_perror("Negative vcn in inode %llu",
-			       	(unsigned long long)icx->ni->mft_no);
+				(unsigned long long)icx->ni->mft_no);
 		return STATUS_ERROR;
 	}
 
@@ -822,7 +822,7 @@ int ntfs_ib_read(ntfs_index_context *icx, VCN vcn, INDEX_BLOCK *dst)
 			ntfs_log_perror("Failed to read index block");
 		else
 			ntfs_log_error("Failed(%lld) to read full index block at "
-				       "%lld\n", (long long)ret, (long long)pos);
+					"%lld\n", (long long)ret, (long long)pos);
 		return -1;
 	}
 
@@ -925,7 +925,7 @@ int ntfs_index_lookup(const void *key, const int key_len, ntfs_index_context *ic
 		icx->vcn_size_bits = ni->vol->cluster_size_bits;
 	else
 		icx->vcn_size_bits = NTFS_BLOCK_SIZE_BITS;
-			/* get the appropriate collation function */
+	/* get the appropriate collation function */
 	icx->ir = ir;
 	icx->collate = ntfs_get_collate_function(ir->collation_rule);
 	if (!icx->collate) {
@@ -996,8 +996,8 @@ descend_into_child_node:
 
 	if ((ib->index.ih_flags & NODE_MASK) == LEAF_NODE) {
 		ntfs_log_error("Index entry with child node found in a leaf "
-			       "node in inode 0x%llx.\n",
-			       (unsigned long long)ni->mft_no);
+				"node in inode 0x%llx.\n",
+				(unsigned long long)ni->mft_no);
 		goto err_out;
 	}
 
@@ -1028,7 +1028,7 @@ done:
 }
 
 static INDEX_BLOCK *ntfs_ib_alloc(VCN ib_vcn, u32 ib_size,
-				  INDEX_HEADER_FLAGS node_type)
+		INDEX_HEADER_FLAGS node_type)
 {
 	INDEX_BLOCK *ib;
 	int ih_size = sizeof(INDEX_HEADER);
@@ -1049,10 +1049,10 @@ static INDEX_BLOCK *ntfs_ib_alloc(VCN ib_vcn, u32 ib_size,
 	ib->index_block_vcn = cpu_to_sle64(ib_vcn);
 
 	ib->index.entries_offset = cpu_to_le32((ih_size +
-			le16_to_cpu(ib->usa_count) * 2 + 7) & ~7);
+				le16_to_cpu(ib->usa_count) * 2 + 7) & ~7);
 	ib->index.index_length = const_cpu_to_le32(0);
 	ib->index.allocated_size = cpu_to_le32(ib_size -
-					       (sizeof(INDEX_BLOCK) - ih_size));
+			(sizeof(INDEX_BLOCK) - ih_size));
 	ib->index.ih_flags = node_type;
 
 	return ib;
@@ -1112,7 +1112,7 @@ static int ntfs_ibm_add(ntfs_index_context *icx)
 	 */
 	memset(bmp, 0, sizeof(bmp));
 	if (ntfs_attr_add(icx->ni, AT_BITMAP, icx->name, icx->name_len,
-			  bmp, sizeof(bmp))) {
+				bmp, sizeof(bmp))) {
 		ntfs_log_perror("Failed to add AT_BITMAP");
 		return STATUS_ERROR;
 	}
@@ -1221,7 +1221,7 @@ static VCN ntfs_ibm_get_free(ntfs_index_context *icx)
 	ntfs_log_trace("Entering\n");
 
 	bm = ntfs_attr_readall(icx->ni, AT_BITMAP,  icx->name, icx->name_len,
-			       &size);
+			&size);
 	if (!bm)
 		return (VCN)-1;
 
@@ -1300,7 +1300,7 @@ static void ntfs_ir_nill(INDEX_ROOT *ir)
 }
 
 static int ntfs_ib_copy_tail(ntfs_index_context *icx, INDEX_BLOCK *src,
-			     INDEX_ENTRY *median, VCN new_vcn)
+		INDEX_ENTRY *median, VCN new_vcn)
 {
 	u8 *ies_end;
 	INDEX_ENTRY *ie_head;		/* first entry after the median */
@@ -1310,7 +1310,7 @@ static int ntfs_ib_copy_tail(ntfs_index_context *icx, INDEX_BLOCK *src,
 	ntfs_log_trace("Entering\n");
 
 	dst = ntfs_ib_alloc(new_vcn, icx->block_size,
-			    src->index.ih_flags & NODE_MASK);
+			src->index.ih_flags & NODE_MASK);
 	if (!dst)
 		return STATUS_ERROR;
 
@@ -1321,7 +1321,7 @@ static int ntfs_ib_copy_tail(ntfs_index_context *icx, INDEX_BLOCK *src,
 	memcpy(ntfs_ie_get_first(&dst->index), ie_head, tail_size);
 
 	dst->index.index_length = cpu_to_le32(tail_size +
-					      le32_to_cpu(dst->index.entries_offset));
+			le32_to_cpu(dst->index.entries_offset));
 	ret = ntfs_ib_write(icx, dst);
 
 	free(dst);
@@ -1329,7 +1329,7 @@ static int ntfs_ib_copy_tail(ntfs_index_context *icx, INDEX_BLOCK *src,
 }
 
 static int ntfs_ib_cut_tail(ntfs_index_context *icx, INDEX_BLOCK *ib,
-			    INDEX_ENTRY *ie)
+		INDEX_ENTRY *ie)
 {
 	char *ies_start, *ies_end;
 	INDEX_ENTRY *ie_last;
@@ -1346,7 +1346,7 @@ static int ntfs_ib_cut_tail(ntfs_index_context *icx, INDEX_BLOCK *ib,
 	memcpy(ie, ie_last, le16_to_cpu(ie_last->length));
 
 	ib->index.index_length = cpu_to_le32(((char *)ie - ies_start) +
-		le16_to_cpu(ie->length) + le32_to_cpu(ib->index.entries_offset));
+			le16_to_cpu(ie->length) + le32_to_cpu(ib->index.entries_offset));
 
 	if (ntfs_ib_write(icx, ib))
 		return STATUS_ERROR;
@@ -1364,7 +1364,7 @@ static int ntfs_ia_add(ntfs_index_context *icx)
 	if (!ntfs_attr_exist(icx->ni, AT_INDEX_ALLOCATION, icx->name, icx->name_len)) {
 
 		if (ntfs_attr_add(icx->ni, AT_INDEX_ALLOCATION, icx->name,
-				  icx->name_len, NULL, 0)) {
+					icx->name_len, NULL, 0)) {
 			ntfs_log_perror("Failed to add AT_INDEX_ALLOCATION");
 			return -1;
 		}
@@ -1427,25 +1427,25 @@ retry :
 
 	ir->index.ih_flags = LARGE_INDEX;
 	ir->index.index_length = cpu_to_le32(le32_to_cpu(ir->index.entries_offset)
-					     + le16_to_cpu(ie->length));
+			+ le16_to_cpu(ie->length));
 	ir->index.allocated_size = ir->index.index_length;
 	ix_root_size = sizeof(INDEX_ROOT) - sizeof(INDEX_HEADER)
-			+ le32_to_cpu(ir->index.allocated_size);
+		+ le32_to_cpu(ir->index.allocated_size);
 	if (ntfs_resident_attr_value_resize(ctx->mrec, ctx->attr,
-					ix_root_size)) {
-			/*
-			 * When there is no space to build a non-resident
-			 * index, we may have to move the root to an extent
-			 */
+				ix_root_size)) {
+		/*
+		 * When there is no space to build a non-resident
+		 * index, we may have to move the root to an extent
+		 */
 		if ((errno == ENOSPC)
-		    && (ctx->al_entry || !ntfs_inode_add_attrlist(icx->ni))) {
+				&& (ctx->al_entry || !ntfs_inode_add_attrlist(icx->ni))) {
 			ntfs_attr_put_search_ctx(ctx);
 			ctx = (ntfs_attr_search_ctx*)NULL;
 			ir = ntfs_ir_lookup(icx->ni, icx->name, icx->name_len,
-							&ctx);
+					&ctx);
 			if (ir
-			    && !ntfs_attr_record_move_away(ctx, ix_root_size
-				    - le32_to_cpu(ctx->attr->value_length))) {
+					&& !ntfs_attr_record_move_away(ctx, ix_root_size
+						- le32_to_cpu(ctx->attr->value_length))) {
 				ntfs_attr_put_search_ctx(ctx);
 				ctx = (ntfs_attr_search_ctx*)NULL;
 				goto retry;
@@ -1552,7 +1552,7 @@ static int ntfs_ie_add_vcn(INDEX_ENTRY **ie)
 }
 
 static int ntfs_ih_insert(INDEX_HEADER *ih, INDEX_ENTRY *orig_ie, VCN new_vcn,
-			  int pos)
+		int pos)
 {
 	INDEX_ENTRY *ie_node, *ie;
 	int ret = STATUS_ERROR;
@@ -1604,7 +1604,7 @@ int ntfsck_update_index_entry(ntfs_index_context *ictx)
 }
 
 static int ntfs_ir_insert_median(ntfs_index_context *icx, INDEX_ENTRY *median,
-				 VCN new_vcn)
+		VCN new_vcn)
 {
 	u32 new_size;
 	int ret;
@@ -1616,7 +1616,7 @@ static int ntfs_ir_insert_median(ntfs_index_context *icx, INDEX_ENTRY *median,
 		return STATUS_ERROR;
 
 	new_size = le32_to_cpu(icx->ir->index.index_length) +
-			le16_to_cpu(median->length);
+		le16_to_cpu(median->length);
 	if (!(median->ie_flags & INDEX_ENTRY_NODE))
 		new_size += sizeof(VCN);
 
@@ -1629,7 +1629,7 @@ static int ntfs_ir_insert_median(ntfs_index_context *icx, INDEX_ENTRY *median,
 		return STATUS_ERROR;
 
 	return ntfs_ih_insert(&icx->ir->index, median, new_vcn,
-			      ntfs_icx_parent_pos(icx));
+			ntfs_icx_parent_pos(icx));
 }
 
 static int ntfs_ib_split(ntfs_index_context *icx, INDEX_BLOCK *ib);
@@ -1760,7 +1760,7 @@ int ntfs_ie_add(ntfs_index_context *icx, INDEX_ENTRY *ie)
 			break;
 
 		ntfs_log_trace("index block sizes: allocated: %d  needed: %d\n",
-			       allocated_size, new_size);
+				allocated_size, new_size);
 
 		if (icx->is_in_root) {
 			if (ntfs_ir_make_space(icx, new_size) == STATUS_ERROR)
@@ -1806,7 +1806,7 @@ int ntfs_index_add_filename(ntfs_inode *ni, FILE_NAME_ATTR *fn, MFT_REF mref)
 	}
 
 	fn_size = (fn->file_name_length * sizeof(ntfschar)) +
-			sizeof(FILE_NAME_ATTR);
+		sizeof(FILE_NAME_ATTR);
 	ie_size = (sizeof(INDEX_ENTRY_HEADER) + fn_size + 7) & ~7;
 
 	ie = ntfs_calloc(ie_size);
@@ -1832,7 +1832,7 @@ out:
 }
 
 static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
-			   INDEX_ENTRY *ie, INDEX_BLOCK *ib)
+		INDEX_ENTRY *ie, INDEX_BLOCK *ib)
 {
 	INDEX_ENTRY *ie_roam = NULL;
 	INDEX_ENTRY *ie_dup = NULL;
@@ -1856,7 +1856,7 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 		 * while deleting an entry from root index
 		 */
 		freed_space = le32_to_cpu(ih->allocated_size)
-				- le32_to_cpu(ih->index_length);
+			- le32_to_cpu(ih->index_length);
 		if (full && (freed_space > 0) && !(freed_space & 7)) {
 			ntfs_ir_truncate(icx, le32_to_cpu(ih->index_length));
 			/* do nothing if truncation fails */
@@ -1921,7 +1921,7 @@ static void ntfs_ir_leafify(ntfs_index_context *icx, INDEX_HEADER *ih)
  *  in the INDEX_ROOT which is not the only one there.
  */
 static int ntfs_ih_reparent_end(ntfs_index_context *icx, INDEX_HEADER *ih,
-				INDEX_BLOCK *ib)
+		INDEX_BLOCK *ib)
 {
 	INDEX_ENTRY *ie, *ie_prev;
 
@@ -2260,7 +2260,7 @@ out:
  */
 
 INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
-			ntfs_index_context *ictx)
+		ntfs_index_context *ictx)
 {
 	INDEX_ENTRY *entry;
 	s64 vcn;
@@ -2318,7 +2318,7 @@ INDEX_ENTRY *ntfs_index_walk_down(INDEX_ENTRY *ie,
  */
 
 INDEX_ENTRY *ntfs_index_walk_up(INDEX_ENTRY *ie,
-			ntfs_index_context *ictx)
+		ntfs_index_context *ictx)
 {
 	INDEX_ENTRY *entry;
 	s64 vcn;
@@ -2329,7 +2329,7 @@ INDEX_ENTRY *ntfs_index_walk_up(INDEX_ENTRY *ie,
 			ictx->pindex--;
 			if (!ictx->pindex) {
 
-					/* we have reached the root */
+				/* we have reached the root */
 
 				free(ictx->ib);
 				ictx->ib = (INDEX_BLOCK*)NULL;
@@ -2338,27 +2338,27 @@ INDEX_ENTRY *ntfs_index_walk_up(INDEX_ENTRY *ie,
 				if (ictx->actx)
 					free(ictx->actx);
 				ictx->ir = ntfs_ir_lookup(ictx->ni,
-					ictx->name, ictx->name_len,
-					&ictx->actx);
+						ictx->name, ictx->name_len,
+						&ictx->actx);
 				if (ictx->ir)
 					entry = ntfs_ie_get_by_pos(
-						&ictx->ir->index,
-						ictx->parent_pos[ictx->pindex]);
+							&ictx->ir->index,
+							ictx->parent_pos[ictx->pindex]);
 				else
 					entry = (INDEX_ENTRY*)NULL;
 			} else {
-					/* up into non-root node */
+				/* up into non-root node */
 				vcn = ictx->parent_vcn[ictx->pindex];
 				if (!ntfs_ib_read(ictx,vcn,ictx->ib)) {
 					entry = ntfs_ie_get_by_pos(
-						&ictx->ib->index,
-						ictx->parent_pos[ictx->pindex]);
+							&ictx->ib->index,
+							ictx->parent_pos[ictx->pindex]);
 				} else
 					entry = (INDEX_ENTRY*)NULL;
 			}
-		ictx->entry = entry;
+			ictx->entry = entry;
 		} while (entry && (ictx->pindex > 0)
-			 && (entry->ie_flags & INDEX_ENTRY_END));
+				&& (entry->ie_flags & INDEX_ENTRY_END));
 	} else
 		entry = (INDEX_ENTRY*)NULL;
 	return (entry);
@@ -2399,19 +2399,19 @@ INDEX_ENTRY *ntfs_index_next(INDEX_ENTRY *ie, ntfs_index_context *ictx)
 	int ret;
 	le16 flags;
 
-			/*
-                         * lookup() may have returned an invalid node
-			 * when searching for a partial key
-			 * if this happens, walk up
-			 */
+	/*
+	 * lookup() may have returned an invalid node
+	 * when searching for a partial key
+	 * if this happens, walk up
+	 */
 
 	if (ie->ie_flags & INDEX_ENTRY_END)
 		next = ntfs_index_walk_up(ie, ictx);
 	else {
-			/*
-			 * get next entry in same node
-                         * there is always one after any entry with data
-			 */
+		/*
+		 * get next entry in same node
+		 * there is always one after any entry with data
+		 */
 
 		next = (INDEX_ENTRY*)((char*)ie + le16_to_cpu(ie->length));
 		++ictx->parent_pos[ictx->pindex];
@@ -2428,20 +2428,20 @@ INDEX_ENTRY *ntfs_index_next(INDEX_ENTRY *ie, ntfs_index_context *ictx)
 			return NULL;
 		flags = next->ie_flags;
 
-			/* walk down if it has a subnode */
+		/* walk down if it has a subnode */
 
 		if (flags & INDEX_ENTRY_NODE) {
 			next = ntfs_index_walk_down(next,ictx);
 		} else {
 
-				/* walk up it has no subnode, nor data */
+			/* walk up it has no subnode, nor data */
 
 			if (flags & INDEX_ENTRY_END) {
 				next = ntfs_index_walk_up(next, ictx);
 			}
 		}
 	}
-		/* return NULL if stuck at end of a block */
+	/* return NULL if stuck at end of a block */
 
 	if (next && (next->ie_flags & INDEX_ENTRY_END))
 		next = (INDEX_ENTRY*)NULL;

--- a/libntfs/inode.c
+++ b/libntfs/inode.c
@@ -131,7 +131,7 @@ static void __ntfs_inode_release(ntfs_inode *ni)
 
 	if (NInoDirty(ni))
 		ntfs_log_error("Releasing dirty inode %lld!\n",
-			       (long long)ni->mft_no);
+				(long long)ni->mft_no);
 	if (NInoAttrList(ni) && ni->attr_list)
 		free(ni->attr_list);
 	free(ni->mrec);
@@ -223,8 +223,8 @@ static ntfs_inode *ntfs_inode_real_open(ntfs_volume *vol, const MFT_REF mref)
 	lthle = ctx->attr->value_length;
 	if (le32_to_cpu(lthle) < offsetof(STANDARD_INFORMATION, owner_id)) {
 		ntfs_log_error("Corrupt STANDARD_INFORMATION in base"
-			" record %lld\n",
-			(long long)MREF(mref));
+				" record %lld\n",
+				(long long)MREF(mref));
 		goto put_err_out;
 	}
 	std_info = (STANDARD_INFORMATION *)((u8 *)ctx->attr +
@@ -234,8 +234,8 @@ static ntfs_inode *ntfs_inode_real_open(ntfs_volume *vol, const MFT_REF mref)
 	ni->last_data_change_time = std_info->last_data_change_time;
 	ni->last_mft_change_time = std_info->last_mft_change_time;
 	ni->last_access_time = std_info->last_access_time;
-		/* Insert v3 extensions if present */
-		/* length may be seen as 48 (v1.x) or 72 (v3.x) */
+	/* Insert v3 extensions if present */
+	/* length may be seen as 48 (v1.x) or 72 (v3.x) */
 	if (le32_to_cpu(lthle) >= offsetof(STANDARD_INFORMATION, v3_end)) {
 		set_nino_flag(ni, v3_Extensions);
 		ni->owner_id = std_info->owner_id;
@@ -250,7 +250,7 @@ static ntfs_inode *ntfs_inode_real_open(ntfs_volume *vol, const MFT_REF mref)
 	/* Set attribute list information. */
 	olderrno = errno;
 	if (ntfs_attr_lookup(AT_ATTRIBUTE_LIST, AT_UNNAMED, 0,
-			CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 		if (errno != ENOENT)
 			goto put_err_out;
 		/* Attribute list attribute does not present. */
@@ -401,7 +401,7 @@ int ntfs_inode_real_close(ntfs_inode *ni)
 			if (base_ni->nr_extents) {
 				/* Resize the memory buffer. */
 				tmp_nis = realloc(tmp_nis, base_ni->nr_extents *
-						  sizeof(ntfs_inode *));
+						sizeof(ntfs_inode *));
 				/* Ignore errors, they don't really matter. */
 				if (tmp_nis)
 					base_ni->extent_nis = tmp_nis;
@@ -420,7 +420,7 @@ int ntfs_inode_real_close(ntfs_inode *ni)
 		 */
 		if (i != -1)
 			ntfs_log_error("Extent inode %lld was not found\n",
-				       (long long)ni->mft_no);
+					(long long)ni->mft_no);
 	}
 
 	__ntfs_inode_release(ni);
@@ -439,7 +439,7 @@ err:
 
 void ntfs_inode_nidata_free(const struct CACHED_GENERIC *cached)
 {
-        ntfs_inode_real_close(((const struct CACHED_NIDATA*)cached)->ni);
+	ntfs_inode_real_close(((const struct CACHED_NIDATA*)cached)->ni);
 }
 
 /*
@@ -457,7 +457,7 @@ int ntfs_inode_nidata_hash(const struct CACHED_GENERIC *item)
  */
 
 static int idata_cache_compare(const struct CACHED_GENERIC *cached,
-			const struct CACHED_GENERIC *wanted)
+		const struct CACHED_GENERIC *wanted)
 {
 	return (((const struct CACHED_NIDATA*)cached)->inum
 			!= ((const struct CACHED_NIDATA*)wanted)->inum);
@@ -478,7 +478,7 @@ void ntfs_inode_invalidate(ntfs_volume *vol, const MFT_REF mref)
 	item.pathname = (const char*)NULL;
 	item.varsize = 0;
 	ntfs_invalidate_cache(vol->nidata_cache,
-				GENERIC(&item),idata_cache_compare,CACHE_FREE);
+			GENERIC(&item),idata_cache_compare,CACHE_FREE);
 }
 
 #endif
@@ -500,13 +500,13 @@ ntfs_inode *ntfs_inode_open(ntfs_volume *vol, const MFT_REF mref)
 	struct CACHED_NIDATA item;
 	struct CACHED_NIDATA *cached;
 
-		/* fetch idata from cache */
+	/* fetch idata from cache */
 	item.inum = MREF(mref);
 	debug_double_inode(item.inum,1);
 	item.pathname = (const char*)NULL;
 	item.varsize = 0;
 	cached = (struct CACHED_NIDATA*)ntfs_fetch_cache(vol->nidata_cache,
-				GENERIC(&item),idata_cache_compare);
+			GENERIC(&item),idata_cache_compare);
 	if (cached) {
 		ni = cached->ni;
 		/* do not keep open entries in cache */
@@ -551,21 +551,21 @@ int ntfs_inode_close(ntfs_inode *ni)
 			dirty = NInoDirty(ni) || NInoAttrListDirty(ni);
 			if (dirty) {
 				res = ntfs_inode_sync(ni);
-					/* do a real close if sync failed */
+				/* do a real close if sync failed */
 				if (res)
 					ntfs_inode_real_close(ni);
 			} else
 				res = 0;
 
 			if (!res) {
-					/* feed idata into cache */
+				/* feed idata into cache */
 				item.inum = ni->mft_no;
 				item.ni = ni;
 				item.pathname = (const char*)NULL;
 				item.varsize = 0;
 				debug_cached_inode(ni);
 				ntfs_enter_cache(ni->vol->nidata_cache,
-					GENERIC(&item), idata_cache_compare);
+						GENERIC(&item), idata_cache_compare);
 			}
 		} else {
 			/* cache not ready or system file, really close */
@@ -625,30 +625,30 @@ ntfs_inode *ntfs_extent_inode_open(ntfs_inode *base_ni, const leMFT_REF mref)
 			(unsigned long long)base_ni->mft_no);
 
 	if (!base_ni->mft_no) {
-			/*
-			 * When getting extents of MFT, we must be sure
-			 * they are in the MFT part which has already
-			 * been mapped, otherwise we fall into an endless
-			 * recursion.
-			 * Situations have been met where extents locations
-			 * are described in themselves.
-			 * This is a severe error which chkdsk cannot fix.
-			 */
+		/*
+		 * When getting extents of MFT, we must be sure
+		 * they are in the MFT part which has already
+		 * been mapped, otherwise we fall into an endless
+		 * recursion.
+		 * Situations have been met where extents locations
+		 * are described in themselves.
+		 * This is a severe error which chkdsk cannot fix.
+		 */
 		vol = base_ni->vol;
 		extent_vcn = mft_no << vol->mft_record_size_bits
-				>> vol->cluster_size_bits;
+			>> vol->cluster_size_bits;
 		rl = vol->mft_na->rl;
 		if (rl) {
 			while (rl->length
-			    && ((rl->vcn + rl->length) <= extent_vcn))
+					&& ((rl->vcn + rl->length) <= extent_vcn))
 				rl++;
 		}
 		if (!rl || (rl->lcn < 0)) {
 			ntfs_log_error("MFT is corrupt, cannot read"
-				" its unmapped extent record %lld\n",
+					" its unmapped extent record %lld\n",
 					(long long)mft_no);
 			ntfs_log_error("Note : chkdsk cannot fix this,"
-				" try ntfsfix\n");
+					" try ntfsfix\n");
 			errno = EIO;
 			ni = (ntfs_inode*)NULL;
 			goto out;
@@ -667,11 +667,11 @@ ntfs_inode *ntfs_extent_inode_open(ntfs_inode *base_ni, const leMFT_REF mref)
 			/* Verify the sequence number if given. */
 			seq_no = MSEQNO_LE(mref);
 			if (seq_no && seq_no != le16_to_cpu(
-					ni->mrec->sequence_number)) {
+						ni->mrec->sequence_number)) {
 				errno = EIO;
 				ntfs_log_perror("Found stale extent mft "
-					"reference mft=%lld",
-					(long long)ni->mft_no);
+						"reference mft=%lld",
+						(long long)ni->mft_no);
 				goto out;
 			}
 			goto out;
@@ -685,7 +685,7 @@ ntfs_inode *ntfs_extent_inode_open(ntfs_inode *base_ni, const leMFT_REF mref)
 		goto err_out;
 
 	if ((base_ni->mft_no != 0 &&(MREF_LE(ni->mrec->base_mft_record) == 0)) ||
-	    (MREF_LE(ni->mrec->base_mft_record) != base_ni->mft_no)) {
+			(MREF_LE(ni->mrec->base_mft_record) != base_ni->mft_no)) {
 		ntfs_log_error("Base mft record(%"PRIu64") of inode(%"PRIu64") "
 				"is not a base inode(%"PRIu64")\n",
 				MREF_LE(ni->mrec->base_mft_record), mft_no,
@@ -793,7 +793,7 @@ static int ntfs_inode_sync_standard_information(ntfs_inode *ni)
 	if (!ctx)
 		return -1;
 	if (ntfs_attr_lookup(AT_STANDARD_INFORMATION, AT_UNNAMED,
-			     0, CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+				0, CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 		ntfs_log_perror("Failed to sync standard info (inode %lld)",
 				(long long)ni->mft_no);
 		ntfs_attr_put_search_ctx(ctx);
@@ -809,12 +809,12 @@ static int ntfs_inode_sync_standard_information(ntfs_inode *ni)
 		std_info->last_access_time = ni->last_access_time;
 	}
 
-		/* JPA update v3.x extensions, ensuring consistency */
+	/* JPA update v3.x extensions, ensuring consistency */
 
 	lthle = ctx->attr->value_length;
 	lth = le32_to_cpu(lthle);
 	if (test_nino_flag(ni, v3_Extensions)
-	    && (lth < offsetof(STANDARD_INFORMATION, v3_end)))
+			&& (lth < offsetof(STANDARD_INFORMATION, v3_end)))
 		ntfs_log_error("bad sync of standard information\n");
 
 	if (lth >= offsetof(STANDARD_INFORMATION, v3_end)) {
@@ -863,7 +863,7 @@ static int ntfs_inode_sync_file_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 	reparse_tag = const_cpu_to_le32(0);
 	if (ni->flags & FILE_ATTR_REPARSE_POINT) {
 		if (!ntfs_attr_lookup(AT_REPARSE_POINT, NULL,
-				0, CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					0, CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			rpp = (REPARSE_POINT*)((u8 *)ctx->attr +
 					le16_to_cpu(ctx->attr->value_offset));
 			reparse_tag = rpp->reparse_tag;
@@ -888,12 +888,12 @@ static int ntfs_inode_sync_file_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 				index_ni = dir_ni;
 			else
 				index_ni = ntfs_inode_open(ni->vol,
-					le64_to_cpu(fn->parent_directory));
+						le64_to_cpu(fn->parent_directory));
 		if (!index_ni) {
 			if (!err)
 				err = errno;
 			ntfs_log_perror("Failed to open inode %lld with index",
-				(long long)MREF_LE(fn->parent_directory));
+					(long long)MREF_LE(fn->parent_directory));
 			continue;
 		}
 
@@ -910,7 +910,7 @@ static int ntfs_inode_sync_file_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 			ntfs_log_perror("Failed to get index ctx, inode %lld",
 					(long long)index_ni->mft_no);
 			if ((ni != index_ni) && !dir_ni
-			    && ntfs_inode_close(index_ni) && !err)
+					&& ntfs_inode_close(index_ni) && !err)
 				err = errno;
 			continue;
 		}
@@ -933,8 +933,8 @@ static int ntfs_inode_sync_file_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 		/* Update flags and file size. */
 		fnx = (FILE_NAME_ATTR *)ictx->data;
 		fnx->file_attributes =
-				(fnx->file_attributes & ~FILE_ATTR_VALID_FLAGS) |
-				(ni->flags & FILE_ATTR_VALID_FLAGS);
+			(fnx->file_attributes & ~FILE_ATTR_VALID_FLAGS) |
+			(ni->flags & FILE_ATTR_VALID_FLAGS);
 		if (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)
 			fnx->data_size = fnx->allocated_size
 				= const_cpu_to_sle64(0);
@@ -948,7 +948,7 @@ static int ntfs_inode_sync_file_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 			 */
 			fn->allocated_size = fnx->allocated_size;
 		}
-			/* update or clear the reparse tag in the index */
+		/* update or clear the reparse tag in the index */
 		fnx->reparse_point_tag = reparse_tag;
 		if (!test_nino_flag(ni, TimesSet)) {
 			fnx->creation_time = ni->creation_time;
@@ -964,7 +964,7 @@ static int ntfs_inode_sync_file_name(ntfs_inode *ni, ntfs_inode *dir_ni)
 		ntfs_index_entry_mark_dirty(ictx);
 		ntfs_index_ctx_put(ictx);
 		if ((ni != index_ni) && !dir_ni
-		    && ntfs_inode_close(index_ni) && !err)
+				&& ntfs_inode_close(index_ni) && !err)
 			err = errno;
 	}
 	/* Check for real error occurred. */
@@ -1064,21 +1064,21 @@ int ntfs_inode_sync_in_dir(ntfs_inode *ni, ntfs_inode *dir_ni)
 
 		if (na->data_size == ni->attr_list_size) {
 			if (ntfs_attr_pwrite(na, 0, ni->attr_list_size,
-				        ni->attr_list) != ni->attr_list_size) {
+						ni->attr_list) != ni->attr_list_size) {
 				if (!err || errno == EIO) {
 					err = errno;
 					if (err != EIO)
 						err = EBUSY;
 					ntfs_log_perror("Attribute list sync "
-						"failed (write, inode %lld)",
-						(long long)ni->mft_no);
+							"failed (write, inode %lld)",
+							(long long)ni->mft_no);
 				}
 				NInoAttrListSetDirty(ni);
 			}
 		} else {
 			err = EIO;
 			ntfs_log_error("Attribute list sync failed (bad size, "
-				       "inode %lld)\n", (long long)ni->mft_no);
+					"inode %lld)\n", (long long)ni->mft_no);
 			NInoAttrListSetDirty(ni);
 		}
 		ntfs_attr_close(na);
@@ -1111,7 +1111,7 @@ sync_inode:
 				continue;
 
 			if (ntfs_mft_record_write(eni->vol, eni->mft_no,
-						  eni->mrec)) {
+						eni->mrec)) {
 				if (!err || errno == EIO) {
 					err = errno;
 					if (err != EIO)
@@ -1210,7 +1210,7 @@ int ntfs_inode_add_attrlist(ntfs_inode *ni)
 		}
 
 		ale_size = (sizeof(ATTR_LIST_ENTRY) + sizeof(ntfschar) *
-					ctx->attr->name_length + 7) & ~7;
+				ctx->attr->name_length + 7) & ~7;
 		al_len += ale_size;
 
 		aln = realloc(al, al_len);
@@ -1227,7 +1227,7 @@ int ntfs_inode_add_attrlist(ntfs_inode *ni)
 		/* Add attribute to attribute list. */
 		ale->type = ctx->attr->type;
 		ale->length = cpu_to_le16((sizeof(ATTR_LIST_ENTRY) +
-			sizeof(ntfschar) * ctx->attr->name_length + 7) & ~7);
+					sizeof(ntfschar) * ctx->attr->name_length + 7) & ~7);
 		ale->name_length = ctx->attr->name_length;
 		ale->name_offset = (u8 *)ale->name - (u8 *)ale;
 		if (ctx->attr->non_resident)
@@ -1235,7 +1235,7 @@ int ntfs_inode_add_attrlist(ntfs_inode *ni)
 		else
 			ale->lowest_vcn = const_cpu_to_sle64(0);
 		ale->mft_reference = MK_LE_MREF(ni->mft_no,
-			le16_to_cpu(ni->mrec->sequence_number));
+				le16_to_cpu(ni->mrec->sequence_number));
 		ale->instance = ctx->attr->instance;
 		memcpy(ale->name, (u8 *)ctx->attr +
 				le16_to_cpu(ctx->attr->name_offset),
@@ -1261,7 +1261,7 @@ int ntfs_inode_add_attrlist(ntfs_inode *ni)
 			le32_to_cpu(ni->mrec->bytes_in_use) <
 			offsetof(ATTR_RECORD, resident_end)) {
 		if (ntfs_inode_free_space(ni,
-				offsetof(ATTR_RECORD, resident_end))) {
+					offsetof(ATTR_RECORD, resident_end))) {
 			/* Failed to free space. */
 			err = errno;
 			ntfs_log_perror("Failed to free space for attrlist");
@@ -1366,10 +1366,10 @@ int ntfs_inode_free_space(ntfs_inode *ni, int size)
 	}
 
 	ntfs_log_trace("Entering for inode %lld, size %d\n",
-		       (unsigned long long)ni->mft_no, size);
+			(unsigned long long)ni->mft_no, size);
 
 	freed = (le32_to_cpu(ni->mrec->bytes_allocated) -
-				le32_to_cpu(ni->mrec->bytes_in_use));
+			le32_to_cpu(ni->mrec->bytes_in_use));
 
 	if (size <= freed)
 		return 0;
@@ -1397,7 +1397,7 @@ retry:
 		}
 
 		if (ntfs_inode_base(ctx->ntfs_ino)->mft_no == FILE_MFT &&
-		    ctx->attr->type == AT_DATA)
+				ctx->attr->type == AT_DATA)
 			goto retry;
 
 		if (ctx->attr->type == AT_INDEX_ROOT)
@@ -1491,10 +1491,10 @@ int ntfs_inode_badclus_bad(u64 mft_no, ATTR_RECORD *attr)
 	}
 
 	if (mft_no != FILE_BadClus)
-	       	return 0;
+		return 0;
 
 	if (attr->type != AT_DATA)
-	       	return 0;
+		return 0;
 
 	if ((ustr = ntfs_str2ucs("$Bad", &len)) == NULL) {
 		ntfs_log_perror("Couldn't convert '$Bad' to Unicode");
@@ -1502,8 +1502,8 @@ int ntfs_inode_badclus_bad(u64 mft_no, ATTR_RECORD *attr)
 	}
 
 	if (ustr && ntfs_names_are_equal(ustr, len,
-			(ntfschar *)((u8 *)attr + le16_to_cpu(attr->name_offset)),
-			attr->name_length, 0, NULL, 0))
+				(ntfschar *)((u8 *)attr + le16_to_cpu(attr->name_offset)),
+				attr->name_length, 0, NULL, 0))
 		ret = 1;
 
 	ntfs_ucsfree(ustr);
@@ -1532,7 +1532,7 @@ int ntfs_inode_get_times(ntfs_inode *ni, char *value, size_t size)
 	ctx = ntfs_attr_get_search_ctx(ni, NULL);
 	if (ctx) {
 		if (ntfs_attr_lookup(AT_STANDARD_INFORMATION, AT_UNNAMED,
-				     0, CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					0, CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			ntfs_log_perror("Failed to get standard info (inode %lld)",
 					(long long)ni->mft_no);
 		} else {
@@ -1559,7 +1559,7 @@ int ntfs_inode_get_times(ntfs_inode *ni, char *value, size_t size)
 					ret = 32;
 				else
 					ret = -ERANGE;
-			}
+		}
 		ntfs_attr_put_search_ctx(ctx);
 	}
 	return (ret ? ret : -errno);
@@ -1580,7 +1580,7 @@ int ntfs_inode_get_times(ntfs_inode *ni, char *value, size_t size)
  */
 
 int ntfs_inode_set_times(ntfs_inode *ni, const char *value, size_t size,
-			int flags)
+		int flags)
 {
 	ntfs_attr_search_ctx *ctx;
 	STANDARD_INFORMATION *std_info;
@@ -1594,19 +1594,19 @@ int ntfs_inode_set_times(ntfs_inode *ni, const char *value, size_t size,
 	if ((size >= 8) && !(flags & XATTR_CREATE)) {
 		/* Copy, to avoid alignment issue encountered on ARM */
 		memcpy(times, value,
-			(size < sizeof(times) ? size : sizeof(times)));
+				(size < sizeof(times) ? size : sizeof(times)));
 		now = ntfs_current_time();
-			/* update the standard information attribute */
+		/* update the standard information attribute */
 		ctx = ntfs_attr_get_search_ctx(ni, NULL);
 		if (ctx) {
 			if (ntfs_attr_lookup(AT_STANDARD_INFORMATION,
-					AT_UNNAMED, 0, CASE_SENSITIVE,
-					0, NULL, 0, ctx)) {
+						AT_UNNAMED, 0, CASE_SENSITIVE,
+						0, NULL, 0, ctx)) {
 				ntfs_log_perror("Failed to get standard info (inode %lld)",
 						(long long)ni->mft_no);
 			} else {
 				std_info = (STANDARD_INFORMATION *)((u8 *)ctx->attr +
-					le16_to_cpu(ctx->attr->value_offset));
+						le16_to_cpu(ctx->attr->value_offset));
 				/*
 				 * Mark times set to avoid overwriting
 				 * them when the inode is closed.
@@ -1638,10 +1638,10 @@ int ntfs_inode_set_times(ntfs_inode *ni, const char *value, size_t size,
 				ntfs_attr_reinit_search_ctx(ctx);
 				cnt = 0;
 				while (!ntfs_attr_lookup(AT_FILE_NAME,
-						AT_UNNAMED, 0, CASE_SENSITIVE,
-						0, NULL, 0, ctx)) {
+							AT_UNNAMED, 0, CASE_SENSITIVE,
+							0, NULL, 0, ctx)) {
 					fn = (FILE_NAME_ATTR*)((u8 *)ctx->attr +
-						le16_to_cpu(ctx->attr->value_offset));
+							le16_to_cpu(ctx->attr->value_offset));
 					fn->creation_time
 						= cpu_to_sle64(times[0]);
 					if (size >= 16)
@@ -1657,7 +1657,7 @@ int ntfs_inode_set_times(ntfs_inode *ni, const char *value, size_t size,
 					ret = 0;
 				else {
 					ntfs_log_perror("Failed to get file names (inode %lld)",
-						(long long)ni->mft_no);
+							(long long)ni->mft_no);
 				}
 			}
 			ntfs_attr_put_search_ctx(ctx);

--- a/libntfs/ioctl.c
+++ b/libntfs/ioctl.c
@@ -92,7 +92,7 @@ static int fstrim_clusters(ntfs_volume *vol, LCN lcn, s64 length)
 	uint64_t range[2];
 
 	ntfs_log_debug("fstrim_clusters: %lld length %lld\n",
-		(long long) lcn, (long long) length);
+			(long long) lcn, (long long) length);
 
 	range[0] = lcn << vol->cluster_size_bits;
 	range[1] = length << vol->cluster_size_bits;
@@ -134,11 +134,11 @@ static int read_u64(const char *path, u64 *n)
 }
 
 /* Find discard limits for current backing device.
- */
+*/
 static int fstrim_limits(ntfs_volume *vol,
-			u64 *discard_alignment,
-			u64 *discard_granularity,
-			u64 *discard_max_bytes)
+		u64 *discard_alignment,
+		u64 *discard_granularity,
+		u64 *discard_max_bytes)
 {
 	struct stat statbuf;
 	char path1[40]; /* holds "/sys/dev/block/%d:%d" */
@@ -148,7 +148,7 @@ static int fstrim_limits(ntfs_volume *vol,
 	/* Stat the backing device.  Caller has ensured it is a block device. */
 	if (stat(vol->dev->d_name, &statbuf) == -1) {
 		ntfs_log_debug("fstrim_limits: could not stat %s\n",
-			vol->dev->d_name);
+				vol->dev->d_name);
 		return -errno;
 	}
 
@@ -162,7 +162,7 @@ static int fstrim_limits(ntfs_volume *vol,
 	 * /sys/dev/block/MAJOR:MINOR/../queue/discard_max_bytes
 	 */
 	snprintf(path1, sizeof path1, "/sys/dev/block/%d:%d",
-		major(statbuf.st_rdev), minor(statbuf.st_rdev));
+			major(statbuf.st_rdev), minor(statbuf.st_rdev));
 
 	snprintf(path2, sizeof path2, "%s/discard_alignment", path1);
 	ret = read_u64(path2, discard_alignment);
@@ -184,7 +184,7 @@ static int fstrim_limits(ntfs_volume *vol,
 			return ret;
 		else {
 			snprintf(path2, sizeof path2,
-				"%s/../queue/discard_granularity", path1);
+					"%s/../queue/discard_granularity", path1);
 			ret = read_u64(path2, discard_granularity);
 			if (ret) {
 				if (ret != -ENOENT)
@@ -202,7 +202,7 @@ static int fstrim_limits(ntfs_volume *vol,
 			return ret;
 		else {
 			snprintf(path2, sizeof path2,
-				"%s/../queue/discard_max_bytes", path1);
+					"%s/../queue/discard_max_bytes", path1);
 			ret = read_u64(path2, discard_max_bytes);
 			if (ret) {
 				if (ret != -ENOENT)
@@ -264,9 +264,9 @@ static int fstrim(ntfs_volume *vol, void *data, u64 *trimmed)
 	int ret;
 
 	ntfs_log_debug("fstrim: start=%llu len=%llu minlen=%llu\n",
-		(unsigned long long) start,
-		(unsigned long long) len,
-		(unsigned long long) minlen);
+			(unsigned long long) start,
+			(unsigned long long) len,
+			(unsigned long long) minlen);
 
 	*trimmed = 0;
 
@@ -316,7 +316,7 @@ static int fstrim(ntfs_volume *vol, void *data, u64 *trimmed)
 	if (buf == NULL)
 		return -errno;
 	for (start_buf = 0; start_buf < vol->nr_clusters;
-	     start_buf += FSTRIM_BUFSIZ * 8) {
+			start_buf += FSTRIM_BUFSIZ * 8) {
 		s64 count;
 		s64 br;
 		LCN end_buf, start_lcn;
@@ -353,9 +353,9 @@ static int fstrim(ntfs_volume *vol, void *data, u64 *trimmed)
 				 */
 				end_lcn = start_lcn+1;
 				while (end_lcn < end_buf &&
-					(u64) (end_lcn-start_lcn) << vol->cluster_size_bits
-					  < discard_max_bytes &&
-					!ntfs_bit_get(buf, end_lcn-start_buf))
+						(u64) (end_lcn-start_lcn) << vol->cluster_size_bits
+						< discard_max_bytes &&
+						!ntfs_bit_get(buf, end_lcn-start_buf))
 					end_lcn++;
 				aligned_lcn = align_up(vol, start_lcn,
 						discard_granularity);
@@ -364,12 +364,12 @@ static int fstrim(ntfs_volume *vol, void *data, u64 *trimmed)
 				else {
 					aligned_count =
 						align_down(vol,
-							end_lcn - aligned_lcn,
-							discard_granularity);
+								end_lcn - aligned_lcn,
+								discard_granularity);
 				}
 				if (aligned_count) {
 					ret = fstrim_clusters(vol,
-						aligned_lcn, aligned_count);
+							aligned_lcn, aligned_count);
 					if (ret)
 						goto free_out;
 
@@ -390,30 +390,30 @@ free_out:
 #endif /* FITRIM && BLKDISCARD */
 
 int ntfs_ioctl(ntfs_inode *ni, unsigned long cmd,
-			void *arg __attribute__((unused)),
-			unsigned int flags __attribute__((unused)), void *data)
+		void *arg __attribute__((unused)),
+		unsigned int flags __attribute__((unused)), void *data)
 {
 	int ret = 0;
 
 	switch (cmd) {
 #if defined(FITRIM) && defined(BLKDISCARD)
-	case FITRIM:
-		if (!ni || !data)
-			ret = -EINVAL;
-		else {
-			u64 trimmed;
-			struct fstrim_range *range = (struct fstrim_range*)data;
+		case FITRIM:
+			if (!ni || !data)
+				ret = -EINVAL;
+			else {
+				u64 trimmed;
+				struct fstrim_range *range = (struct fstrim_range*)data;
 
-			ret = fstrim(ni->vol, data, &trimmed);
-			range->len = trimmed;
-		}
-		break;
+				ret = fstrim(ni->vol, data, &trimmed);
+				range->len = trimmed;
+			}
+			break;
 #else
 #warning Trimming not supported : FITRIM or BLKDISCARD not defined
 #endif
-	default :
-		ret = -EINVAL;
-		break;
+		default :
+			ret = -EINVAL;
+			break;
 	}
 	return (ret);
 }

--- a/libntfs/lcnalloc.c
+++ b/libntfs/lcnalloc.c
@@ -79,13 +79,13 @@ static void ntfs_cluster_update_zone_pos(ntfs_volume *vol, u8 zone, LCN tc)
 
 	if (zone == ZONE_MFT)
 		ntfs_cluster_set_zone_pos(vol->mft_lcn, vol->mft_zone_end,
-					  &vol->mft_zone_pos, tc);
+				&vol->mft_zone_pos, tc);
 	else if (zone == ZONE_DATA1)
 		ntfs_cluster_set_zone_pos(vol->mft_zone_end, vol->nr_clusters,
-					  &vol->data1_zone_pos, tc);
+				&vol->data1_zone_pos, tc);
 	else /* zone == ZONE_DATA2 */
 		ntfs_cluster_set_zone_pos(0, vol->mft_zone_start,
-					  &vol->data2_zone_pos, tc);
+				&vol->data2_zone_pos, tc);
 }
 
 /*
@@ -126,40 +126,40 @@ static s64 max_empty_bit_range(unsigned char *buf, int size)
 	i = 0;
 	while (i < size) {
 		switch (*buf) {
-		case 0 :
-			do {
-				buf++;
-				run += 8;
-				i++;
-			} while ((i < size) && !*buf);
-			break;
-		case 255 :
-			if (run > max_range) {
-				max_range = run;
-				start_pos = (s64)i * 8 - run;
-			}
-			run = 0;
-			do {
-				buf++;
-				i++;
-			} while ((i < size) && (*buf == 255));
-			break;
-		default :
-			for (j = 0; j < 8; j++) {
+			case 0 :
+				do {
+					buf++;
+					run += 8;
+					i++;
+				} while ((i < size) && !*buf);
+				break;
+			case 255 :
+				if (run > max_range) {
+					max_range = run;
+					start_pos = (s64)i * 8 - run;
+				}
+				run = 0;
+				do {
+					buf++;
+					i++;
+				} while ((i < size) && (*buf == 255));
+				break;
+			default :
+				for (j = 0; j < 8; j++) {
 
-				int bit = *buf & (1 << j);
+					int bit = *buf & (1 << j);
 
-				if (bit) {
-					if (run > max_range) {
-						max_range = run;
-						start_pos = (s64)i * 8 + (j - run);
-					}
-					run = 0;
-				} else
-					run++;
-			}
-			i++;
-			buf++;
+					if (bit) {
+						if (run > max_range) {
+							max_range = run;
+							start_pos = (s64)i * 8 + (j - run);
+						}
+						run = 0;
+					} else
+						run++;
+				}
+				i++;
+				buf++;
 
 		}
 	}
@@ -171,7 +171,7 @@ static s64 max_empty_bit_range(unsigned char *buf, int size)
 }
 
 static int bitmap_writeback(ntfs_volume *vol, s64 pos, s64 size, void *b,
-			    u8 *writeback)
+		u8 *writeback)
 {
 	s64 written;
 
@@ -251,8 +251,8 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 	int err = 0, rlpos, rlsize, buf_size;
 
 	ntfs_log_enter("Entering with count = 0x%llx, start_lcn = 0x%llx, "
-		       "zone = %s_ZONE.\n", (long long)count, (long long)
-		       start_lcn, zone == MFT_ZONE ? "MFT" : "DATA");
+			"zone = %s_ZONE.\n", (long long)count, (long long)
+			start_lcn, zone == MFT_ZONE ? "MFT" : "DATA");
 
 	if (!vol || count < 0 || start_lcn < -1 || !vol->lcnbmp_na ||
 			(s8)zone < FIRST_ZONE || zone > LAST_ZONE) {
@@ -315,12 +315,12 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 	clusters = count;
 	rlpos = rlsize = 0;
 	while (1) {
-			/* check whether we have exhausted the current zone */
+		/* check whether we have exhausted the current zone */
 		if (search_zone & vol->full_zones)
 			goto zone_pass_done;
 		last_read_pos = bmp_pos >> 3;
 		br = ntfs_attr_pread(vol->lcnbmp_na, last_read_pos,
-				     LCNBMP_ALLOC_SIZE, buf);
+				LCNBMP_ALLOC_SIZE, buf);
 		if (br <= 0) {
 			if (!br)
 				goto zone_pass_done;
@@ -382,8 +382,8 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 			if (NVolFreeSpaceKnown(vol)) {
 				if (vol->free_clusters <= 0)
 					ntfs_log_error("Non-positive free"
-					       " clusters (%lld)!\n",
-						(long long)vol->free_clusters);
+							" clusters (%lld)!\n",
+							(long long)vol->free_clusters);
 				else
 					vol->free_clusters--;
 			}
@@ -394,20 +394,20 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 			 */
 			if (prev_lcn == lcn + bmp_pos - prev_run_len && rlpos) {
 				ntfs_log_debug("Cluster coalesce: prev_lcn: "
-					       "%lld  lcn: %lld  bmp_pos: %lld  "
-					       "prev_run_len: %lld\n",
-					       (long long)prev_lcn,
-					       (long long)lcn, (long long)bmp_pos,
-					       (long long)prev_run_len);
+						"%lld  lcn: %lld  bmp_pos: %lld  "
+						"prev_run_len: %lld\n",
+						(long long)prev_lcn,
+						(long long)lcn, (long long)bmp_pos,
+						(long long)prev_run_len);
 				rl[rlpos - 1].length = ++prev_run_len;
 			} else {
 				if (rlpos)
 					rl[rlpos].vcn = rl[rlpos - 1].vcn +
-							prev_run_len;
+						prev_run_len;
 				else {
 					rl[rlpos].vcn = start_vcn;
 					ntfs_log_debug("Start_vcn: %lld\n",
-						       (long long)start_vcn);
+							(long long)start_vcn);
 				}
 
 				rl[rlpos].lcn = prev_lcn = lcn + bmp_pos;
@@ -416,14 +416,14 @@ runlist *ntfs_cluster_alloc(ntfs_volume *vol, VCN start_vcn, s64 count,
 			}
 
 			ntfs_log_debug("RUN:   %-16lld %-16lld %-16lld\n",
-				       (long long)rl[rlpos - 1].vcn,
-				       (long long)rl[rlpos - 1].lcn,
-				       (long long)rl[rlpos - 1].length);
+					(long long)rl[rlpos - 1].vcn,
+					(long long)rl[rlpos - 1].lcn,
+					(long long)rl[rlpos - 1].length);
 			/* Done? */
 			if (!--clusters) {
 				if (used_zone_pos)
 					ntfs_cluster_update_zone_pos(vol,
-						search_zone, lcn + bmp_pos + 1 +
+							search_zone, lcn + bmp_pos + 1 +
 							NTFS_LCNALLOC_SKIP);
 				goto done_ret;
 			}
@@ -487,42 +487,43 @@ done_zones_check:
 			pass = 1;
 			if (rlpos) {
 				LCN tc = rl[rlpos - 1].lcn +
-				      rl[rlpos - 1].length + NTFS_LCNALLOC_SKIP;
+					rl[rlpos - 1].length + NTFS_LCNALLOC_SKIP;
 
 				if (used_zone_pos)
 					ntfs_cluster_update_zone_pos(vol,
-						search_zone, tc);
+							search_zone, tc);
 			}
 
 			switch (search_zone) {
-			case ZONE_MFT:
-				ntfs_log_trace("Zone switch: mft -> data1\n");
-switch_to_data1_zone:		search_zone = ZONE_DATA1;
-				zone_start = vol->data1_zone_pos;
-				zone_end = vol->nr_clusters;
-				if (zone_start == vol->mft_zone_end)
-					pass = 2;
-				break;
-			case ZONE_DATA1:
-				ntfs_log_trace("Zone switch: data1 -> data2\n");
-				search_zone = ZONE_DATA2;
-				zone_start = vol->data2_zone_pos;
-				zone_end = vol->mft_zone_start;
-				if (!zone_start)
-					pass = 2;
-				break;
-			case ZONE_DATA2:
-				if (!(done_zones & ZONE_DATA1)) {
-					ntfs_log_trace("data2 -> data1\n");
-					goto switch_to_data1_zone;
-				}
-				ntfs_log_trace("Zone switch: data2 -> mft\n");
-				search_zone = ZONE_MFT;
-				zone_start = vol->mft_zone_pos;
-				zone_end = vol->mft_zone_end;
-				if (zone_start == vol->mft_zone_start)
-					pass = 2;
-				break;
+				case ZONE_MFT:
+					ntfs_log_trace("Zone switch: mft -> data1\n");
+switch_to_data1_zone:
+					search_zone = ZONE_DATA1;
+					zone_start = vol->data1_zone_pos;
+					zone_end = vol->nr_clusters;
+					if (zone_start == vol->mft_zone_end)
+						pass = 2;
+					break;
+				case ZONE_DATA1:
+					ntfs_log_trace("Zone switch: data1 -> data2\n");
+					search_zone = ZONE_DATA2;
+					zone_start = vol->data2_zone_pos;
+					zone_end = vol->mft_zone_start;
+					if (!zone_start)
+						pass = 2;
+					break;
+				case ZONE_DATA2:
+					if (!(done_zones & ZONE_DATA1)) {
+						ntfs_log_trace("data2 -> data1\n");
+						goto switch_to_data1_zone;
+					}
+					ntfs_log_trace("Zone switch: data2 -> mft\n");
+					search_zone = ZONE_MFT;
+					zone_start = vol->mft_zone_pos;
+					zone_end = vol->mft_zone_end;
+					if (zone_start == vol->mft_zone_start)
+						pass = 2;
+					break;
 			}
 
 			bmp_pos = zone_start;
@@ -596,14 +597,14 @@ int ntfs_cluster_free_from_rl(ntfs_volume *vol, runlist *rl)
 	for (; rl->length; rl++) {
 
 		ntfs_log_trace("Dealloc lcn 0x%llx, len 0x%llx.\n",
-			       (long long)rl->lcn, (long long)rl->length);
+				(long long)rl->lcn, (long long)rl->length);
 
 		if (rl->lcn >= 0) {
 			update_full_status(vol,rl->lcn);
 			if (ntfs_bitmap_clear_run(vol->lcnbmp_na, rl->lcn,
-						  rl->length)) {
+						rl->length)) {
 				ntfs_log_perror("Cluster deallocation failed "
-					       "(%lld, %lld)",
+						"(%lld, %lld)",
 						(long long)rl->lcn,
 						(long long)rl->length);
 				goto out;
@@ -619,10 +620,10 @@ int ntfs_cluster_free_from_rl(ntfs_volume *vol, runlist *rl)
 out:
 	vol->free_clusters += nr_freed;
 	if (NVolFreeSpaceKnown(vol)
-	    && (vol->free_clusters > vol->nr_clusters))
+			&& (vol->free_clusters > vol->nr_clusters))
 		ntfs_log_error("Too many free clusters (%lld > %lld)!",
-			       (long long)vol->free_clusters,
-			       (long long)vol->nr_clusters);
+				(long long)vol->free_clusters,
+				(long long)vol->nr_clusters);
 	return ret;
 }
 
@@ -638,17 +639,17 @@ int ntfs_cluster_free_basic(ntfs_volume *vol, s64 lcn, s64 count)
 
 	ntfs_log_trace("Entering.\n");
 	ntfs_log_trace("Dealloc lcn 0x%llx, len 0x%llx.\n",
-			       (long long)lcn, (long long)count);
+			(long long)lcn, (long long)count);
 
 	if (lcn >= 0) {
 		update_full_status(vol,lcn);
 		if (ntfs_bitmap_clear_run(vol->lcnbmp_na, lcn,
-						  count)) {
+					count)) {
 			ntfs_log_perror("Cluster deallocation failed "
-				       "(%lld, %lld)",
+					"(%lld, %lld)",
 					(long long)lcn,
 					(long long)count);
-				goto out;
+			goto out;
 		}
 		nr_freed += count;
 
@@ -660,8 +661,8 @@ out:
 	vol->free_clusters += nr_freed;
 	if (vol->free_clusters > vol->nr_clusters)
 		ntfs_log_error("Too many free clusters (%lld > %lld)!",
-			       (long long)vol->free_clusters,
-			       (long long)vol->nr_clusters);
+				(long long)vol->free_clusters,
+				(long long)vol->nr_clusters);
 	return ret;
 }
 
@@ -695,8 +696,8 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 	}
 
 	ntfs_log_enter("Entering for inode 0x%llx, attr 0x%x, count 0x%llx, "
-		       "vcn 0x%llx.\n", (unsigned long long)na->ni->mft_no,
-		       le32_to_cpu(na->type), (long long)count, (long long)start_vcn);
+			"vcn 0x%llx.\n", (unsigned long long)na->ni->mft_no,
+			le32_to_cpu(na->type), (long long)count, (long long)start_vcn);
 
 	rl = ntfs_attr_find_vcn(na, start_vcn);
 	if (!rl) {
@@ -724,7 +725,7 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 		/* Do the actual freeing of the clusters in this run. */
 		update_full_status(vol,rl->lcn + delta);
 		if (ntfs_bitmap_clear_run(vol->lcnbmp_na, rl->lcn + delta,
-					  to_free))
+					to_free))
 			goto leave;
 		nr_freed = to_free;
 
@@ -764,7 +765,7 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 		if (rl->lcn != LCN_HOLE) {
 			update_full_status(vol,rl->lcn);
 			if (ntfs_bitmap_clear_run(vol->lcnbmp_na, rl->lcn,
-					to_free)) {
+						to_free)) {
 				// FIXME: Eeek! We need rollback! (AIA)
 				ntfs_log_perror("%s: Clearing bitmap run failed",
 						__FUNCTION__);
@@ -783,7 +784,7 @@ int ntfs_cluster_free(ntfs_volume *vol, ntfs_attr *na, VCN start_vcn, s64 count)
 		// FIXME: Eeek! BUG()
 		errno = EIO;
 		ntfs_log_perror("%s: count still not zero (%lld)", __FUNCTION__,
-			       (long long)count);
+				(long long)count);
 		goto out;
 	}
 
@@ -792,8 +793,8 @@ out:
 	vol->free_clusters += nr_freed ;
 	if (vol->free_clusters > vol->nr_clusters)
 		ntfs_log_error("Too many free clusters (%lld > %lld)!",
-			       (long long)vol->free_clusters,
-			       (long long)vol->nr_clusters);
+				(long long)vol->free_clusters,
+				(long long)vol->nr_clusters);
 leave:
 	ntfs_log_leave("\n");
 	return ret;

--- a/libntfs/logfile.c
+++ b/libntfs/logfile.c
@@ -91,14 +91,14 @@ static BOOL ntfs_check_restart_page_header(RESTART_PAGE_HEADER *rp, s64 pos)
 	 * Nevertheless, do all the relevant checks before rejecting.
 	 */
 	if (((rp->major_ver != const_cpu_to_sle16(1))
-			 || (rp->minor_ver != const_cpu_to_sle16(1)))
-	   && ((rp->major_ver != const_cpu_to_sle16(2))
-			 || (rp->minor_ver != const_cpu_to_sle16(0)))) {
+				|| (rp->minor_ver != const_cpu_to_sle16(1)))
+			&& ((rp->major_ver != const_cpu_to_sle16(2))
+				|| (rp->minor_ver != const_cpu_to_sle16(0)))) {
 		ntfs_log_error("$LogFile version %i.%i is not "
 				"supported.\n   (This driver supports version "
 				"1.1 and 2.0 only.)\n",
-					(int)sle16_to_cpu(rp->major_ver),
-					(int)sle16_to_cpu(rp->minor_ver));
+				(int)sle16_to_cpu(rp->major_ver),
+				(int)sle16_to_cpu(rp->minor_ver));
 		return FALSE;
 	}
 	/*
@@ -134,7 +134,7 @@ skip_usa_checks:
 	 */
 	ra_ofs = le16_to_cpu(rp->restart_area_offset);
 	if (ra_ofs & 7 || (have_usa ? ra_ofs < usa_end :
-			ra_ofs < offsetof(RESTART_PAGE_HEADER, usn)) ||
+				ra_ofs < offsetof(RESTART_PAGE_HEADER, usn)) ||
 			ra_ofs > logfile_system_page_size) {
 		ntfs_log_error("$LogFile restart page specifies "
 				"inconsistent restart area offset.\n");
@@ -197,7 +197,7 @@ static BOOL ntfs_check_restart_area(RESTART_PAGE_HEADER *rp)
 	ca_ofs = le16_to_cpu(ra->client_array_offset);
 	if (((ca_ofs + 7) & ~7) != ca_ofs ||
 			ra_ofs + ca_ofs > (u16)(NTFS_BLOCK_SIZE -
-			sizeof(u16))) {
+				sizeof(u16))) {
 		ntfs_log_error("$LogFile restart area specifies "
 				"inconsistent client array offset.\n");
 		return FALSE;
@@ -208,7 +208,7 @@ static BOOL ntfs_check_restart_area(RESTART_PAGE_HEADER *rp)
 	 * Also, the calculated length must not exceed the specified length.
 	 */
 	ra_len = ca_ofs + le16_to_cpu(ra->log_clients) *
-			sizeof(LOG_CLIENT_RECORD);
+		sizeof(LOG_CLIENT_RECORD);
 	if ((u32)(ra_ofs + ra_len) > le32_to_cpu(rp->system_page_size) ||
 			(u32)(ra_ofs + le16_to_cpu(ra->restart_area_length)) >
 			le32_to_cpu(rp->system_page_size) ||
@@ -225,11 +225,11 @@ static BOOL ntfs_check_restart_area(RESTART_PAGE_HEADER *rp)
 	 * overflowing the client array.
 	 */
 	if ((ra->client_free_list != LOGFILE_NO_CLIENT &&
-			le16_to_cpu(ra->client_free_list) >=
-			le16_to_cpu(ra->log_clients)) ||
+				le16_to_cpu(ra->client_free_list) >=
+				le16_to_cpu(ra->log_clients)) ||
 			(ra->client_in_use_list != LOGFILE_NO_CLIENT &&
-			le16_to_cpu(ra->client_in_use_list) >=
-			le16_to_cpu(ra->log_clients))) {
+			 le16_to_cpu(ra->client_in_use_list) >=
+			 le16_to_cpu(ra->log_clients))) {
 		ntfs_log_error("$LogFile restart area specifies "
 				"overflowing client free and/or in use lists.\n");
 		return FALSE;
@@ -290,14 +290,14 @@ static BOOL ntfs_check_log_client_array(RESTART_PAGE_HEADER *rp)
 	u32 offset_clients;
 
 	ntfs_log_trace("Entering.\n");
-		/* The restart area must be fully within page */
+	/* The restart area must be fully within page */
 	if ((le16_to_cpu(rp->restart_area_offset) + sizeof(RESTART_AREA))
 			> le32_to_cpu(rp->system_page_size))
 		goto err_out;
 	ra = (RESTART_AREA*)((u8*)rp + le16_to_cpu(rp->restart_area_offset));
 	offset_clients = le16_to_cpu(rp->restart_area_offset)
-			+ le16_to_cpu(ra->client_array_offset);
-		/* The clients' records must begin within page */
+		+ le16_to_cpu(ra->client_array_offset);
+	/* The clients' records must begin within page */
 	if (offset_clients >= le32_to_cpu(rp->system_page_size))
 		goto err_out;
 	ca = (LOG_CLIENT_RECORD*)((u8*)ra +
@@ -318,7 +318,7 @@ check_list:
 			idx = le16_to_cpu(cr->next_client)) {
 		if (!nr_clients || idx >= le16_to_cpu(ra->log_clients))
 			goto err_out;
-			/* The client record must be fully within page */
+		/* The client record must be fully within page */
 		if ((offset_clients + (idx + 1)*sizeof(LOG_CLIENT_RECORD))
 				> le32_to_cpu(rp->system_page_size))
 			goto err_out;
@@ -398,9 +398,9 @@ static int ntfs_check_and_load_restart_page(ntfs_attr *log_na,
 	 * and shorter than the full log size
 	 */
 	if ((le32_to_cpu(rp->system_page_size)
-			> (u32)(le16_to_cpu(rp->usa_count) - 1)*NTFS_BLOCK_SIZE)
-	   || (le32_to_cpu(rp->system_page_size)
-			> le64_to_cpu(log_na->data_size)))
+				> (u32)(le16_to_cpu(rp->usa_count) - 1)*NTFS_BLOCK_SIZE)
+			|| (le32_to_cpu(rp->system_page_size)
+				> le64_to_cpu(log_na->data_size)))
 		return (EINVAL);
 	trp = ntfs_malloc(le32_to_cpu(rp->system_page_size));
 	if (!trp)
@@ -413,7 +413,7 @@ static int ntfs_check_and_load_restart_page(ntfs_attr *log_na,
 	if (le32_to_cpu(rp->system_page_size) <= NTFS_BLOCK_SIZE)
 		memcpy(trp, rp, le32_to_cpu(rp->system_page_size));
 	else if (ntfs_attr_pread(log_na, pos,
-			le32_to_cpu(rp->system_page_size), trp) !=
+				le32_to_cpu(rp->system_page_size), trp) !=
 			le32_to_cpu(rp->system_page_size)) {
 		err = errno;
 		ntfs_log_error("Failed to read whole restart page into the "
@@ -428,7 +428,7 @@ static int ntfs_check_and_load_restart_page(ntfs_attr *log_na,
 	 */
 	if ((!ntfs_is_chkd_record(trp->magic) || le16_to_cpu(trp->usa_count))
 			&& ntfs_mst_post_read_fixup((NTFS_RECORD*)trp,
-			le32_to_cpu(rp->system_page_size))) {
+				le32_to_cpu(rp->system_page_size))) {
 		/*
 		 * A multi sector tranfer error was detected.  We only need to
 		 * abort if the restart page contents exceed the multi sector
@@ -438,7 +438,7 @@ static int ntfs_check_and_load_restart_page(ntfs_attr *log_na,
 				le16_to_cpu(ra->restart_area_length) >
 				NTFS_BLOCK_SIZE - (int)sizeof(u16)) {
 			ntfs_log_error("Multi sector transfer error "
-				   "detected in $LogFile restart page.\n");
+					"detected in $LogFile restart page.\n");
 			err = EINVAL;
 			goto err_out;
 		}
@@ -601,7 +601,7 @@ BOOL ntfs_check_logfile(ntfs_attr *log_na, RESTART_PAGE_HEADER **rp)
 		 * find a valid one further in the file.
 		 */
 		if (err != EINVAL)
-		      goto err_out;
+			goto err_out;
 		/* Continue looking. */
 		if (!pos)
 			pos = NTFS_BLOCK_SIZE >> 1;
@@ -620,7 +620,7 @@ is_empty:
 		if (rstr2_ph)
 			ntfs_log_error("BUG: rstr2_ph isn't NULL!\n");
 		ntfs_log_error("Did not find any restart pages in "
-			   "$LogFile and it was not empty.\n");
+				"$LogFile and it was not empty.\n");
 		return FALSE;
 	}
 	/* If both restart pages were found, use the more recent one. */
@@ -705,8 +705,8 @@ BOOL ntfs_is_logfile_clean(ntfs_attr *log_na, RESTART_PAGE_HEADER *rp)
 	if (ra->client_in_use_list != LOGFILE_NO_CLIENT &&
 			!(ra->flags & RESTART_VOLUME_IS_CLEAN)) {
 		ntfs_log_error("The disk contains an unclean file system (%d, "
-			       "%d).\n", le16_to_cpu(ra->client_in_use_list),
-			       le16_to_cpu(ra->flags));
+				"%d).\n", le16_to_cpu(ra->client_in_use_list),
+				le16_to_cpu(ra->flags));
 		return FALSE;
 	}
 	/* $LogFile indicates a clean shutdown. */

--- a/libntfs/logging.c
+++ b/libntfs/logging.c
@@ -315,7 +315,7 @@ void ntfs_log_set_handler(ntfs_log_handler *handler)
  *          num  Number of output characters
  */
 int ntfs_log_redirect(const char *function, const char *file,
-	int line, u32 level, void *data, const char *format, ...)
+		int line, u32 level, void *data, const char *format, ...)
 {
 	int olderr = errno;
 	int ret;
@@ -354,13 +354,13 @@ int ntfs_log_redirect(const char *function, const char *file,
 
 #ifdef HAVE_SYSLOG_H
 
-#define LOG_LINE_LEN 	512
+#define LOG_LINE_LEN	512
 
 int ntfs_log_handler_syslog(const char *function  __attribute__((unused)),
-			    const char *file __attribute__((unused)),
-			    int line __attribute__((unused)), u32 level,
-			    void *data __attribute__((unused)),
-			    const char *format, va_list args)
+		const char *file __attribute__((unused)),
+		int line __attribute__((unused)), u32 level,
+		void *data __attribute__((unused)),
+		const char *format, va_list args)
 {
 	char logbuf[LOG_LINE_LEN];
 	int ret, olderr = errno;
@@ -404,8 +404,8 @@ void ntfs_log_early_error(const char *format, ...)
 #ifdef HAVE_SYSLOG_H
 	openlog("ntfs-3g", LOG_PID, LOG_USER);
 	ntfs_log_handler_syslog(NULL, NULL, 0,
-		NTFS_LOG_LEVEL_ERROR, NULL,
-		format, args);
+			NTFS_LOG_LEVEL_ERROR, NULL,
+			format, args);
 #else
 	vfprintf(stderr,format,args);
 #endif
@@ -434,7 +434,7 @@ void ntfs_log_early_error(const char *format, ...)
  *          num  Number of output characters
  */
 int ntfs_log_handler_fprintf(const char *function, const char *file,
-	int line, u32 level, void *data, const char *format, va_list args)
+		int line, u32 level, void *data, const char *format, va_list args)
 {
 #ifdef DEBUG
 	int i;
@@ -458,7 +458,7 @@ int ntfs_log_handler_fprintf(const char *function, const char *file,
 		ret += fprintf(stream, " ");
 #endif
 	if ((ntfs_log.flags & NTFS_LOG_FLAG_ONLYNAME) &&
-	    (strchr(file, PATH_SEP)))		/* Abbreviate the filename */
+			(strchr(file, PATH_SEP)))		/* Abbreviate the filename */
 		file = strrchr(file, PATH_SEP) + 1;
 
 	if (ntfs_log.flags & NTFS_LOG_FLAG_PREFIX)	/* Prefix the output */
@@ -471,7 +471,7 @@ int ntfs_log_handler_fprintf(const char *function, const char *file,
 		ret += fprintf(stream, "(%d) ", line);
 
 	if ((ntfs_log.flags & NTFS_LOG_FLAG_FUNCTION) || /* Source function */
-	    (level & NTFS_LOG_LEVEL_TRACE) || (level & NTFS_LOG_LEVEL_ENTER))
+			(level & NTFS_LOG_LEVEL_TRACE) || (level & NTFS_LOG_LEVEL_ENTER))
 		ret += fprintf(stream, "%s(): ", function);
 
 	ret += vfprintf(stream, format, args);
@@ -504,8 +504,8 @@ int ntfs_log_handler_fprintf(const char *function, const char *file,
  * Returns:  0  Message wasn't logged
  */
 int ntfs_log_handler_null(const char *function __attribute__((unused)), const char *file __attribute__((unused)),
-	int line __attribute__((unused)), u32 level __attribute__((unused)), void *data __attribute__((unused)),
-	const char *format __attribute__((unused)), va_list args __attribute__((unused)))
+		int line __attribute__((unused)), u32 level __attribute__((unused)), void *data __attribute__((unused)),
+		const char *format __attribute__((unused)), va_list args __attribute__((unused)))
 {
 	return 0;
 }
@@ -532,7 +532,7 @@ int ntfs_log_handler_null(const char *function __attribute__((unused)), const ch
  *          num  Number of output characters
  */
 int ntfs_log_handler_stdout(const char *function, const char *file,
-	int line, u32 level, void *data, const char *format, va_list args)
+		int line, u32 level, void *data, const char *format, va_list args)
 {
 	if (!data)
 		data = stdout;
@@ -563,7 +563,7 @@ int ntfs_log_handler_stdout(const char *function, const char *file,
  *          num  Number of output characters
  */
 int ntfs_log_handler_outerr(const char *function, const char *file,
-	int line, u32 level, void *data, const char *format, va_list args)
+		int line, u32 level, void *data, const char *format, va_list args)
 {
 	if (!data)
 		data = ntfs_log_get_stream(level);
@@ -593,7 +593,7 @@ int ntfs_log_handler_outerr(const char *function, const char *file,
  *          num  Number of output characters
  */
 int ntfs_log_handler_stderr(const char *function, const char *file,
-	int line, u32 level, void *data, const char *format, va_list args)
+		int line, u32 level, void *data, const char *format, va_list args)
 {
 	if (!data)
 		data = stderr;

--- a/libntfs/mft.c
+++ b/libntfs/mft.c
@@ -92,7 +92,7 @@ int ntfs_mft_records_read(const ntfs_volume *vol, const MFT_REF mref,
 	if (!vol || !vol->mft_na || !b || count < 0) {
 		errno = EINVAL;
 		ntfs_log_perror("%s: b=%p  count=%lld  mft=%llu", __FUNCTION__,
-			b, (long long)count, (unsigned long long)MREF(mref));
+				b, (long long)count, (unsigned long long)MREF(mref));
 		return -1;
 	}
 	m = MREF(mref);
@@ -178,9 +178,9 @@ int ntfs_mft_records_write(const ntfs_volume *vol, const MFT_REF mref,
 				vol->mft_record_size_bits) {
 			errno = ESPIPE;
 			ntfs_log_perror("Trying to write non-allocated mftmirr"
-				" records (%lld > %lld)", (long long)m + cnt,
-				(long long)vol->mftmirr_na->initialized_size >>
-				vol->mft_record_size_bits);
+					" records (%lld > %lld)", (long long)m + cnt,
+					(long long)vol->mftmirr_na->initialized_size >>
+					vol->mft_record_size_bits);
 			return -1;
 		}
 		bmirr = ntfs_malloc(cnt * vol->mft_record_size);
@@ -234,7 +234,7 @@ int ntfs_mft_records_write(const ntfs_volume *vol, const MFT_REF mref,
  */
 
 int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
-			  MFT_RECORD *m)
+		MFT_RECORD *m)
 {
 	ATTR_RECORD *a;
 	int ret = -1;
@@ -264,8 +264,8 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 				goto err_out;
 		} else if (!NVolNoFixupWarn(vol)) {
 			ntfs_log_error("Record %llu has no FILE magic (0x%x)\n",
-				(unsigned long long)MREF(mref),
-				(int)le32_to_cpu(*(le32*)m));
+					(unsigned long long)MREF(mref),
+					(int)le32_to_cpu(*(le32*)m));
 			goto err_out;
 		}
 	}
@@ -282,9 +282,9 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 				goto err_out;
 		} else {
 			ntfs_log_error("Record %llu has corrupt allocation size "
-				       "(%u <> %u)\n", (unsigned long long)MREF(mref),
-				       vol->mft_record_size,
-				       le32_to_cpu(m->bytes_allocated));
+					"(%u <> %u)\n", (unsigned long long)MREF(mref),
+					vol->mft_record_size,
+					le32_to_cpu(m->bytes_allocated));
 			goto err_out;
 		}
 	}
@@ -294,21 +294,21 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 	if (biu & 7) {
 		ntfs_log_error("Used size of MFT record is badly aligned "
 				"in record %llu",
-			       (unsigned long long)MREF(mref));
+				(unsigned long long)MREF(mref));
 		goto err_out;
 	}
 
 	/* check used size overflow */
 	if (!NVolNoFixupWarn(vol) && !NVolFsck(vol) && (biu > vol->mft_record_size)) {
 		ntfs_log_error("Record %llu has corrupt in-use size "
-			       "(%u > %u)\n", (unsigned long long)MREF(mref),
-			       (int)biu, (int)vol->mft_record_size);
+				"(%u > %u)\n", (unsigned long long)MREF(mref),
+				(int)biu, (int)vol->mft_record_size);
 		goto err_out;
 	}
 
 	offset = le16_to_cpu(m->attrs_offset);
 	min_offset = ((le16_to_cpu(m->usa_ofs) +
-			le16_to_cpu(m->usa_count) * 2) + 7) & ~7;
+				le16_to_cpu(m->usa_count) * 2) + 7) & ~7;
 
 	/* check alignment of attribute start offset */
 	if (offset & 7) {
@@ -317,7 +317,7 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 			ntfs_print_problem(vol, PR_MFT_ATTR_OFFSET_CORRUPTED, &pctx);
 		} else
 			ntfs_log_error("Attributes badly aligned in record %llu",
-				       (unsigned long long)MREF(mref));
+					(unsigned long long)MREF(mref));
 		if (ntfs_ask_repair(vol)) {
 			offset = (offset + 7) & ~7;
 			m->attrs_offset = cpu_to_le16(offset);
@@ -338,7 +338,7 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 	a = (ATTR_RECORD *)((char *)m + offset);
 	if (p2n(a) < p2n(m) || (char *)a > (char *)m + vol->mft_record_size) {
 		ntfs_log_error("Record %llu is corrupt\n",
-			       (unsigned long long)MREF(mref));
+				(unsigned long long)MREF(mref));
 		goto err_out;
 	}
 
@@ -348,7 +348,7 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 
 		/* check all attributes inconsistency */
 		while ((space >= (s32)offsetof(ATTR_RECORD, resident_end)) &&
-		       (a->type != AT_END)) {
+				(a->type != AT_END)) {
 			if (ntfs_is_valid_attr_type(a) == FALSE) {
 				offset += sizeof(ATTR_TYPES);
 				a = (ATTR_RECORD *)((char *)m + offset);
@@ -357,7 +357,7 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 			}
 
 			if ((le32_to_cpu(a->length) <= (u32)space)
-			    && !(le32_to_cpu(a->length) & 7)) {
+					&& !(le32_to_cpu(a->length) & 7)) {
 				if (!ntfs_attr_inconsistent(vol, a, mref, &fixed)) {
 					offset += le32_to_cpu(a->length);
 					space -= le32_to_cpu(a->length);
@@ -366,7 +366,7 @@ int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 					goto err_out;
 			} else {
 				ntfs_log_error("Corrupted MFT record %llu\n",
-				       (unsigned long long)MREF(mref));
+						(unsigned long long)MREF(mref));
 				goto err_out;
 			}
 		}
@@ -455,8 +455,8 @@ int ntfs_file_record_read(const ntfs_volume *vol, const MFT_REF mref,
 	 * whether sequence numbers are matched */
 	if (MSEQNO(mref) && MSEQNO(mref) != le16_to_cpu(m->sequence_number)) {
 		ntfs_log_error("Record %llu has wrong SeqNo (%d <> %d)\n",
-			       (unsigned long long)MREF(mref), MSEQNO(mref),
-			       le16_to_cpu(m->sequence_number));
+				(unsigned long long)MREF(mref), MSEQNO(mref),
+				le16_to_cpu(m->sequence_number));
 		errno = EIO;
 		goto err_out;
 	}
@@ -535,14 +535,14 @@ int ntfs_mft_record_layout(const ntfs_volume *vol, const MFT_REF mref,
 	mrec->link_count = const_cpu_to_le16(0);
 	/* Aligned to 8-byte boundary. */
 	mrec->attrs_offset = cpu_to_le16((le16_to_cpu(mrec->usa_ofs) +
-			(le16_to_cpu(mrec->usa_count) << 1) + 7) & ~7);
+				(le16_to_cpu(mrec->usa_count) << 1) + 7) & ~7);
 	mrec->flags = const_cpu_to_le16(0);
 	/*
 	 * Using attrs_offset plus eight bytes (for the termination attribute),
 	 * aligned to 8-byte boundary.
 	 */
 	mrec->bytes_in_use = cpu_to_le32((le16_to_cpu(mrec->attrs_offset) + 8 +
-			7) & ~7);
+				7) & ~7);
 	mrec->bytes_allocated = cpu_to_le32(vol->mft_record_size);
 	mrec->base_mft_record = const_cpu_to_le64((MFT_REF)0);
 	mrec->next_attr_instance = const_cpu_to_le16(0);
@@ -857,7 +857,7 @@ static int ntfs_mft_bitmap_extend_allocation_i(ntfs_volume *vol)
 		goto undo_alloc;
 
 	if (ntfs_attr_lookup(mftbmp_na->type, mftbmp_na->name,
-			mftbmp_na->name_len, 0, rl[1].vcn, NULL, 0, ctx)) {
+				mftbmp_na->name_len, 0, rl[1].vcn, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find last attribute extent of "
 				"mft bitmap attribute.\n");
 		goto undo_alloc;
@@ -883,7 +883,7 @@ static int ntfs_mft_bitmap_extend_allocation_i(ntfs_volume *vol)
 	/* Expand the attribute record if necessary. */
 	old_alen = le32_to_cpu(a->length);
 	if (ntfs_attr_record_resize(m, a, mp_size +
-			le16_to_cpu(a->mapping_pairs_offset))) {
+				le16_to_cpu(a->mapping_pairs_offset))) {
 		ntfs_log_info("extending $MFT bitmap\n");
 		ret = ntfs_mft_attr_extend(vol->mftbmp_na);
 		if (ret == STATUS_OK)
@@ -897,8 +897,8 @@ static int ntfs_mft_bitmap_extend_allocation_i(ntfs_volume *vol)
 	mp_rebuilt = TRUE;
 	/* Generate the mapping pairs array directly into the attr record. */
 	if (ntfs_mapping_pairs_build(vol, (u8*)a +
-			le16_to_cpu(a->mapping_pairs_offset), mp_size, rl2, ll,
-			NULL)) {
+				le16_to_cpu(a->mapping_pairs_offset), mp_size, rl2, ll,
+				NULL)) {
 		ntfs_log_error("Failed to build mapping pairs array for "
 				"mft bitmap attribute.\n");
 		errno = EIO;
@@ -918,7 +918,7 @@ static int ntfs_mft_bitmap_extend_allocation_i(ntfs_volume *vol)
 		ntfs_inode_mark_dirty(ctx->ntfs_ino);
 		ntfs_attr_reinit_search_ctx(ctx);
 		if (ntfs_attr_lookup(mftbmp_na->type, mftbmp_na->name,
-				mftbmp_na->name_len, 0, 0, NULL, 0, ctx)) {
+					mftbmp_na->name_len, 0, 0, NULL, 0, ctx)) {
 			ntfs_log_error("Failed to find first attribute "
 					"extent of mft bitmap attribute.\n");
 			goto restore_undo_alloc;
@@ -937,7 +937,7 @@ restore_undo_alloc:
 	err = errno;
 	ntfs_attr_reinit_search_ctx(ctx);
 	if (ntfs_attr_lookup(mftbmp_na->type, mftbmp_na->name,
-			mftbmp_na->name_len, 0, rl[1].vcn, NULL, 0, ctx)) {
+				mftbmp_na->name_len, 0, rl[1].vcn, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find last attribute extent of "
 				"mft bitmap attribute.%s\n", es);
 		ntfs_attr_put_search_ctx(ctx);
@@ -968,9 +968,9 @@ undo_alloc:
 		vol->free_clusters++;
 	if (mp_rebuilt) {
 		if (ntfs_mapping_pairs_build(vol, (u8*)a +
-				le16_to_cpu(a->mapping_pairs_offset),
-				old_alen - le16_to_cpu(a->mapping_pairs_offset),
-				rl2, ll, NULL))
+					le16_to_cpu(a->mapping_pairs_offset),
+					old_alen - le16_to_cpu(a->mapping_pairs_offset),
+					rl2, ll, NULL))
 			ntfs_log_error("Failed to restore mapping "
 					"pairs array.%s\n", es);
 		if (ntfs_attr_record_resize(m, a, old_alen))
@@ -1037,7 +1037,7 @@ static int ntfs_mft_bitmap_extend_initialized(ntfs_volume *vol)
 		goto out;
 
 	if (ntfs_attr_lookup(mftbmp_na->type, mftbmp_na->name,
-			mftbmp_na->name_len, 0, 0, NULL, 0, ctx)) {
+				mftbmp_na->name_len, 0, 0, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find first attribute extent of "
 				"mft bitmap attribute.\n");
 		err = errno;
@@ -1074,7 +1074,7 @@ static int ntfs_mft_bitmap_extend_initialized(ntfs_volume *vol)
 		goto err_out;
 
 	if (ntfs_attr_lookup(mftbmp_na->type, mftbmp_na->name,
-			mftbmp_na->name_len, 0, 0, NULL, 0, ctx)) {
+				mftbmp_na->name_len, 0, 0, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find first attribute extent of "
 				"mft bitmap attribute.%s\n", es);
 put_err_out:
@@ -1206,7 +1206,7 @@ static int ntfs_mft_data_extend_allocation(ntfs_volume *vol)
 		goto undo_alloc;
 
 	if (ntfs_attr_lookup(mft_na->type, mft_na->name, mft_na->name_len, 0,
-			rl[1].vcn, NULL, 0, ctx)) {
+				rl[1].vcn, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find last attribute extent of "
 				"mft data attribute.\n");
 		goto undo_alloc;
@@ -1232,7 +1232,7 @@ static int ntfs_mft_data_extend_allocation(ntfs_volume *vol)
 	/* Expand the attribute record if necessary. */
 	old_alen = le32_to_cpu(a->length);
 	if (ntfs_attr_record_resize(m, a,
-			mp_size + le16_to_cpu(a->mapping_pairs_offset))) {
+				mp_size + le16_to_cpu(a->mapping_pairs_offset))) {
 		ret = ntfs_mft_attr_extend(vol->mft_na);
 		if (ret == STATUS_OK)
 			goto ok;
@@ -1247,8 +1247,8 @@ static int ntfs_mft_data_extend_allocation(ntfs_volume *vol)
 	 * Generate the mapping pairs array directly into the attribute record.
 	 */
 	if (ntfs_mapping_pairs_build(vol,
-			(u8*)a + le16_to_cpu(a->mapping_pairs_offset), mp_size,
-			rl2, ll, NULL)) {
+				(u8*)a + le16_to_cpu(a->mapping_pairs_offset), mp_size,
+				rl2, ll, NULL)) {
 		ntfs_log_error("Failed to build mapping pairs array of "
 				"mft data attribute.\n");
 		errno = EIO;
@@ -1270,7 +1270,7 @@ static int ntfs_mft_data_extend_allocation(ntfs_volume *vol)
 		ntfs_inode_mark_dirty(ctx->ntfs_ino);
 		ntfs_attr_reinit_search_ctx(ctx);
 		if (ntfs_attr_lookup(mft_na->type, mft_na->name,
-				mft_na->name_len, 0, 0, NULL, 0, ctx)) {
+					mft_na->name_len, 0, 0, NULL, 0, ctx)) {
 			ntfs_log_error("Failed to find first attribute "
 					"extent of mft data attribute.\n");
 			goto restore_undo_alloc;
@@ -1292,7 +1292,7 @@ restore_undo_alloc:
 	err = errno;
 	ntfs_attr_reinit_search_ctx(ctx);
 	if (ntfs_attr_lookup(mft_na->type, mft_na->name, mft_na->name_len, 0,
-			rl[1].vcn, NULL, 0, ctx)) {
+				rl[1].vcn, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find last attribute extent of "
 				"mft data attribute.%s\n", es);
 		ntfs_attr_put_search_ctx(ctx);
@@ -1319,9 +1319,9 @@ undo_alloc:
 				"runlist.%s\n", es);
 	if (mp_rebuilt) {
 		if (ntfs_mapping_pairs_build(vol, (u8*)a +
-				le16_to_cpu(a->mapping_pairs_offset),
-				old_alen - le16_to_cpu(a->mapping_pairs_offset),
-				rl2, ll, NULL))
+					le16_to_cpu(a->mapping_pairs_offset),
+					old_alen - le16_to_cpu(a->mapping_pairs_offset),
+					rl2, ll, NULL))
 			ntfs_log_error("Failed to restore mapping pairs "
 					"array.%s\n", es);
 		if (ntfs_attr_record_resize(m, a, old_alen))
@@ -1404,7 +1404,7 @@ static int ntfs_mft_record_init(ntfs_volume *vol, s64 size)
 		goto undo_data_init;
 
 	if (ntfs_attr_lookup(mft_na->type, mft_na->name, mft_na->name_len, 0,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find first attribute extent of "
 				"mft data attribute.\n");
 		ntfs_attr_put_search_ctx(ctx);
@@ -1426,7 +1426,7 @@ static int ntfs_mft_record_init(ntfs_volume *vol, s64 size)
 
 	/* Sanity checks. */
 	if (mft_na->data_size > mft_na->allocated_size ||
-	    mft_na->initialized_size > mft_na->data_size)
+			mft_na->initialized_size > mft_na->data_size)
 		NTFS_BUG("mft_na sanity checks failed");
 
 	/* Sync MFT to minimize data loss if there won't be clean unmount. */
@@ -1459,11 +1459,11 @@ static int ntfs_mft_rec_init(ntfs_volume *vol, s64 size)
 		errno = EIO;
 		ntfs_log_perror("%s: unexpected $MFT sizes, see below", __FUNCTION__);
 		ntfs_log_error("$MFT: size=%lld  allocated_size=%lld  "
-			       "data_size=%lld  initialized_size=%lld\n",
-			       (long long)size,
-			       (long long)mft_na->allocated_size,
-			       (long long)mft_na->data_size,
-			       (long long)mft_na->initialized_size);
+				"data_size=%lld  initialized_size=%lld\n",
+				(long long)size,
+				(long long)mft_na->allocated_size,
+				(long long)mft_na->data_size,
+				(long long)mft_na->initialized_size);
 		goto out;
 	}
 
@@ -1476,7 +1476,7 @@ static int ntfs_mft_rec_init(ntfs_volume *vol, s64 size)
 		goto undo_data_init;
 
 	if (ntfs_attr_lookup(mft_na->type, mft_na->name, mft_na->name_len, 0,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		ntfs_log_error("Failed to find first attribute extent of "
 				"mft data attribute.\n");
 		ntfs_attr_put_search_ctx(ctx);
@@ -1493,7 +1493,7 @@ static int ntfs_mft_rec_init(ntfs_volume *vol, s64 size)
 
 	/* Sanity checks. */
 	if (mft_na->data_size > mft_na->allocated_size ||
-	    mft_na->initialized_size > mft_na->data_size)
+			mft_na->initialized_size > mft_na->data_size)
 		NTFS_BUG("mft_na sanity checks failed");
 out:
 	ntfs_log_leave("\n");
@@ -1532,11 +1532,11 @@ ntfs_inode *ntfs_mft_rec_alloc(ntfs_volume *vol, BOOL mft_data)
 	forced_mft_data = FALSE;
 	if (mft_data) {
 		ntfs_inode *ext_ni = ntfs_inode_open(vol, FILE_mft_data);
-			/*
-			 * If record 15 cannot be opened, it is probably in
-			 * use as an extent. Apply standard procedure for
-			 * further extents.
-			 */
+		/*
+		 * If record 15 cannot be opened, it is probably in
+		 * use as an extent. Apply standard procedure for
+		 * further extents.
+		 */
 		if (ext_ni) {
 			/*
 			 * Make sure record 15 is a base extent and it has
@@ -1545,8 +1545,8 @@ ntfs_inode *ntfs_mft_rec_alloc(ntfs_volume *vol, BOOL mft_data)
 			 * extents of MFT, so we need a special check.
 			 * If already used, apply standard procedure.
 			 */
-   			if (!ext_ni->mrec->base_mft_record
-			    && !ext_ni->mrec->link_count)
+			if (!ext_ni->mrec->base_mft_record
+					&& !ext_ni->mrec->link_count)
 				forced_mft_data = TRUE;
 			ntfs_inode_close(ext_ni);
 			/* Double-check, in case it is used for MFT */
@@ -1555,10 +1555,10 @@ ntfs_inode *ntfs_mft_rec_alloc(ntfs_volume *vol, BOOL mft_data)
 
 				for (i=0; i<base_ni->nr_extents; i++) {
 					if (base_ni->extent_nis[i]
-					    && (base_ni->extent_nis[i]->mft_no
-							== FILE_mft_data))
+							&& (base_ni->extent_nis[i]->mft_no
+								== FILE_mft_data))
 						forced_mft_data = FALSE;
-   				}
+				}
 			}
 		}
 	}
@@ -1603,20 +1603,20 @@ found_free_rec:
 	}
 	/* Sanity check that the mft record is really not in use. */
 	if (!forced_mft_data
-	    && (ntfs_is_file_record(m->magic)
-	    && (m->flags & MFT_RECORD_IN_USE))) {
+			&& (ntfs_is_file_record(m->magic)
+				&& (m->flags & MFT_RECORD_IN_USE))) {
 		ntfs_log_error("Inode %lld is used but it wasn't marked in "
-			       "$MFT bitmap. Fixed.\n", (long long)bit);
+				"$MFT bitmap. Fixed.\n", (long long)bit);
 		free(m);
 		goto undo_mftbmp_alloc;
 	}
 
-		/*
-		 * Retrieve the former seq_no and usn so that the new record
-		 * cannot be mistaken for the former one.
-		 * However the original record may just be garbage, so
-		 * use some sensible value when they cannot be retrieved.
-		 */
+	/*
+	 * Retrieve the former seq_no and usn so that the new record
+	 * cannot be mistaken for the former one.
+	 * However the original record may just be garbage, so
+	 * use some sensible value when they cannot be retrieved.
+	 */
 	seq_no = m->sequence_number;
 	if (le16_to_cpu(m->usa_ofs) <= (NTFS_BLOCK_SIZE - 2))
 		usn = *(le16*)((u8*)m + (le16_to_cpu(m->usa_ofs) & -2));
@@ -1651,7 +1651,7 @@ found_free_rec:
 	ni->nr_extents = -1;
 	ni->base_ni = base_ni;
 	m->base_mft_record = MK_LE_MREF(base_ni->mft_no,
-					le16_to_cpu(base_ni->mrec->sequence_number));
+			le16_to_cpu(base_ni->mrec->sequence_number));
 	/*
 	 * Attach the extent inode to the base inode, reallocating
 	 * memory if needed.
@@ -1682,8 +1682,8 @@ found_free_rec:
 	ni->data_size = ni->allocated_size = 0;
 	ni->flags = const_cpu_to_le32(0);
 	ni->creation_time = ni->last_data_change_time =
-			ni->last_mft_change_time =
-			ni->last_access_time = ntfs_current_time();
+		ni->last_mft_change_time =
+		ni->last_access_time = ntfs_current_time();
 	/* Update the default mft allocation position if it was used. */
 	if (!base_ni)
 		vol->mft_data_pos = bit + 1;
@@ -1803,8 +1803,8 @@ ntfs_inode *ntfs_mft_record_alloc(ntfs_volume *vol, ntfs_inode *base_ni)
 
 	if (base_ni)
 		ntfs_log_enter("Entering (allocating an extent mft record for "
-			       "base mft record %lld).\n",
-			       (long long)base_ni->mft_no);
+				"base mft record %lld).\n",
+				(long long)base_ni->mft_no);
 	else
 		ntfs_log_enter("Entering (allocating a base mft record)\n");
 	if (!vol || !vol->mft_na || !vol->mftbmp_na) {
@@ -1932,16 +1932,16 @@ found_free_rec:
 	/* Sanity check that the mft record is really not in use. */
 	if (ntfs_is_file_record(m->magic) && (m->flags & MFT_RECORD_IN_USE)) {
 		ntfs_log_error("Inode %lld is used but it wasn't marked in "
-			       "$MFT bitmap. Fixed.\n", (long long)bit);
+				"$MFT bitmap. Fixed.\n", (long long)bit);
 		free(m);
 		goto retry;
 	}
 	seq_no = m->sequence_number;
-		/*
-		 * As ntfs_mft_record_read() returns what has been read
-		 * even when the fixups have been found bad, we have to
-		 * check where we fetch the initial usn from.
-		 */
+	/*
+	 * As ntfs_mft_record_read() returns what has been read
+	 * even when the fixups have been found bad, we have to
+	 * check where we fetch the initial usn from.
+	 */
 	usa_ofs = le16_to_cpu(m->usa_ofs);
 	if (!(usa_ofs & 1) && (usa_ofs < NTFS_BLOCK_SIZE)) {
 		usn = *(le16*)((u8*)m + usa_ofs);
@@ -2008,8 +2008,8 @@ found_free_rec:
 	ni->data_size = ni->allocated_size = 0;
 	ni->flags = const_cpu_to_le32(0);
 	ni->creation_time = ni->last_data_change_time =
-			ni->last_mft_change_time =
-			ni->last_access_time = ntfs_current_time();
+		ni->last_mft_change_time =
+		ni->last_access_time = ntfs_current_time();
 	/* Update the default mft allocation position if it was used. */
 	if (!base_ni)
 		vol->mft_data_pos = bit + 1;

--- a/libntfs/mst.c
+++ b/libntfs/mst.c
@@ -63,7 +63,7 @@ is_valid_record(u32 size, u16 usa_ofs, u16 usa_count)
  *		record in @b will have been set to "BAAD".
  */
 int ntfs_mst_post_read_fixup_warn(NTFS_RECORD *b, const u32 size,
-					BOOL warn)
+		BOOL warn)
 {
 	u16 usa_ofs, usa_count, usn;
 	u16 *usa_pos, *data_pos;
@@ -79,7 +79,7 @@ int ntfs_mst_post_read_fixup_warn(NTFS_RECORD *b, const u32 size,
 		if (warn) {
 			ntfs_log_perror("%s: magic: 0x%08lx  size: %ld "
 					"  usa_ofs: %d  usa_count: %u",
-					 __FUNCTION__,
+					__FUNCTION__,
 					(long)le32_to_cpu(*(le32 *)b),
 					(long)size, (int)usa_ofs,
 					(unsigned int)usa_count);
@@ -113,9 +113,9 @@ int ntfs_mst_post_read_fixup_warn(NTFS_RECORD *b, const u32 size,
 			 */
 			errno = EIO;
 			ntfs_log_perror("Incomplete multi-sector transfer: "
-				"magic: 0x%08x  size: %d  usa_ofs: %d  usa_count:"
-				" %d  data: %d  usn: %d", le32_to_cpu(*(le32 *)b), size,
-				usa_ofs, usa_count, *data_pos, usn);
+					"magic: 0x%08x  size: %d  usa_ofs: %d  usa_count:"
+					" %d  data: %d  usn: %d", le32_to_cpu(*(le32 *)b), size,
+					usa_ofs, usa_count, *data_pos, usn);
 			b->magic = magic_BAAD;
 			return -1;
 		}

--- a/libntfs/object_id.c
+++ b/libntfs/object_id.c
@@ -129,7 +129,7 @@ struct OBJECT_ID_INDEX {		/* index entry in $Extend/$ObjId */
 } ;
 
 static ntfschar objid_index_name[] = { const_cpu_to_le16('$'),
-					 const_cpu_to_le16('O') };
+	const_cpu_to_le16('O') };
 
 /*
  *			Set the index for a new object id
@@ -139,7 +139,7 @@ static ntfschar objid_index_name[] = { const_cpu_to_le16('$'),
  */
 
 static int set_object_id_index(ntfs_inode *ni, ntfs_index_context *xo,
-			const OBJECT_ID_ATTR *object_id)
+		const OBJECT_ID_ATTR *object_id)
 {
 	struct OBJECT_ID_INDEX indx;
 	u64 file_id_cpu;
@@ -150,15 +150,15 @@ static int set_object_id_index(ntfs_inode *ni, ntfs_index_context *xo,
 	file_id_cpu = MK_MREF(ni->mft_no,le16_to_cpu(seqn));
 	file_id = cpu_to_le64(file_id_cpu);
 	indx.header.data_offset = const_cpu_to_le16(
-					sizeof(INDEX_ENTRY_HEADER)
-					+ sizeof(OBJECT_ID_INDEX_KEY));
+			sizeof(INDEX_ENTRY_HEADER)
+			+ sizeof(OBJECT_ID_INDEX_KEY));
 	indx.header.data_length = const_cpu_to_le16(
-					sizeof(OBJECT_ID_INDEX_DATA));
+			sizeof(OBJECT_ID_INDEX_DATA));
 	indx.header.reservedV = const_cpu_to_le32(0);
 	indx.header.length = const_cpu_to_le16(
-					sizeof(struct OBJECT_ID_INDEX));
+			sizeof(struct OBJECT_ID_INDEX));
 	indx.header.key_length = const_cpu_to_le16(
-					sizeof(OBJECT_ID_INDEX_KEY));
+			sizeof(OBJECT_ID_INDEX_KEY));
 	indx.header.flags = const_cpu_to_le16(0);
 	indx.header.reserved = const_cpu_to_le16(0);
 
@@ -191,7 +191,7 @@ static ntfs_index_context *open_object_id_index(ntfs_volume *vol)
 	ntfs_inode *dir_ni;
 	ntfs_index_context *xo;
 
-		/* do not use path_name_to inode - could reopen root */
+	/* do not use path_name_to inode - could reopen root */
 	dir_ni = ntfs_inode_open(vol, FILE_Extend);
 	ni = (ntfs_inode*)NULL;
 	if (dir_ni) {
@@ -220,8 +220,8 @@ static ntfs_index_context *open_object_id_index(ntfs_volume *vol)
  */
 
 static int merge_index_data(ntfs_inode *ni,
-			const OBJECT_ID_ATTR *objectid_attr,
-			OBJECT_ID_ATTR *full_objectid)
+		const OBJECT_ID_ATTR *objectid_attr,
+		OBJECT_ID_ATTR *full_objectid)
 {
 	OBJECT_ID_INDEX_KEY key;
 	struct OBJECT_ID_INDEX *entry;
@@ -234,12 +234,12 @@ static int merge_index_data(ntfs_inode *ni,
 	if (xo) {
 		memcpy(&key.object_id,objectid_attr,sizeof(GUID));
 		if (!ntfs_index_lookup(&key,
-				sizeof(OBJECT_ID_INDEX_KEY), xo)) {
+					sizeof(OBJECT_ID_INDEX_KEY), xo)) {
 			entry = (struct OBJECT_ID_INDEX*)xo->entry;
 			/* make sure inode numbers match */
 			if (entry
-			    && (MREF(le64_to_cpu(entry->data.file_id))
-					== ni->mft_no)) {
+					&& (MREF(le64_to_cpu(entry->data.file_id))
+						== ni->mft_no)) {
 				memcpy(&full_objectid->birth_volume_id,
 						&entry->data.birth_volume_id,
 						sizeof(GUID));
@@ -269,7 +269,7 @@ static int merge_index_data(ntfs_inode *ni,
  */
 
 static int remove_object_id_index(ntfs_attr *na, ntfs_index_context *xo,
-				OBJECT_ID_ATTR *old_attr)
+		OBJECT_ID_ATTR *old_attr)
 {
 	OBJECT_ID_INDEX_KEY key;
 	struct OBJECT_ID_INDEX *entry;
@@ -278,23 +278,23 @@ static int remove_object_id_index(ntfs_attr *na, ntfs_index_context *xo,
 
 	ret = na->data_size;
 	if (ret) {
-			/* read the existing object id attribute */
+		/* read the existing object id attribute */
 		size = ntfs_attr_pread(na, 0, sizeof(GUID), old_attr);
 		if (size >= (s64)sizeof(GUID)) {
 			memcpy(&key.object_id,
-				&old_attr->object_id,sizeof(GUID));
+					&old_attr->object_id,sizeof(GUID));
 			if (!ntfs_index_lookup(&key,
-					sizeof(OBJECT_ID_INDEX_KEY), xo)) {
+						sizeof(OBJECT_ID_INDEX_KEY), xo)) {
 				entry = (struct OBJECT_ID_INDEX*)xo->entry;
 				memcpy(&old_attr->birth_volume_id,
-					&entry->data.birth_volume_id,
-					sizeof(GUID));
+						&entry->data.birth_volume_id,
+						sizeof(GUID));
 				memcpy(&old_attr->birth_object_id,
-					&entry->data.birth_object_id,
-					sizeof(GUID));
+						&entry->data.birth_object_id,
+						sizeof(GUID));
 				memcpy(&old_attr->domain_id,
-					&entry->data.domain_id,
-					sizeof(GUID));
+						&entry->data.domain_id,
+						sizeof(GUID));
 				if (ntfs_index_rm(xo))
 					ret = -1;
 			}
@@ -321,7 +321,7 @@ static int remove_object_id_index(ntfs_attr *na, ntfs_index_context *xo,
  */
 
 static int update_object_id(ntfs_inode *ni, ntfs_index_context *xo,
-			const OBJECT_ID_ATTR *value, size_t size)
+		const OBJECT_ID_ATTR *value, size_t size)
 {
 	OBJECT_ID_ATTR old_attr;
 	ntfs_attr *na;
@@ -334,18 +334,18 @@ static int update_object_id(ntfs_inode *ni, ntfs_index_context *xo,
 	na = ntfs_attr_open(ni, AT_OBJECT_ID, AT_UNNAMED, 0);
 	if (na) {
 		memset(&old_attr, 0, sizeof(OBJECT_ID_ATTR));
-			/* remove the existing index entry */
+		/* remove the existing index entry */
 		oldsize = remove_object_id_index(na,xo,&old_attr);
 		if (oldsize < 0)
 			res = -1;
 		else {
 			/* resize attribute */
 			res = ntfs_attr_truncate(na, (s64)sizeof(GUID));
-				/* write the object_id in attribute */
+			/* write the object_id in attribute */
 			if (!res && value) {
 				written = (int)ntfs_attr_pwrite(na,
-					(s64)0, (s64)sizeof(GUID),
-					&value->object_id);
+						(s64)0, (s64)sizeof(GUID),
+						&value->object_id);
 				if (written != (s64)sizeof(GUID)) {
 					ntfs_log_error("Failed to update "
 							"object id\n");
@@ -353,12 +353,12 @@ static int update_object_id(ntfs_inode *ni, ntfs_index_context *xo,
 					res = -1;
 				}
 			}
-				/* overwrite index data with new value */
+			/* overwrite index data with new value */
 			memcpy(&old_attr, value,
-				(size < sizeof(OBJECT_ID_ATTR)
-					? size : sizeof(OBJECT_ID_ATTR)));
+					(size < sizeof(OBJECT_ID_ATTR)
+					 ? size : sizeof(OBJECT_ID_ATTR)));
 			if (!res
-			    && set_object_id_index(ni,xo,&old_attr)) {
+					&& set_object_id_index(ni,xo,&old_attr)) {
 				/*
 				 * If cannot index, try to remove the object
 				 * id and log the error. There will be an
@@ -432,10 +432,10 @@ int ntfs_delete_object_id_index(ntfs_inode *ni)
 	res = 0;
 	na = ntfs_attr_open(ni, AT_OBJECT_ID, AT_UNNAMED, 0);
 	if (na) {
-			/*
-			 * read the existing object id
-			 * and un-index it
-			 */
+		/*
+		 * read the existing object id
+		 * and un-index it
+		 */
 		xo = open_object_id_index(ni->vol);
 		if (xo) {
 			if (remove_object_id_index(na,xo,&old_attr) < 0)
@@ -472,27 +472,27 @@ int ntfs_get_ntfs_object_id(ntfs_inode *ni, char *value, size_t size)
 	full_size = 0;	/* default to no data and some error to be defined */
 	if (ni) {
 		objectid_attr = (OBJECT_ID_ATTR*)ntfs_attr_readall(ni,
-			AT_OBJECT_ID,(ntfschar*)NULL, 0, &attr_size);
+				AT_OBJECT_ID,(ntfschar*)NULL, 0, &attr_size);
 		if (objectid_attr) {
-				/* restrict to only GUID present in attr */
+			/* restrict to only GUID present in attr */
 			if (attr_size == sizeof(GUID)) {
 				memcpy(&full_objectid.object_id,
 						objectid_attr,sizeof(GUID));
 				full_size = sizeof(GUID);
-					/* get data from index, if any */
+				/* get data from index, if any */
 				if (!merge_index_data(ni, objectid_attr,
-						&full_objectid)) {
+							&full_objectid)) {
 					full_size = sizeof(OBJECT_ID_ATTR);
 				}
 				if (full_size <= (s64)size) {
 					if (value)
 						memcpy(value,&full_objectid,
-							full_size);
+								full_size);
 					else
 						errno = EINVAL;
 				}
 			} else {
-			/* unexpected size, better return unsupported */
+				/* unexpected size, better return unsupported */
 				errno = EOPNOTSUPP;
 				full_size = 0;
 			}
@@ -516,7 +516,7 @@ int ntfs_get_ntfs_object_id(ntfs_inode *ni, char *value, size_t size)
  */
 
 int ntfs_set_ntfs_object_id(ntfs_inode *ni,
-			const char *value, size_t size, int flags)
+		const char *value, size_t size, int flags)
 {
 	OBJECT_ID_INDEX_KEY key;
 	ntfs_inode *xoni;
@@ -530,19 +530,19 @@ int ntfs_set_ntfs_object_id(ntfs_inode *ni,
 			/* make sure the GUID was not used elsewhere */
 			memcpy(&key.object_id, value, sizeof(GUID));
 			if ((ntfs_index_lookup(&key,
-					sizeof(OBJECT_ID_INDEX_KEY), xo))
-			    || (MREF_LE(((struct OBJECT_ID_INDEX*)xo->entry)
-					->data.file_id) == ni->mft_no)) {
+							sizeof(OBJECT_ID_INDEX_KEY), xo))
+					|| (MREF_LE(((struct OBJECT_ID_INDEX*)xo->entry)
+							->data.file_id) == ni->mft_no)) {
 				ntfs_index_ctx_reinit(xo);
 				res = add_object_id(ni, flags);
 				if (!res) {
-						/* update value and index */
+					/* update value and index */
 					res = update_object_id(ni,xo,
-						(const OBJECT_ID_ATTR*)value,
-						size);
+							(const OBJECT_ID_ATTR*)value,
+							size);
 				}
 			} else {
-					/* GUID is present elsewhere */
+				/* GUID is present elsewhere */
 				res = -1;
 				errno = EEXIST;
 			}
@@ -583,7 +583,7 @@ int ntfs_remove_ntfs_object_id(ntfs_inode *ni)
 		 * open and delete the object id
 		 */
 		na = ntfs_attr_open(ni, AT_OBJECT_ID,
-			AT_UNNAMED,0);
+				AT_UNNAMED,0);
 		if (na) {
 			/* first remove index (old object id needed) */
 			xo = open_object_id_index(ni->vol);
@@ -595,20 +595,18 @@ int ntfs_remove_ntfs_object_id(ntfs_inode *ni)
 				} else {
 					/* now remove attribute */
 					res = ntfs_attr_rm(na);
-					if (res
-					    && (oldsize > (int)sizeof(GUID))) {
-					/*
-					 * If we could not remove the
-					 * attribute, try to restore the
-					 * index and log the error. There
-					 * will be an inconsistency if
-					 * the reindexing fails.
-					 */
-						set_object_id_index(ni, xo,
-							&old_attr);
+					if (res && (oldsize > (int)sizeof(GUID))) {
+						/*
+						 * If we could not remove the
+						 * attribute, try to restore the
+						 * index and log the error. There
+						 * will be an inconsistency if
+						 * the reindexing fails.
+						 */
+						set_object_id_index(ni, xo, &old_attr);
 						ntfs_log_error(
-						"Failed to remove object id."
-						" Possible corruption.\n");
+								"Failed to remove object id."
+								" Possible corruption.\n");
 					}
 				}
 
@@ -620,7 +618,7 @@ int ntfs_remove_ntfs_object_id(ntfs_inode *ni)
 			}
 			olderrno = errno;
 			ntfs_attr_close(na);
-					/* avoid errno pollution */
+			/* avoid errno pollution */
 			if (errno == ENOENT)
 				errno = olderrno;
 		} else {

--- a/libntfs/realpath.c
+++ b/libntfs/realpath.c
@@ -25,9 +25,9 @@
 #ifndef HAVE_REALPATH
 char *ntfs_realpath(const char *path, char *resolved_path)
 {
-       strncpy(resolved_path, path, PATH_MAX);
-       resolved_path[PATH_MAX] = '\0';
-       return resolved_path;
+	strncpy(resolved_path, path, PATH_MAX);
+	resolved_path[PATH_MAX] = '\0';
+	return resolved_path;
 }
 #endif
 

--- a/libntfs/reparse.c
+++ b/libntfs/reparse.c
@@ -111,7 +111,7 @@ static const ntfschar vol_junction_head[] = {
 } ;
 
 static ntfschar reparse_index_name[] = { const_cpu_to_le16('$'),
-					 const_cpu_to_le16('R') };
+	const_cpu_to_le16('R') };
 
 static const char mappingdir[] = ".NTFS-3G/";
 
@@ -161,7 +161,7 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
 			 * whose lower case is smaller (such as umlauted Y)
 			 */
 			if ((cpuchar < vol->upcase_len)
-			    && (le16_to_cpu(vol->upcase[cpuchar]) < cpuchar))
+					&& (le16_to_cpu(vol->upcase[cpuchar]) < cpuchar))
 				find.attr.file_name[i] = vol->upcase[cpuchar];
 			else
 				find.attr.file_name[i] = uname[i];
@@ -175,19 +175,19 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
 		 * so we still have to check whether this is a real match
 		 */
 		if (icx->entry && (icx->entry->ie_flags & INDEX_ENTRY_END))
-				/* get next entry if reaching end of block */
+			/* get next entry if reaching end of block */
 			entry = ntfs_index_next(icx->entry, icx);
 		else
 			entry = icx->entry;
 		if (entry) {
 			found = &entry->key.file_name;
 			if (lkup
-			   && ntfs_names_are_equal(find.attr.file_name,
-				find.attr.file_name_length,
-				found->file_name, found->file_name_length,
-				IGNORE_CASE,
-				vol->upcase, vol->upcase_len))
-					lkup = 0;
+					&& ntfs_names_are_equal(find.attr.file_name,
+						find.attr.file_name_length,
+						found->file_name, found->file_name_length,
+						IGNORE_CASE,
+						vol->upcase, vol->upcase_len))
+				lkup = 0;
 			if (!lkup) {
 				/*
 				 * name found :
@@ -218,7 +218,7 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
  */
 
 static char *search_absolute(ntfs_volume *vol, ntfschar *path,
-				int count, BOOL isdir)
+		int count, BOOL isdir)
 {
 	ntfs_inode *ni;
 	u64 inum;
@@ -244,7 +244,7 @@ static char *search_absolute(ntfs_volume *vol, ntfschar *path,
 		do {
 			len = 0;
 			while (((start + len) < count)
-			    && (path[start + len] != const_cpu_to_le16('\\')))
+					&& (path[start + len] != const_cpu_to_le16('\\')))
 				len++;
 			inum = ntfs_fix_file_name(ni, &path[start], len);
 			ntfs_inode_close(ni);
@@ -257,18 +257,18 @@ static char *search_absolute(ntfs_volume *vol, ntfschar *path,
 					path[start++] = const_cpu_to_le16('/');
 			}
 		} while (ni
-		    && (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)
-		    && !(ni->flags & FILE_ATTR_REPARSE_POINT)
-		    && (start < count));
-	if (ni
-	    && ((ni->mrec->flags & MFT_RECORD_IS_DIRECTORY ? isdir : !isdir)
-		|| (ni->flags & FILE_ATTR_REPARSE_POINT)))
-		if (ntfs_ucstombs(path, count, &target, 0) < 0) {
-			if (target)
-				ntfs_attr_name_free(&target);
-		}
-	if (ni)
-		ntfs_inode_close(ni);
+				&& (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)
+				&& !(ni->flags & FILE_ATTR_REPARSE_POINT)
+				&& (start < count));
+		if (ni
+				&& ((ni->mrec->flags & MFT_RECORD_IS_DIRECTORY ? isdir : !isdir)
+					|| (ni->flags & FILE_ATTR_REPARSE_POINT)))
+			if (ntfs_ucstombs(path, count, &target, 0) < 0) {
+				if (target)
+					ntfs_attr_name_free(&target);
+			}
+		if (ni)
+			ntfs_inode_close(ni);
 	}
 	return (target);
 }
@@ -301,28 +301,28 @@ static char *search_relative(ntfs_inode *ni, ntfschar *path, int count)
 	ok = TRUE;
 	morelinks = FALSE;
 	curni = ntfs_dir_parent_inode(ni);
-		/*
-		 * Examine and translate the path, until we reach either
-		 *  - the end,
-		 *  - an unknown item
-		 *  - a non-directory
-		 *  - another reparse point,
-		 * A reparse point is not dereferenced, it will be
-		 * examined later when the translated path is dereferenced,
-		 * however the final part of the path will not be adjusted
-		 * to correct case.
-		 */
+	/*
+	 * Examine and translate the path, until we reach either
+	 *  - the end,
+	 *  - an unknown item
+	 *  - a non-directory
+	 *  - another reparse point,
+	 * A reparse point is not dereferenced, it will be
+	 * examined later when the translated path is dereferenced,
+	 * however the final part of the path will not be adjusted
+	 * to correct case.
+	 */
 	while (curni && ok && !morelinks && (pos < (count - 1)) && --max) {
 		if ((count >= (pos + 2))
-		    && (path[pos] == const_cpu_to_le16('.'))
-		    && (path[pos+1] == const_cpu_to_le16('\\'))) {
+				&& (path[pos] == const_cpu_to_le16('.'))
+				&& (path[pos+1] == const_cpu_to_le16('\\'))) {
 			path[pos+1] = const_cpu_to_le16('/');
 			pos += 2;
 		} else {
 			if ((count >= (pos + 3))
-			    && (path[pos] == const_cpu_to_le16('.'))
-			    &&(path[pos+1] == const_cpu_to_le16('.'))
-			    && (path[pos+2] == const_cpu_to_le16('\\'))) {
+					&& (path[pos] == const_cpu_to_le16('.'))
+					&&(path[pos+1] == const_cpu_to_le16('.'))
+					&& (path[pos+2] == const_cpu_to_le16('\\'))) {
 				path[pos+2] = const_cpu_to_le16('/');
 				pos += 3;
 				newni = ntfs_dir_parent_inode(curni);
@@ -334,16 +334,16 @@ static char *search_relative(ntfs_inode *ni, ntfschar *path, int count)
 			} else {
 				lth = 0;
 				while (((pos + lth) < count)
-				    && (path[pos + lth] != const_cpu_to_le16('\\')))
+						&& (path[pos + lth] != const_cpu_to_le16('\\')))
 					lth++;
 				if (lth > 0)
 					inum = ntfs_fix_file_name(curni,&path[pos],lth);
 				else
 					inum = (u64)-1;
 				if (!lth
-				    || ((curni != ni)
-					&& ntfs_inode_close(curni))
-				    || (inum == (u64)-1))
+						|| ((curni != ni)
+							&& ntfs_inode_close(curni))
+						|| (inum == (u64)-1))
 					ok = FALSE;
 				else {
 					curni = ntfs_inode_open(ni->vol, MREF(inum));
@@ -356,13 +356,13 @@ static char *search_relative(ntfs_inode *ni, ntfschar *path, int count)
 							path[pos + lth] = const_cpu_to_le16('/');
 							pos += lth + 1;
 							if (morelinks
-							   && ntfs_inode_close(curni))
+									&& ntfs_inode_close(curni))
 								ok = FALSE;
 						} else {
 							pos += lth;
 							if (!morelinks
-							  && (ni->mrec->flags ^ curni->mrec->flags)
-							    & MFT_RECORD_IS_DIRECTORY)
+									&& (ni->mrec->flags ^ curni->mrec->flags)
+									& MFT_RECORD_IS_DIRECTORY)
 								ok = FALSE;
 							if (ntfs_inode_close(curni))
 								ok = FALSE;
@@ -412,7 +412,7 @@ static int ntfs_drive_letter(ntfs_volume *vol, ntfschar letter)
 		else
 			if (errno == ENOENT) {
 				ret = 0;
-					/* avoid errno pollution */
+				/* avoid errno pollution */
 				errno = olderrno;
 			}
 	}
@@ -434,16 +434,16 @@ int ntfs_reparse_check_wsl(ntfs_inode *ni, const REPARSE_POINT *reparse)
 
 	res = -EOPNOTSUPP;
 	switch (reparse->reparse_tag) {
-	case IO_REPARSE_TAG_AF_UNIX :
-	case IO_REPARSE_TAG_LX_FIFO :
-	case IO_REPARSE_TAG_LX_CHR :
-	case IO_REPARSE_TAG_LX_BLK :
-		if (!reparse->reparse_data_length
-		    && (ni->flags & FILE_ATTRIBUTE_RECALL_ON_OPEN))
-			res = 0;
-		break;
-	default :
-		break;
+		case IO_REPARSE_TAG_AF_UNIX :
+		case IO_REPARSE_TAG_LX_FIFO :
+		case IO_REPARSE_TAG_LX_CHR :
+		case IO_REPARSE_TAG_LX_BLK :
+			if (!reparse->reparse_data_length
+					&& (ni->flags & FILE_ATTRIBUTE_RECALL_ON_OPEN))
+				res = 0;
+			break;
+		default :
+			break;
 	}
 	if (res)
 		errno = EOPNOTSUPP;
@@ -463,7 +463,7 @@ int ntfs_reparse_check_wsl(ntfs_inode *ni, const REPARSE_POINT *reparse)
  */
 
 static BOOL valid_reparse_data(ntfs_inode *ni,
-			const REPARSE_POINT *reparse_attr, size_t size)
+		const REPARSE_POINT *reparse_attr, size_t size)
 {
 	BOOL ok;
 	unsigned int offs;
@@ -476,49 +476,49 @@ static BOOL valid_reparse_data(ntfs_inode *ni,
 		&& (size >= sizeof(REPARSE_POINT))
 		&& (reparse_attr->reparse_tag != IO_REPARSE_TAG_RESERVED_ZERO)
 		&& (((size_t)le16_to_cpu(reparse_attr->reparse_data_length)
-			 + sizeof(REPARSE_POINT)
-			 + ((reparse_attr->reparse_tag &
-			     IO_REPARSE_TAG_IS_MICROSOFT) ? 0 : sizeof(GUID))) == size);
+			+ sizeof(REPARSE_POINT)
+			+ ((reparse_attr->reparse_tag &
+					IO_REPARSE_TAG_IS_MICROSOFT) ? 0 : sizeof(GUID))) == size);
 	if (ok) {
 		switch (reparse_attr->reparse_tag) {
 		case IO_REPARSE_TAG_MOUNT_POINT :
 			if (size < sizeof(REPARSE_POINT) +
-				   sizeof(struct MOUNT_POINT_REPARSE_DATA)) {
+					sizeof(struct MOUNT_POINT_REPARSE_DATA)) {
 				ok = FALSE;
 				break;
 			}
 			mount_point_data = (const struct MOUNT_POINT_REPARSE_DATA*)
-						reparse_attr->reparse_data;
+				reparse_attr->reparse_data;
 			offs = le16_to_cpu(mount_point_data->subst_name_offset);
 			lth = le16_to_cpu(mount_point_data->subst_name_length);
-				/* consistency checks */
+			/* consistency checks */
 			if (!(ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)
-			    || ((size_t)((sizeof(REPARSE_POINT)
-				 + sizeof(struct MOUNT_POINT_REPARSE_DATA)
-				 + offs + lth)) > size))
+					|| ((size_t)((sizeof(REPARSE_POINT)
+						+ sizeof(struct MOUNT_POINT_REPARSE_DATA)
+						+ offs + lth)) > size))
 				ok = FALSE;
 			break;
 		case IO_REPARSE_TAG_SYMLINK :
 			if (size < sizeof(REPARSE_POINT) +
-				   sizeof(struct SYMLINK_REPARSE_DATA)) {
+					sizeof(struct SYMLINK_REPARSE_DATA)) {
 				ok = FALSE;
 				break;
 			}
 			symlink_data = (const struct SYMLINK_REPARSE_DATA*)
-						reparse_attr->reparse_data;
+				reparse_attr->reparse_data;
 			offs = le16_to_cpu(symlink_data->subst_name_offset);
 			lth = le16_to_cpu(symlink_data->subst_name_length);
 			if ((size_t)((sizeof(REPARSE_POINT)
-				 + sizeof(struct SYMLINK_REPARSE_DATA)
-				 + offs + lth)) > size)
+					+ sizeof(struct SYMLINK_REPARSE_DATA)
+					+ offs + lth)) > size)
 				ok = FALSE;
 			break;
 		case IO_REPARSE_TAG_LX_SYMLINK :
 			wsl_reparse_data = (const struct WSL_LINK_REPARSE_DATA*)
-						reparse_attr->reparse_data;
+				reparse_attr->reparse_data;
 			if ((le16_to_cpu(reparse_attr->reparse_data_length)
-					<= sizeof(wsl_reparse_data->type))
-			    || (wsl_reparse_data->type != const_cpu_to_le32(2)))
+						<= sizeof(wsl_reparse_data->type))
+					|| (wsl_reparse_data->type != const_cpu_to_le32(2)))
 				ok = FALSE;
 			break;
 		case IO_REPARSE_TAG_AF_UNIX :
@@ -526,7 +526,7 @@ static BOOL valid_reparse_data(ntfs_inode *ni,
 		case IO_REPARSE_TAG_LX_CHR :
 		case IO_REPARSE_TAG_LX_BLK :
 			if (reparse_attr->reparse_data_length
-			    || !(ni->flags & FILE_ATTRIBUTE_RECALL_ON_OPEN))
+					|| !(ni->flags & FILE_ATTRIBUTE_RECALL_ON_OPEN))
 				ok = FALSE;
 			break;
 		default :
@@ -554,7 +554,7 @@ static BOOL valid_reparse_data(ntfs_inode *ni,
  */
 
 static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
-			int count, const char *mnt_point, BOOL isdir)
+		int count, const char *mnt_point, BOOL isdir)
 {
 	char *target;
 	char *fulltarget;
@@ -564,36 +564,36 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
 
 	target = (char*)NULL;
 	fulltarget = (char*)NULL;
-			/*
-			 * For a valid directory junction we want \??\x:\
-			 * where \ is an individual char and x a non-null char
-			 */
+	/*
+	 * For a valid directory junction we want \??\x:\
+	 * where \ is an individual char and x a non-null char
+	 */
 	if ((count >= 7)
-	    && !memcmp(junction,dir_junction_head,8)
-	    && junction[4]
-	    && (junction[5] == const_cpu_to_le16(':'))
-	    && (junction[6] == const_cpu_to_le16('\\')))
+			&& !memcmp(junction,dir_junction_head,8)
+			&& junction[4]
+			&& (junction[5] == const_cpu_to_le16(':'))
+			&& (junction[6] == const_cpu_to_le16('\\')))
 		kind = DIR_JUNCTION;
 	else
-			/*
-			 * For a valid volume junction we want \\?\Volume{
-			 * and a final \ (where \ is an individual char)
-			 */
+		/*
+		 * For a valid volume junction we want \\?\Volume{
+		 * and a final \ (where \ is an individual char)
+		 */
 		if ((count >= 12)
-		    && !memcmp(junction,vol_junction_head,22)
-		    && (junction[count-1] == const_cpu_to_le16('\\')))
+				&& !memcmp(junction,vol_junction_head,22)
+				&& (junction[count-1] == const_cpu_to_le16('\\')))
 			kind = VOL_JUNCTION;
 		else
 			kind = NO_JUNCTION;
-			/*
-			 * Directory junction with an explicit path and
-			 * no specific definition for the drive letter :
-			 * try to interpret as a target on the same volume
-			 */
+	/*
+	 * Directory junction with an explicit path and
+	 * no specific definition for the drive letter :
+	 * try to interpret as a target on the same volume
+	 */
 	if ((kind == DIR_JUNCTION)
-	    && (count >= 7)
-	    && junction[7]
-	    && !ntfs_drive_letter(vol, junction[4])) {
+			&& (count >= 7)
+			&& junction[7]
+			&& !ntfs_drive_letter(vol, junction[4])) {
 		target = search_absolute(vol,&junction[7],count - 7, isdir);
 		if (target) {
 			fulltarget = (char*)ntfs_malloc(strlen(mnt_point)
@@ -606,29 +606,29 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
 			ntfs_attr_name_free(&target);
 		}
 	}
-			/*
-			 * Volume junctions or directory junctions with
-			 * target not found on current volume :
-			 * link to /.NTFS-3G/target which the user can
-			 * define as a symbolic link to the real target
-			 */
+	/*
+	 * Volume junctions or directory junctions with
+	 * target not found on current volume :
+	 * link to /.NTFS-3G/target which the user can
+	 * define as a symbolic link to the real target
+	 */
 	if (((kind == DIR_JUNCTION) && !fulltarget)
-	    || (kind == VOL_JUNCTION)) {
+			|| (kind == VOL_JUNCTION)) {
 		sz = ntfs_ucstombs(&junction[4],
-			(kind == VOL_JUNCTION ? count - 5 : count - 4),
-			&target, 0);
+				(kind == VOL_JUNCTION ? count - 5 : count - 4),
+				&target, 0);
 		if ((sz > 0) && target) {
-				/* reverse slashes */
+			/* reverse slashes */
 			for (q=target; *q; q++)
 				if (*q == '\\')
 					*q = '/';
-				/* force uppercase drive letter */
+			/* force uppercase drive letter */
 			if ((target[1] == ':')
-			    && (target[0] >= 'a')
-			    && (target[0] <= 'z'))
+					&& (target[0] >= 'a')
+					&& (target[0] <= 'z'))
 				target[0] += 'A' - 'a';
 			fulltarget = (char*)ntfs_malloc(strlen(mnt_point)
-				    + sizeof(mappingdir) + strlen(target) + 1);
+					+ sizeof(mappingdir) + strlen(target) + 1);
 			if (fulltarget) {
 				strcpy(fulltarget,mnt_point);
 				strcat(fulltarget,"/");
@@ -657,8 +657,8 @@ static char *ntfs_get_fulllink(ntfs_volume *vol, ntfschar *junction,
  */
 
 char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, int count,
-			const char *mnt_point __attribute__((unused)),
-			BOOL isdir)
+		const char *mnt_point __attribute__((unused)),
+		BOOL isdir)
 {
 	char *target;
 	char *fulltarget;
@@ -668,41 +668,41 @@ char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, int count,
 
 	target = (char*)NULL;
 	fulltarget = (char*)NULL;
-			/*
-			 * For a full valid path we want x:\
-			 * where \ is an individual char and x a non-null char
-			 */
+	/*
+	 * For a full valid path we want x:\
+	 * where \ is an individual char and x a non-null char
+	 */
 	if ((count >= 3)
-	    && junction[0]
-	    && (junction[1] == const_cpu_to_le16(':'))
-	    && (junction[2] == const_cpu_to_le16('\\')))
+			&& junction[0]
+			&& (junction[1] == const_cpu_to_le16(':'))
+			&& (junction[2] == const_cpu_to_le16('\\')))
 		kind = FULL_PATH;
 	else
-			/*
-			 * For an absolute path we want an initial \
-			 */
+		/*
+		 * For an absolute path we want an initial \
+		 */
 		if ((count >= 0)
-		    && (junction[0] == const_cpu_to_le16('\\')))
+				&& (junction[0] == const_cpu_to_le16('\\')))
 			kind = ABS_PATH;
 		else
 			kind = REJECTED_PATH;
-			/*
-			 * Full path, with a drive letter and
-			 * no specific definition for the drive letter :
-			 * try to interpret as a target on the same volume.
-			 * Do the same for an abs path with no drive letter.
-			 */
+	/*
+	 * Full path, with a drive letter and
+	 * no specific definition for the drive letter :
+	 * try to interpret as a target on the same volume.
+	 * Do the same for an abs path with no drive letter.
+	 */
 	if (((kind == FULL_PATH)
-	    && (count >= 3)
-	    && junction[3]
-	    && !ntfs_drive_letter(vol, junction[0]))
-	    || (kind == ABS_PATH)) {
+				&& (count >= 3)
+				&& junction[3]
+				&& !ntfs_drive_letter(vol, junction[0]))
+			|| (kind == ABS_PATH)) {
 		if (kind == ABS_PATH)
 			target = search_absolute(vol, &junction[1],
-				count - 1, isdir);
+					count - 1, isdir);
 		else
 			target = search_absolute(vol, &junction[3],
-				count - 3, isdir);
+					count - 3, isdir);
 		if (target) {
 			fulltarget = (char*)ntfs_malloc(
 					strlen(vol->abs_mnt_point)
@@ -715,27 +715,27 @@ char *ntfs_get_abslink(ntfs_volume *vol, ntfschar *junction, int count,
 			ntfs_attr_name_free(&target);
 		}
 	}
-			/*
-			 * full path with target not found on current volume :
-			 * link to /.NTFS-3G/target which the user can
-			 * define as a symbolic link to the real target
-			 */
+	/*
+	 * full path with target not found on current volume :
+	 * link to /.NTFS-3G/target which the user can
+	 * define as a symbolic link to the real target
+	 */
 	if ((kind == FULL_PATH) && !fulltarget) {
 		sz = ntfs_ucstombs(&junction[0],
-			count,&target, 0);
+				count,&target, 0);
 		if ((sz > 0) && target) {
-				/* reverse slashes */
+			/* reverse slashes */
 			for (q=target; *q; q++)
 				if (*q == '\\')
 					*q = '/';
-				/* force uppercase drive letter */
+			/* force uppercase drive letter */
 			if ((target[1] == ':')
-			    && (target[0] >= 'a')
-			    && (target[0] <= 'z'))
+					&& (target[0] >= 'a')
+					&& (target[0] <= 'z'))
 				target[0] += 'A' - 'a';
 			fulltarget = (char*)ntfs_malloc(
-				strlen(vol->abs_mnt_point)
-				    + sizeof(mappingdir) + strlen(target) + 1);
+					strlen(vol->abs_mnt_point)
+					+ sizeof(mappingdir) + strlen(target) + 1);
 			if (fulltarget) {
 				strcpy(fulltarget,vol->abs_mnt_point);
 				strcat(fulltarget,"/");
@@ -798,7 +798,7 @@ char *ntfs_make_symlink(ntfs_inode *ni, const char *mnt_point)
 	target = (char*)NULL;
 	bad = TRUE;
 	isdir = (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)
-			 != const_cpu_to_le16(0);
+		!= const_cpu_to_le16(0);
 	vol = ni->vol;
 	reparse_attr = (REPARSE_POINT*)ntfs_attr_readall(ni,
 			AT_REPARSE_POINT,(ntfschar*)NULL, 0, &attr_size);
@@ -807,29 +807,29 @@ char *ntfs_make_symlink(ntfs_inode *ni, const char *mnt_point)
 		switch (reparse_attr->reparse_tag) {
 		case IO_REPARSE_TAG_MOUNT_POINT :
 			mount_point_data = (struct MOUNT_POINT_REPARSE_DATA*)
-						reparse_attr->reparse_data;
+				reparse_attr->reparse_data;
 			offs = le16_to_cpu(mount_point_data->subst_name_offset);
 			lth = le16_to_cpu(mount_point_data->subst_name_length);
-				/* reparse data consistency has been checked */
+			/* reparse data consistency has been checked */
 			target = ntfs_get_fulllink(vol,
-				(ntfschar*)&mount_point_data->path_buffer[offs],
-				lth/2, mnt_point, isdir);
+					(ntfschar*)&mount_point_data->path_buffer[offs],
+					lth/2, mnt_point, isdir);
 			if (target)
 				bad = FALSE;
 			break;
 		case IO_REPARSE_TAG_SYMLINK :
 			symlink_data = (struct SYMLINK_REPARSE_DATA*)
-						reparse_attr->reparse_data;
+				reparse_attr->reparse_data;
 			offs = le16_to_cpu(symlink_data->subst_name_offset);
 			lth = le16_to_cpu(symlink_data->subst_name_length);
 			p = (ntfschar*)&symlink_data->path_buffer[offs];
-				/*
-				 * Predetermine the kind of target,
-				 * the called function has to make a full check
-				 */
+			/*
+			 * Predetermine the kind of target,
+			 * the called function has to make a full check
+			 */
 			if (*p++ == const_cpu_to_le16('\\')) {
 				if ((*p == const_cpu_to_le16('?'))
-				    || (*p == const_cpu_to_le16('\\')))
+						|| (*p == const_cpu_to_le16('\\')))
 					kind = FULL_TARGET;
 				else
 					kind = ABS_TARGET;
@@ -839,33 +839,33 @@ char *ntfs_make_symlink(ntfs_inode *ni, const char *mnt_point)
 				else
 					kind = REL_TARGET;
 			p--;
-				/* reparse data consistency has been checked */
+			/* reparse data consistency has been checked */
 			switch (kind) {
 			case FULL_TARGET :
 				if (!(symlink_data->flags
-				   & const_cpu_to_le32(1))) {
+							& const_cpu_to_le32(1))) {
 					target = ntfs_get_fulllink(vol,
-						p, lth/2,
-						mnt_point, isdir);
+							p, lth/2,
+							mnt_point, isdir);
 					if (target)
 						bad = FALSE;
 				}
 				break;
 			case ABS_TARGET :
 				if (symlink_data->flags
-				   & const_cpu_to_le32(1)) {
+						& const_cpu_to_le32(1)) {
 					target = ntfs_get_abslink(vol,
-						p, lth/2,
-						mnt_point, isdir);
+							p, lth/2,
+							mnt_point, isdir);
 					if (target)
 						bad = FALSE;
 				}
 				break;
 			case REL_TARGET :
 				if (symlink_data->flags
-				   & const_cpu_to_le32(1)) {
+						& const_cpu_to_le32(1)) {
 					target = ntfs_get_rellink(ni,
-						p, lth/2);
+							p, lth/2);
 					if (target)
 						bad = FALSE;
 				}
@@ -874,15 +874,15 @@ char *ntfs_make_symlink(ntfs_inode *ni, const char *mnt_point)
 			break;
 		case IO_REPARSE_TAG_LX_SYMLINK :
 			wsl_link_data = (struct WSL_LINK_REPARSE_DATA*)
-						reparse_attr->reparse_data;
+				reparse_attr->reparse_data;
 			if (wsl_link_data->type == const_cpu_to_le32(2)) {
 				lth = le16_to_cpu(
-					reparse_attr->reparse_data_length)
+						reparse_attr->reparse_data_length)
 					- sizeof(wsl_link_data->type);
 				target = (char*)ntfs_malloc(lth + 1);
 				if (target) {
 					memcpy(target, wsl_link_data->link,
-						lth);
+							lth);
 					target[lth] = 0;
 					bad = FALSE;
 				}
@@ -915,11 +915,11 @@ BOOL ntfs_possible_symlink(ntfs_inode *ni)
 			AT_REPARSE_POINT,(ntfschar*)NULL, 0, &attr_size);
 	if (reparse_attr && attr_size) {
 		switch (reparse_attr->reparse_tag) {
-		case IO_REPARSE_TAG_MOUNT_POINT :
-		case IO_REPARSE_TAG_SYMLINK :
-		case IO_REPARSE_TAG_LX_SYMLINK :
-			possible = TRUE;
-		default : ;
+			case IO_REPARSE_TAG_MOUNT_POINT :
+			case IO_REPARSE_TAG_SYMLINK :
+			case IO_REPARSE_TAG_LX_SYMLINK :
+				possible = TRUE;
+			default : ;
 		}
 		free(reparse_attr);
 	}
@@ -935,7 +935,7 @@ BOOL ntfs_possible_symlink(ntfs_inode *ni)
  */
 
 static int set_reparse_index(ntfs_inode *ni, ntfs_index_context *xr,
-			le32 reparse_tag)
+		le32 reparse_tag)
 {
 	struct REPARSE_INDEX indx;
 	u64 file_id_cpu;
@@ -946,18 +946,18 @@ static int set_reparse_index(ntfs_inode *ni, ntfs_index_context *xr,
 	file_id_cpu = MK_MREF(ni->mft_no,le16_to_cpu(seqn));
 	file_id = cpu_to_le64(file_id_cpu);
 	indx.header.data_offset = const_cpu_to_le16(
-					sizeof(INDEX_ENTRY_HEADER)
-					+ sizeof(REPARSE_INDEX_KEY));
+			sizeof(INDEX_ENTRY_HEADER)
+			+ sizeof(REPARSE_INDEX_KEY));
 	indx.header.data_length = const_cpu_to_le16(0);
 	indx.header.reservedV = const_cpu_to_le32(0);
 	indx.header.length = const_cpu_to_le16(
-					sizeof(struct REPARSE_INDEX));
+			sizeof(struct REPARSE_INDEX));
 	indx.header.key_length = const_cpu_to_le16(
-					sizeof(REPARSE_INDEX_KEY));
+			sizeof(REPARSE_INDEX_KEY));
 	indx.header.flags = const_cpu_to_le16(0);
 	indx.header.reserved = const_cpu_to_le16(0);
 	indx.key.reparse_tag = reparse_tag;
-		/* danger on processors which require proper alignment ! */
+	/* danger on processors which require proper alignment ! */
 	memcpy(&indx.key.file_id, &file_id, 8);
 	indx.filling = const_cpu_to_le32(0);
 	ntfs_index_ctx_reinit(xr);
@@ -974,7 +974,7 @@ static int set_reparse_index(ntfs_inode *ni, ntfs_index_context *xr,
  */
 
 static int remove_reparse_index(ntfs_attr *na, ntfs_index_context *xr,
-				le32 *preparse_tag)
+		le32 *preparse_tag)
 {
 	REPARSE_INDEX_KEY key;
 	u64 file_id_cpu;
@@ -985,17 +985,17 @@ static int remove_reparse_index(ntfs_attr *na, ntfs_index_context *xr,
 
 	ret = na->data_size;
 	if (ret) {
-			/* read the existing reparse_tag */
+		/* read the existing reparse_tag */
 		size = ntfs_attr_pread(na, 0, 4, preparse_tag);
 		if (size == 4) {
 			seqn = na->ni->mrec->sequence_number;
 			file_id_cpu = MK_MREF(na->ni->mft_no,le16_to_cpu(seqn));
 			file_id = cpu_to_le64(file_id_cpu);
 			key.reparse_tag = *preparse_tag;
-		/* danger on processors which require proper alignment ! */
+			/* danger on processors which require proper alignment ! */
 			memcpy(&key.file_id, &file_id, 8);
 			if (!ntfs_index_lookup(&key, sizeof(REPARSE_INDEX_KEY), xr)
-			    && ntfs_index_rm(xr))
+					&& ntfs_index_rm(xr))
 				ret = -1;
 		} else {
 			ret = -1;
@@ -1021,7 +1021,7 @@ static ntfs_index_context *open_reparse_index(ntfs_volume *vol)
 	ntfs_inode *dir_ni;
 	ntfs_index_context *xr;
 
-		/* do not use path_name_to inode - could reopen root */
+	/* do not use path_name_to inode - could reopen root */
 	dir_ni = ntfs_inode_open(vol, FILE_Extend);
 	ni = (ntfs_inode*)NULL;
 	if (dir_ni) {
@@ -1055,7 +1055,7 @@ static ntfs_index_context *open_reparse_index(ntfs_volume *vol)
  */
 
 static int update_reparse_data(ntfs_inode *ni, ntfs_index_context *xr,
-			const char *value, size_t size)
+		const char *value, size_t size)
 {
 	int res;
 	int written;
@@ -1066,7 +1066,7 @@ static int update_reparse_data(ntfs_inode *ni, ntfs_index_context *xr,
 	res = 0;
 	na = ntfs_attr_open(ni, AT_REPARSE_POINT, AT_UNNAMED, 0);
 	if (na) {
-			/* remove the existing reparse data */
+		/* remove the existing reparse data */
 		oldsize = remove_reparse_index(na,xr,&reparse_tag);
 		if (oldsize < 0)
 			res = -1;
@@ -1076,18 +1076,18 @@ static int update_reparse_data(ntfs_inode *ni, ntfs_index_context *xr,
 			/* overwrite value if any */
 			if (!res && value) {
 				written = (int)ntfs_attr_pwrite(na,
-						 (s64)0, (s64)size, value);
+						(s64)0, (s64)size, value);
 				if (written != (s64)size) {
 					ntfs_log_error("Failed to update "
-						"reparse data\n");
+							"reparse data\n");
 					errno = EIO;
 					res = -1;
 				}
 			}
 			if (!res
-			    && set_reparse_index(ni,xr,
-				((const REPARSE_POINT*)value)->reparse_tag)
-			    && (oldsize > 0)) {
+					&& set_reparse_index(ni,xr,
+						((const REPARSE_POINT*)value)->reparse_tag)
+					&& (oldsize > 0)) {
 				/*
 				 * If cannot index, try to remove the reparse
 				 * data and log the error. There will be an
@@ -1124,10 +1124,10 @@ int ntfs_delete_reparse_index(ntfs_inode *ni)
 	res = 0;
 	na = ntfs_attr_open(ni, AT_REPARSE_POINT, AT_UNNAMED, 0);
 	if (na) {
-			/*
-			 * read the existing reparse data (the tag is enough)
-			 * and un-index it
-			 */
+		/*
+		 * read the existing reparse data (the tag is enough)
+		 * and un-index it
+		 */
 		xr = open_reparse_index(ni->vol);
 		if (xr) {
 			if (remove_reparse_index(na,xr,&reparse_tag) < 0)
@@ -1160,12 +1160,12 @@ int ntfs_get_ntfs_reparse_data(ntfs_inode *ni, char *value, size_t size)
 	if (ni) {
 		if (ni->flags & FILE_ATTR_REPARSE_POINT) {
 			reparse_attr = (REPARSE_POINT*)ntfs_attr_readall(ni,
-				AT_REPARSE_POINT,(ntfschar*)NULL, 0, &attr_size);
+					AT_REPARSE_POINT,(ntfschar*)NULL, 0, &attr_size);
 			if (reparse_attr) {
 				if (attr_size <= (s64)size) {
 					if (value)
 						memcpy(value,reparse_attr,
-							attr_size);
+								attr_size);
 					else
 						errno = EINVAL;
 				}
@@ -1186,7 +1186,7 @@ int ntfs_get_ntfs_reparse_data(ntfs_inode *ni, char *value, size_t size)
  */
 
 int ntfs_set_ntfs_reparse_data(ntfs_inode *ni,
-			const char *value, size_t size, int flags)
+		const char *value, size_t size, int flags)
 {
 	int res;
 	u8 dummy;
@@ -1194,31 +1194,31 @@ int ntfs_set_ntfs_reparse_data(ntfs_inode *ni,
 	ntfs_index_context *xr;
 
 	res = 0;
-			/*
-			 * reparse data compatibily with EA is not checked
-			 * any more, it is required by Windows 10, but may
-			 * lead to problems with earlier versions.
-			 */
+	/*
+	 * reparse data compatibily with EA is not checked
+	 * any more, it is required by Windows 10, but may
+	 * lead to problems with earlier versions.
+	 */
 	if (ni && valid_reparse_data(ni, (const REPARSE_POINT*)value, size)) {
 		xr = open_reparse_index(ni->vol);
 		if (xr) {
 			if (!ntfs_attr_exist(ni,AT_REPARSE_POINT,
 						AT_UNNAMED,0)) {
 				if (!(flags & XATTR_REPLACE)) {
-			/*
-			 * no reparse data attribute : add one,
-			 * apparently, this does not feed the new value in
-			 * Note : NTFS version must be >= 3
-			 */
+					/*
+					 * no reparse data attribute : add one,
+					 * apparently, this does not feed the new value in
+					 * Note : NTFS version must be >= 3
+					 */
 					if (ni->vol->major_ver >= 3) {
 						res = ntfs_attr_add(ni,
-							AT_REPARSE_POINT,
-							AT_UNNAMED,0,&dummy,
-							(s64)0);
+								AT_REPARSE_POINT,
+								AT_UNNAMED,0,&dummy,
+								(s64)0);
 						if (!res) {
-						    ni->flags |=
-							FILE_ATTR_REPARSE_POINT;
-						    NInoFileNameSetDirty(ni);
+							ni->flags |=
+								FILE_ATTR_REPARSE_POINT;
+							NInoFileNameSetDirty(ni);
 						}
 						NInoSetDirty(ni);
 					} else {
@@ -1236,7 +1236,7 @@ int ntfs_set_ntfs_reparse_data(ntfs_inode *ni,
 				}
 			}
 			if (!res) {
-					/* update value and index */
+				/* update value and index */
 				res = update_reparse_data(ni,xr,value,size);
 			}
 			xrni = xr->ni;
@@ -1275,34 +1275,34 @@ int ntfs_remove_ntfs_reparse_data(ntfs_inode *ni)
 		 * open and delete the reparse data
 		 */
 		na = ntfs_attr_open(ni, AT_REPARSE_POINT,
-			AT_UNNAMED,0);
+				AT_UNNAMED,0);
 		if (na) {
 			/* first remove index (reparse data needed) */
 			xr = open_reparse_index(ni->vol);
 			if (xr) {
 				if (remove_reparse_index(na,xr,
-						&reparse_tag) < 0) {
+							&reparse_tag) < 0) {
 					res = -1;
 				} else {
 					/* now remove attribute */
 					res = ntfs_attr_rm(na);
 					if (!res) {
 						ni->flags &=
-						    ~FILE_ATTR_REPARSE_POINT;
+							~FILE_ATTR_REPARSE_POINT;
 						NInoFileNameSetDirty(ni);
 					} else {
-					/*
-					 * If we could not remove the
-					 * attribute, try to restore the
-					 * index and log the error. There
-					 * will be an inconsistency if
-					 * the reindexing fails.
-					 */
+						/*
+						 * If we could not remove the
+						 * attribute, try to restore the
+						 * index and log the error. There
+						 * will be an inconsistency if
+						 * the reindexing fails.
+						 */
 						set_reparse_index(ni, xr,
-							reparse_tag);
+								reparse_tag);
 						ntfs_log_error(
-						"Failed to remove reparse data."
-						" Possible corruption.\n");
+								"Failed to remove reparse data."
+								" Possible corruption.\n");
 					}
 				}
 				xrni = xr->ni;
@@ -1313,7 +1313,7 @@ int ntfs_remove_ntfs_reparse_data(ntfs_inode *ni)
 			}
 			olderrno = errno;
 			ntfs_attr_close(na);
-					/* avoid errno pollution */
+			/* avoid errno pollution */
 			if (errno == ENOENT)
 				errno = olderrno;
 		} else {
@@ -1333,7 +1333,7 @@ int ntfs_remove_ntfs_reparse_data(ntfs_inode *ni)
  */
 
 int ntfs_reparse_set_wsl_symlink(ntfs_inode *ni,
-			const ntfschar *target, int target_len)
+		const ntfschar *target, int target_len)
 {
 	int res;
 	int len;
@@ -1350,7 +1350,7 @@ int ntfs_reparse_set_wsl_symlink(ntfs_inode *ni,
 		reparse = (REPARSE_POINT*)malloc(reparse_len);
 		if (reparse) {
 			data = (struct WSL_LINK_REPARSE_DATA*)
-					reparse->reparse_data;
+				reparse->reparse_data;
 			reparse->reparse_tag = IO_REPARSE_TAG_LX_SYMLINK;
 			reparse->reparse_data_length
 				= cpu_to_le16(sizeof(data->type) + len);
@@ -1358,7 +1358,7 @@ int ntfs_reparse_set_wsl_symlink(ntfs_inode *ni,
 			data->type = const_cpu_to_le32(2);
 			memcpy(data->link, utarget, len);
 			res = ntfs_set_ntfs_reparse_data(ni,
-				(char*)reparse, reparse_len, 0);
+					(char*)reparse, reparse_len, 0);
 			free(reparse);
 		}
 	}
@@ -1382,22 +1382,22 @@ int ntfs_reparse_set_wsl_not_symlink(ntfs_inode *ni, mode_t mode)
 	res = -1;
 	len = 0;
 	switch (mode) {
-	case S_IFSOCK :
-		reparse_tag = IO_REPARSE_TAG_AF_UNIX;
-		break;
-	case S_IFIFO :
-		reparse_tag = IO_REPARSE_TAG_LX_FIFO;
-		break;
-	case S_IFCHR :
-		reparse_tag = IO_REPARSE_TAG_LX_CHR;
-		break;
-	case S_IFBLK :
-		reparse_tag = IO_REPARSE_TAG_LX_BLK;
-		break;
-	default :
-		len = -1;
-		errno = EOPNOTSUPP;
-		break;
+		case S_IFSOCK :
+			reparse_tag = IO_REPARSE_TAG_AF_UNIX;
+			break;
+		case S_IFIFO :
+			reparse_tag = IO_REPARSE_TAG_LX_FIFO;
+			break;
+		case S_IFCHR :
+			reparse_tag = IO_REPARSE_TAG_LX_CHR;
+			break;
+		case S_IFBLK :
+			reparse_tag = IO_REPARSE_TAG_LX_BLK;
+			break;
+		default :
+			len = -1;
+			errno = EOPNOTSUPP;
+			break;
 	}
 	if (len >= 0) {
 		reparse_len = sizeof(REPARSE_POINT) + len;
@@ -1407,7 +1407,7 @@ int ntfs_reparse_set_wsl_not_symlink(ntfs_inode *ni, mode_t mode)
 			reparse->reparse_data_length = cpu_to_le16(len);
 			reparse->reserved = const_cpu_to_le16(0);
 			res = ntfs_set_ntfs_reparse_data(ni,
-				(char*)reparse, reparse_len, 0);
+					(char*)reparse, reparse_len, 0);
 			free(reparse);
 		}
 	}
@@ -1431,9 +1431,9 @@ REPARSE_POINT *ntfs_get_reparse_point(ntfs_inode *ni)
 	reparse_attr = (REPARSE_POINT*)NULL;
 	if (ni) {
 		reparse_attr = (REPARSE_POINT*)ntfs_attr_readall(ni,
-			AT_REPARSE_POINT,(ntfschar*)NULL, 0, &attr_size);
+				AT_REPARSE_POINT,(ntfschar*)NULL, 0, &attr_size);
 		if (reparse_attr
-		    && !valid_reparse_data(ni, reparse_attr, attr_size)) {
+				&& !valid_reparse_data(ni, reparse_attr, attr_size)) {
 			free(reparse_attr);
 			reparse_attr = (REPARSE_POINT*)NULL;
 			errno = EINVAL;

--- a/libntfs/runlist.c
+++ b/libntfs/runlist.c
@@ -79,7 +79,7 @@ static void ntfs_rl_mm(runlist_element *base, int dst, int src, int size)
  * Returns:
  */
 static void ntfs_rl_mc(runlist_element *dstbase, int dst,
-		       runlist_element *srcbase, int src, int size)
+		runlist_element *srcbase, int src, int size)
 {
 	if (size > 0)
 		memcpy(dstbase + dst, srcbase + src, size * sizeof(*dstbase));
@@ -114,7 +114,7 @@ static runlist_element *ntfs_rl_malloc(int size)
  * On error, return NULL with errno set to the error code.
  */
 static runlist_element *ntfs_rl_realloc(runlist_element *rl, int old_size,
-					int new_size)
+		int new_size)
 {
 	old_size = (old_size * sizeof(runlist_element) + 0xfff) & ~0xfff;
 	new_size = (new_size * sizeof(runlist_element) + 0xfff) & ~0xfff;
@@ -133,7 +133,7 @@ static runlist_element *ntfs_rl_realloc(runlist_element *rl, int old_size,
  */
 
 runlist_element *ntfs_rl_extend(ntfs_attr *na, runlist_element *rl,
-			int more_entries)
+		int more_entries)
 {
 	runlist_element *newrl;
 	int last;
@@ -187,7 +187,7 @@ static BOOL ntfs_rl_are_mergeable(runlist_element *dst, runlist_element *src)
 		return FALSE;
 	/* If both runs are non-sparse and contiguous, we can merge them. */
 	if ((dst->lcn >= 0) && (src->lcn >= 0) &&
-		((dst->lcn + dst->length) == src->lcn))
+			((dst->lcn + dst->length) == src->lcn))
 		return TRUE;
 	/* If we are merging two holes, we can merge them. */
 	if ((dst->lcn == LCN_HOLE) && (src->lcn == LCN_HOLE))
@@ -231,7 +231,7 @@ static void __ntfs_rl_merge(runlist_element *dst, runlist_element *src)
  * left unmodified.
  */
 static runlist_element *ntfs_rl_append(runlist_element *dst, int dsize,
-				       runlist_element *src, int ssize, int loc)
+		runlist_element *src, int ssize, int loc)
 {
 	BOOL right = FALSE;	/* Right end of @src needs merging */
 	int marker;		/* End of the inserted runs */
@@ -298,7 +298,7 @@ static runlist_element *ntfs_rl_append(runlist_element *dst, int dsize,
  * left unmodified.
  */
 static runlist_element *ntfs_rl_insert(runlist_element *dst, int dsize,
-				       runlist_element *src, int ssize, int loc)
+		runlist_element *src, int ssize, int loc)
 {
 	BOOL left = FALSE;	/* Left end of @src needs merging */
 	BOOL disc = FALSE;	/* Discontinuity between @dst and @src */
@@ -394,8 +394,8 @@ static runlist_element *ntfs_rl_insert(runlist_element *dst, int dsize,
  * left unmodified.
  */
 runlist_element *ntfs_rl_replace(runlist_element *dst, int dsize,
-					runlist_element *src, int ssize,
-					int loc)
+		runlist_element *src, int ssize,
+		int loc)
 {
 	signed delta;
 	BOOL left  = FALSE;	/* Left end of @src needs merging */
@@ -482,7 +482,7 @@ runlist_element *ntfs_rl_replace(runlist_element *dst, int dsize,
  * left unmodified.
  */
 static runlist_element *ntfs_rl_split(runlist_element *dst, int dsize,
-				      runlist_element *src, int ssize, int loc)
+		runlist_element *src, int ssize, int loc)
 {
 	if (!dst || !src) {
 		ntfs_log_debug("Eeek. ntfs_rl_split() invoked with NULL pointer!\n");
@@ -516,14 +516,14 @@ static runlist_element *ntfs_rl_split(runlist_element *dst, int dsize,
  * ntfs_runlists_merge_i - see ntfs_runlists_merge
  */
 static runlist_element *ntfs_runlists_merge_i(runlist_element *drl,
-					      runlist_element *srl)
+		runlist_element *srl)
 {
 	int di, si;		/* Current index into @[ds]rl. */
 	int sstart;		/* First index with lcn > LCN_RL_NOT_MAPPED. */
 	int dins;		/* Index into @drl at which to insert @srl. */
 	int dend, send;		/* Last index into @[ds]rl. */
 	int dfinal, sfinal;	/* The last index into @[ds]rl with
-				   lcn >= LCN_HOLE. */
+						   lcn >= LCN_HOLE. */
 	int marker = 0;
 	VCN marker_vcn = 0;
 
@@ -608,104 +608,104 @@ static runlist_element *ntfs_runlists_merge_i(runlist_element *drl,
 		;
 
 	{
-	BOOL start;
-	BOOL finish;
-	int ds = dend + 1;		/* Number of elements in drl & srl */
-	int ss = sfinal - sstart + 1;
+		BOOL start;
+		BOOL finish;
+		int ds = dend + 1;		/* Number of elements in drl & srl */
+		int ss = sfinal - sstart + 1;
 
-	start  = ((drl[dins].lcn <  LCN_RL_NOT_MAPPED) ||    /* End of file   */
-		  (drl[dins].vcn == srl[sstart].vcn));	     /* Start of hole */
-	finish = ((drl[dins].lcn >= LCN_RL_NOT_MAPPED) &&    /* End of file   */
-		 ((drl[dins].vcn + drl[dins].length) <=      /* End of hole   */
-		  (srl[send - 1].vcn + srl[send - 1].length)));
+		start  = ((drl[dins].lcn <  LCN_RL_NOT_MAPPED) ||    /* End of file   */
+				(drl[dins].vcn == srl[sstart].vcn));	     /* Start of hole */
+		finish = ((drl[dins].lcn >= LCN_RL_NOT_MAPPED) &&    /* End of file   */
+				((drl[dins].vcn + drl[dins].length) <=      /* End of hole   */
+				 (srl[send - 1].vcn + srl[send - 1].length)));
 
-	/* Or we'll lose an end marker */
-	if (finish && !drl[dins].length)
-		ss++;
-	if (marker && (drl[dins].vcn + drl[dins].length > srl[send - 1].vcn))
-		finish = FALSE;
+		/* Or we'll lose an end marker */
+		if (finish && !drl[dins].length)
+			ss++;
+		if (marker && (drl[dins].vcn + drl[dins].length > srl[send - 1].vcn))
+			finish = FALSE;
 
-	ntfs_log_debug("dfinal = %i, dend = %i\n", dfinal, dend);
-	ntfs_log_debug("sstart = %i, sfinal = %i, send = %i\n", sstart, sfinal, send);
-	ntfs_log_debug("start = %i, finish = %i\n", start, finish);
-	ntfs_log_debug("ds = %i, ss = %i, dins = %i\n", ds, ss, dins);
+		ntfs_log_debug("dfinal = %i, dend = %i\n", dfinal, dend);
+		ntfs_log_debug("sstart = %i, sfinal = %i, send = %i\n", sstart, sfinal, send);
+		ntfs_log_debug("start = %i, finish = %i\n", start, finish);
+		ntfs_log_debug("ds = %i, ss = %i, dins = %i\n", ds, ss, dins);
 
-	if (start) {
-		if (finish)
-			drl = ntfs_rl_replace(drl, ds, srl + sstart, ss, dins);
-		else
-			drl = ntfs_rl_insert(drl, ds, srl + sstart, ss, dins);
-	} else {
-		if (finish)
-			drl = ntfs_rl_append(drl, ds, srl + sstart, ss, dins);
-		else
-			drl = ntfs_rl_split(drl, ds, srl + sstart, ss, dins);
-	}
-	if (!drl) {
-		ntfs_log_perror("Merge failed");
-		return drl;
-	}
-	free(srl);
-	if (marker) {
-		ntfs_log_debug("Triggering marker code.\n");
-		for (ds = dend; drl[ds].length; ds++)
-			;
-		/* We only need to care if @srl ended after @drl. */
-		if (drl[ds].vcn <= marker_vcn) {
-			int slots = 0;
+		if (start) {
+			if (finish)
+				drl = ntfs_rl_replace(drl, ds, srl + sstart, ss, dins);
+			else
+				drl = ntfs_rl_insert(drl, ds, srl + sstart, ss, dins);
+		} else {
+			if (finish)
+				drl = ntfs_rl_append(drl, ds, srl + sstart, ss, dins);
+			else
+				drl = ntfs_rl_split(drl, ds, srl + sstart, ss, dins);
+		}
+		if (!drl) {
+			ntfs_log_perror("Merge failed");
+			return drl;
+		}
+		free(srl);
+		if (marker) {
+			ntfs_log_debug("Triggering marker code.\n");
+			for (ds = dend; drl[ds].length; ds++)
+				;
+			/* We only need to care if @srl ended after @drl. */
+			if (drl[ds].vcn <= marker_vcn) {
+				int slots = 0;
 
-			if (drl[ds].vcn == marker_vcn) {
-				ntfs_log_debug("Old marker = %lli, replacing with "
-						"LCN_ENOENT.\n",
-						(long long)drl[ds].lcn);
-				drl[ds].lcn = (LCN)LCN_ENOENT;
-				goto finished;
-			}
-			/*
-			 * We need to create an unmapped runlist element in
-			 * @drl or extend an existing one before adding the
-			 * ENOENT terminator.
-			 */
-			if (drl[ds].lcn == (LCN)LCN_ENOENT) {
-				ds--;
-				slots = 1;
-			}
-			if (drl[ds].lcn != (LCN)LCN_RL_NOT_MAPPED) {
-				/* Add an unmapped runlist element. */
+				if (drl[ds].vcn == marker_vcn) {
+					ntfs_log_debug("Old marker = %lli, replacing with "
+							"LCN_ENOENT.\n",
+							(long long)drl[ds].lcn);
+					drl[ds].lcn = (LCN)LCN_ENOENT;
+					goto finished;
+				}
+				/*
+				 * We need to create an unmapped runlist element in
+				 * @drl or extend an existing one before adding the
+				 * ENOENT terminator.
+				 */
+				if (drl[ds].lcn == (LCN)LCN_ENOENT) {
+					ds--;
+					slots = 1;
+				}
+				if (drl[ds].lcn != (LCN)LCN_RL_NOT_MAPPED) {
+					/* Add an unmapped runlist element. */
+					if (!slots) {
+						/* FIXME/TODO: We need to have the
+						 * extra memory already! (AIA)
+						 */
+						drl = ntfs_rl_realloc(drl, ds, ds + 2);
+						if (!drl)
+							goto critical_error;
+						slots = 2;
+					}
+					ds++;
+					/* Need to set vcn if it isn't set already. */
+					if (slots != 1)
+						drl[ds].vcn = drl[ds - 1].vcn +
+							drl[ds - 1].length;
+					drl[ds].lcn = (LCN)LCN_RL_NOT_MAPPED;
+					/* We now used up a slot. */
+					slots--;
+				}
+				drl[ds].length = marker_vcn - drl[ds].vcn;
+				/* Finally add the ENOENT terminator. */
+				ds++;
 				if (!slots) {
-					/* FIXME/TODO: We need to have the
-					 * extra memory already! (AIA)
+					/* FIXME/TODO: We need to have the extra
+					 * memory already! (AIA)
 					 */
-					drl = ntfs_rl_realloc(drl, ds, ds + 2);
+					drl = ntfs_rl_realloc(drl, ds, ds + 1);
 					if (!drl)
 						goto critical_error;
-					slots = 2;
 				}
-				ds++;
-				/* Need to set vcn if it isn't set already. */
-				if (slots != 1)
-					drl[ds].vcn = drl[ds - 1].vcn +
-							drl[ds - 1].length;
-				drl[ds].lcn = (LCN)LCN_RL_NOT_MAPPED;
-				/* We now used up a slot. */
-				slots--;
+				drl[ds].vcn = marker_vcn;
+				drl[ds].lcn = (LCN)LCN_ENOENT;
+				drl[ds].length = (s64)0;
 			}
-			drl[ds].length = marker_vcn - drl[ds].vcn;
-			/* Finally add the ENOENT terminator. */
-			ds++;
-			if (!slots) {
-				/* FIXME/TODO: We need to have the extra
-				 * memory already! (AIA)
-				 */
-				drl = ntfs_rl_realloc(drl, ds, ds + 1);
-				if (!drl)
-					goto critical_error;
-			}
-			drl[ds].vcn = marker_vcn;
-			drl[ds].lcn = (LCN)LCN_ENOENT;
-			drl[ds].length = (s64)0;
 		}
-	}
 	}
 
 finished:
@@ -812,7 +812,7 @@ runlist_element *ntfs_mapping_pairs_decompress_i(const ntfs_volume *vol,
 	const u8 *attr_end;	/* End of attribute. */
 	int err, rlsize;	/* Size of runlist buffer. */
 	u16 rlpos;		/* Current runlist position in units of
-				   runlist_elements. */
+					   runlist_elements. */
 	u8 b;			/* Current byte offset in buf. */
 
 	ntfs_log_trace("Entering for attr 0x%x.\n",
@@ -999,7 +999,7 @@ mpa_err:
 		VCN num_clusters;
 
 		num_clusters = ((sle64_to_cpu(attr->allocated_size) +
-				vol->cluster_size - 1) >>
+					vol->cluster_size - 1) >>
 				vol->cluster_size_bits);
 
 		if (num_clusters > vcn) {
@@ -1008,7 +1008,7 @@ mpa_err:
 			 * must be more extents.
 			 */
 			ntfs_log_debug("More extents to follow; vcn = 0x%llx, "
-				       "num_clusters = 0x%llx\n",
+					"num_clusters = 0x%llx\n",
 					(long long)vcn,
 					(long long)num_clusters);
 			rl[rlpos].vcn = vcn;
@@ -1021,7 +1021,7 @@ mpa_err:
 			 * the runlist is corrupt.
 			 */
 			ntfs_log_error("Corrupt attribute. vcn = 0x%llx, "
-				       "num_clusters = 0x%llx\n",
+					"num_clusters = 0x%llx\n",
 					(long long)vcn,
 					(long long)num_clusters);
 			goto mpa_err;
@@ -1283,7 +1283,7 @@ s64 ntfs_rl_pread(const ntfs_volume *vol, const runlist_element *rl,
 		return count;
 	/* Seek in @rl to the run containing @pos. */
 	for (ofs = 0; rl->length && (ofs + (rl->length <<
-			vol->cluster_size_bits) <= pos); rl++)
+					vol->cluster_size_bits) <= pos); rl++)
 		ofs += (rl->length << vol->cluster_size_bits);
 	/* Offset in the run at which to begin reading. */
 	ofs = pos - ofs;
@@ -1295,7 +1295,7 @@ s64 ntfs_rl_pread(const ntfs_volume *vol, const runlist_element *rl,
 				goto rl_err_out;
 			/* It is a hole. Just fill buffer @b with zeroes. */
 			to_read = min(count, (rl->length <<
-					vol->cluster_size_bits) - ofs);
+						vol->cluster_size_bits) - ofs);
 			memset(b, 0, to_read);
 			/* Update counters and proceed with next run. */
 			total += to_read;
@@ -1308,7 +1308,7 @@ s64 ntfs_rl_pread(const ntfs_volume *vol, const runlist_element *rl,
 				ofs);
 retry:
 		bytes_read = ntfs_pread(vol->dev, (rl->lcn <<
-				vol->cluster_size_bits) + ofs, to_read, b);
+					vol->cluster_size_bits) + ofs, to_read, b);
 		/* If everything ok, update progress counters and continue. */
 		if (bytes_read > 0) {
 			total += bytes_read;
@@ -1372,7 +1372,7 @@ s64 ntfs_rl_pwrite(const ntfs_volume *vol, const runlist_element *rl,
 		goto out;
 	/* Seek in @rl to the run containing @pos. */
 	while (rl->length && (ofs + (rl->length <<
-			vol->cluster_size_bits) <= pos)) {
+					vol->cluster_size_bits) <= pos)) {
 		ofs += (rl->length << vol->cluster_size_bits);
 		rl++;
 	}
@@ -1387,7 +1387,7 @@ s64 ntfs_rl_pwrite(const ntfs_volume *vol, const runlist_element *rl,
 				goto rl_err_out;
 
 			to_write = min(count, (rl->length <<
-					       vol->cluster_size_bits) - ofs);
+						vol->cluster_size_bits) - ofs);
 
 			total += to_write;
 			count -= to_write;
@@ -1400,7 +1400,7 @@ s64 ntfs_rl_pwrite(const ntfs_volume *vol, const runlist_element *rl,
 retry:
 		if (!NVolReadOnly(vol))
 			written = ntfs_pwrite(vol->dev, (rl->lcn <<
-					vol->cluster_size_bits) + ofs,
+						vol->cluster_size_bits) + ofs,
 					to_write, b);
 		else
 			written = to_write;
@@ -1806,7 +1806,7 @@ int ntfs_rl_truncate(runlist **arl, const VCN start_vcn)
 			ntfs_log_perror("rl_truncate error: arl: %p", arl);
 		else
 			ntfs_log_perror("rl_truncate error:"
-				" arl: %p *arl: %p", arl, *arl);
+					" arl: %p *arl: %p", arl, *arl);
 		return -1;
 	}
 
@@ -1855,7 +1855,7 @@ int ntfs_rl_truncate(runlist **arl, const VCN start_vcn)
 	 * a multiple of 4096. The code caused crashes and corruptions.
 	 */
 /*
-	 if (!is_end) {
+	if (!is_end) {
 		size_t new_size = (rl - *arl + 1) * sizeof(runlist_element);
 		rl = realloc(*arl, new_size);
 		if (rl)
@@ -1929,8 +1929,8 @@ s64 ntfs_rl_get_compressed_size(ntfs_volume *vol, runlist *rl)
 }
 
 runlist_element *ntfs_rl_punch_hole(runlist_element *dst_rl, int dst_cnt,
-				    VCN start_vcn, s64 len,
-				    runlist_element **punch_rl)
+		VCN start_vcn, s64 len,
+		runlist_element **punch_rl)
 {
 	runlist_element *s_rl, *e_rl, *new_rl, *dst_3rd_rl, hole_rl[1];
 	VCN end_vcn;
@@ -2048,12 +2048,12 @@ runlist_element *ntfs_rl_punch_hole(runlist_element *dst_rl, int dst_cnt,
 		merge_cnt = 1;
 		/* Merge left and right */
 		if (new_1st_cnt + 1 < new_cnt &&
-		    new_rl[new_1st_cnt + 1].lcn == LCN_HOLE) {
+				new_rl[new_1st_cnt + 1].lcn == LCN_HOLE) {
 			s_rl->length += s_rl[2].length;
 			merge_cnt++;
 		}
 	} else if (new_1st_cnt + 1 < new_cnt &&
-		   new_rl[new_1st_cnt + 1].lcn == LCN_HOLE) {
+			new_rl[new_1st_cnt + 1].lcn == LCN_HOLE) {
 		/* Merge left and hole */
 		s_rl = &new_rl[new_1st_cnt];
 		s_rl->length += s_rl[1].length;
@@ -2066,7 +2066,7 @@ runlist_element *ntfs_rl_punch_hole(runlist_element *dst_rl, int dst_cnt,
 		d_rl = s_rl + 1;
 		src_rl = s_rl + 1 + merge_cnt;
 		ntfs_rl_mm(new_rl, (int)(d_rl - new_rl), (int)(src_rl - new_rl),
-			   (int)(&new_rl[new_cnt - 1] - src_rl) + 1);
+				(int)(&new_rl[new_cnt - 1] - src_rl) + 1);
 	}
 
 	if (punch_rl) {
@@ -2147,9 +2147,7 @@ runlist *ntfs_copy_rl_clusters(ntfs_volume *vol, runlist *new_rl, int new_cnt,
 	(R)->vcn = V;				\
 	(R)->lcn = L;				\
 	(R)->length = S;
-/*
-}
-*/
+
 /**
  * test_rl_dump_runlist - Runlist test: Display the contents of a runlist
  * @rl:
@@ -2190,10 +2188,10 @@ static void test_rl_dump_runlist(const runlist_element *rl)
 			if (ind > -LCN_ENOENT - 1)
 				ind = 3;
 			printf("%8lld %8s %8lld\n",
-				rl->vcn, lcn_str[ind], rl->length);
+					rl->vcn, lcn_str[ind], rl->length);
 		} else
 			printf("%8lld %8lld %8lld\n",
-				rl->vcn, rl->lcn, rl->length);
+					rl->vcn, rl->lcn, rl->length);
 		if (!rl->length)
 			break;
 	}
@@ -2342,7 +2340,7 @@ static void test_rl_pure_test(int test, BOOL contig, BOOL multi, int vcn, int le
  */
 static void test_rl_pure(char *contig, char *multi)
 {
-		/* VCN,  LCN, len */
+	/* VCN,  LCN, len */
 	static runlist_element file1[] = {
 		{    0,   -1, 100 },	/* HOLE */
 		{  100, 1100, 100 },	/* DATA */

--- a/libntfs/security.c
+++ b/libntfs/security.c
@@ -74,14 +74,14 @@
 #define STUFFSZ 0x4000 /* unitary stuffing size for $SDS */
 #define FIRST_SECURITY_ID 0x100 /* Lowest security id */
 
-	/* Mask for attributes which can be forced */
+/* Mask for attributes which can be forced */
 #define FILE_ATTR_SETTABLE ( FILE_ATTR_READONLY		\
-				| FILE_ATTR_HIDDEN	\
-				| FILE_ATTR_SYSTEM	\
-				| FILE_ATTR_ARCHIVE	\
-				| FILE_ATTR_TEMPORARY	\
-				| FILE_ATTR_OFFLINE	\
-				| FILE_ATTR_NOT_CONTENT_INDEXED )
+		| FILE_ATTR_HIDDEN	\
+		| FILE_ATTR_SYSTEM	\
+		| FILE_ATTR_ARCHIVE	\
+		| FILE_ATTR_TEMPORARY	\
+		| FILE_ATTR_OFFLINE	\
+		| FILE_ATTR_NOT_CONTENT_INDEXED )
 
 struct SII {		/* this is an image of an $SII index entry */
 	le16 offs;
@@ -119,22 +119,22 @@ struct SDH {		/* this is an image of an $SDH index entry */
 	le32 dataoffsh;
 	le32 datasize;
 	le32 fill3;
-	} ;
+} ;
 
 /*
  *	A few useful constants
  */
 
 static ntfschar sii_stream[] = { const_cpu_to_le16('$'),
-				 const_cpu_to_le16('S'),
-				 const_cpu_to_le16('I'),
-				 const_cpu_to_le16('I'),
-				 const_cpu_to_le16(0) };
+	const_cpu_to_le16('S'),
+	const_cpu_to_le16('I'),
+	const_cpu_to_le16('I'),
+	const_cpu_to_le16(0) };
 static ntfschar sdh_stream[] = { const_cpu_to_le16('$'),
-				 const_cpu_to_le16('S'),
-				 const_cpu_to_le16('D'),
-				 const_cpu_to_le16('H'),
-				 const_cpu_to_le16(0) };
+	const_cpu_to_le16('S'),
+	const_cpu_to_le16('D'),
+	const_cpu_to_le16('H'),
+	const_cpu_to_le16(0) };
 
 /*
  *		null SID (S-1-0-0)
@@ -147,7 +147,7 @@ extern const SID *nullsid;
  */
 
 static const GUID __zero_guid = { const_cpu_to_le32(0), const_cpu_to_le16(0),
-		const_cpu_to_le16(0), { 0, 0, 0, 0, 0, 0, 0, 0 } };
+	const_cpu_to_le16(0), { 0, 0, 0, 0, 0, 0, 0, 0 } };
 static const GUID *const zero_guid = &__zero_guid;
 
 /**
@@ -449,7 +449,7 @@ static int entersecurity_stuff(ntfs_volume *vol, off_t offs)
 		memset(stuff, 0, STUFFSZ);
 		do {
 			written = ntfs_attr_data_write(vol->secure_ni,
-				STREAM_SDS, 4, stuff, STUFFSZ, offs);
+					STREAM_SDS, 4, stuff, STUFFSZ, offs);
 			if (written == STUFFSZ) {
 				total += STUFFSZ;
 				offs += STUFFSZ;
@@ -476,8 +476,8 @@ static int entersecurity_stuff(ntfs_volume *vol, off_t offs)
  */
 
 static int entersecurity_data(ntfs_volume *vol,
-			const SECURITY_DESCRIPTOR_RELATIVE *attr, s64 attrsz,
-			le32 hash, le32 keyid, off_t offs, int gap)
+		const SECURITY_DESCRIPTOR_RELATIVE *attr, s64 attrsz,
+		le32 hash, le32 keyid, off_t offs, int gap)
 {
 	int res;
 	int written1;
@@ -490,13 +490,13 @@ static int entersecurity_data(ntfs_volume *vol,
 	fullsz = attrsz + gap + sizeof(SECURITY_DESCRIPTOR_HEADER);
 	fullattr = (char*)ntfs_malloc(fullsz);
 	if (fullattr) {
-			/*
-			 * Clear the gap from previous descriptor
-			 * this could be useful for appending the second
-			 * copy to the end of file. When creating a new
-			 * 256K block, the gap is cleared while writing
-			 * the first copy
-			 */
+		/*
+		 * Clear the gap from previous descriptor
+		 * this could be useful for appending the second
+		 * copy to the end of file. When creating a new
+		 * 256K block, the gap is cleared while writing
+		 * the first copy
+		 */
 		if (gap)
 			memset(fullattr,0,gap);
 		memcpy(&fullattr[gap + sizeof(SECURITY_DESCRIPTOR_HEADER)],
@@ -507,13 +507,13 @@ static int entersecurity_data(ntfs_volume *vol,
 		phsds->offset = cpu_to_le64(offs);
 		phsds->length = cpu_to_le32(fullsz - gap);
 		written1 = ntfs_attr_data_write(vol->secure_ni,
-			STREAM_SDS, 4, fullattr, fullsz,
-			offs - gap);
+				STREAM_SDS, 4, fullattr, fullsz,
+				offs - gap);
 		written2 = ntfs_attr_data_write(vol->secure_ni,
-			STREAM_SDS, 4, fullattr, fullsz,
-			offs - gap + ALIGN_SDS_BLOCK);
+				STREAM_SDS, 4, fullattr, fullsz,
+				offs - gap + ALIGN_SDS_BLOCK);
 		if ((written1 == fullsz)
-		     && (written2 == written1)) {
+				&& (written2 == written1)) {
 			/*
 			 * Make sure the data size for $SDS marks the end
 			 * of the last security attribute. Windows uses
@@ -523,7 +523,7 @@ static int entersecurity_data(ntfs_volume *vol,
 			 * adjusting the size.
 			 */
 			res = ntfs_attr_shrink_size(vol->secure_ni,STREAM_SDS,
-				4, offs - gap + ALIGN_SDS_BLOCK + fullsz);
+					4, offs - gap + ALIGN_SDS_BLOCK + fullsz);
 		} else
 			errno = ENOSPC;
 		free(fullattr);
@@ -541,7 +541,7 @@ static int entersecurity_data(ntfs_volume *vol,
  */
 
 static int entersecurity_indexes(ntfs_volume *vol, s64 attrsz,
-			le32 hash, le32 keyid, off_t offs)
+		le32 hash, le32 keyid, off_t offs)
 {
 	union {
 		struct {
@@ -557,7 +557,7 @@ static int entersecurity_indexes(ntfs_volume *vol, s64 attrsz,
 	struct SDH newsdh;
 
 	res = -1;
-				/* enter a new $SII record */
+	/* enter a new $SII record */
 
 	xsii = vol->secure_xsii;
 	ntfs_index_ctx_reinit(xsii);
@@ -575,7 +575,7 @@ static int entersecurity_indexes(ntfs_volume *vol, s64 attrsz,
 	newsii.dataoffsh = realign.parts.dataoffsh;
 	newsii.dataoffsl = realign.parts.dataoffsl;
 	newsii.datasize = cpu_to_le32(attrsz
-			 + sizeof(SECURITY_DESCRIPTOR_HEADER));
+			+ sizeof(SECURITY_DESCRIPTOR_HEADER));
 	if (!ntfs_ie_add(xsii,(INDEX_ENTRY*)&newsii)) {
 
 		/* enter a new $SDH record */
@@ -584,7 +584,7 @@ static int entersecurity_indexes(ntfs_volume *vol, s64 attrsz,
 		ntfs_index_ctx_reinit(xsdh);
 		newsdh.offs = const_cpu_to_le16(24);
 		newsdh.size = const_cpu_to_le16(
-			sizeof(SECURITY_DESCRIPTOR_HEADER));
+				sizeof(SECURITY_DESCRIPTOR_HEADER));
 		newsdh.fill1 = const_cpu_to_le32(0);
 		newsdh.indexsz = const_cpu_to_le16(
 				sizeof(struct SDH));
@@ -599,9 +599,9 @@ static int entersecurity_indexes(ntfs_volume *vol, s64 attrsz,
 		newsdh.dataoffsh = realign.parts.dataoffsh;
 		newsdh.dataoffsl = realign.parts.dataoffsl;
 		newsdh.datasize = cpu_to_le32(attrsz
-			 + sizeof(SECURITY_DESCRIPTOR_HEADER));
-                           /* special filler value, Windows generally */
-                           /* fills with 0x00490049, sometimes with zero */
+				+ sizeof(SECURITY_DESCRIPTOR_HEADER));
+		/* special filler value, Windows generally */
+		/* fills with 0x00490049, sometimes with zero */
 		newsdh.fill3 = const_cpu_to_le32(0x00490049);
 		if (!ntfs_ie_add(xsdh,(INDEX_ENTRY*)&newsdh))
 			res = 0;
@@ -619,8 +619,8 @@ static int entersecurity_indexes(ntfs_volume *vol, s64 attrsz,
  */
 
 static le32 entersecurityattr(ntfs_volume *vol,
-			const SECURITY_DESCRIPTOR_RELATIVE *attr, s64 attrsz,
-			le32 hash)
+		const SECURITY_DESCRIPTOR_RELATIVE *attr, s64 attrsz,
+		le32 hash)
 {
 	union {
 		struct {
@@ -657,12 +657,12 @@ static le32 entersecurityattr(ntfs_volume *vol,
 	keyid = const_cpu_to_le32(-1);
 	olderrno = errno;
 	found = !ntfs_index_lookup((char*)&keyid,
-			       sizeof(SII_INDEX_KEY), xsii);
+			sizeof(SII_INDEX_KEY), xsii);
 	if (!found && (errno != ENOENT)) {
 		ntfs_log_perror("Inconsistency in index $SII");
 		psii = (struct SII*)NULL;
 	} else {
-			/* restore errno to avoid misinterpretation */
+		/* restore errno to avoid misinterpretation */
 		errno = olderrno;
 		entry = xsii->entry;
 		psii = (struct SII*)xsii->entry;
@@ -697,13 +697,13 @@ static le32 entersecurityattr(ntfs_volume *vol,
 			next = ntfs_index_next(entry,xsii);
 			if (next) {
 				psii = (struct SII*)next;
-					/* save last key and */
-					/* available position */
+				/* save last key and */
+				/* available position */
 				keyid = psii->keysecurid;
 				realign.parts.dataoffsh
-						 = psii->dataoffsh;
+					= psii->dataoffsh;
 				realign.parts.dataoffsl
-						 = psii->dataoffsl;
+					= psii->dataoffsl;
 				offs = le64_to_cpu(realign.all);
 				size = le32_to_cpu(psii->datasize);
 			}
@@ -712,25 +712,25 @@ static le32 entersecurityattr(ntfs_volume *vol,
 				/* search failed, retry from smallest key */
 				ntfs_index_ctx_reinit(xsii);
 				found = !ntfs_index_lookup((char*)&keyid,
-					       sizeof(SII_INDEX_KEY), xsii);
+						sizeof(SII_INDEX_KEY), xsii);
 				if (!found && (errno != ENOENT)) {
 					ntfs_log_perror("Index $SII is broken");
 					psii = (struct SII*)NULL;
 				} else {
-						/* restore errno */
+					/* restore errno */
 					errno = olderrno;
 					entry = xsii->entry;
 					psii = (struct SII*)entry;
 				}
 				if (psii
-				    && !(psii->flags & INDEX_ENTRY_END)) {
-						/* save first key and */
-						/* available position */
+						&& !(psii->flags & INDEX_ENTRY_END)) {
+					/* save first key and */
+					/* available position */
 					keyid = psii->keysecurid;
 					realign.parts.dataoffsh
-							 = psii->dataoffsh;
+						= psii->dataoffsh;
 					realign.parts.dataoffsl
-							 = psii->dataoffsl;
+						= psii->dataoffsl;
 					offs = le64_to_cpu(realign.all);
 					size = le32_to_cpu(psii->datasize);
 				}
@@ -748,7 +748,7 @@ static le32 entersecurityattr(ntfs_volume *vol,
 		na = ntfs_attr_open(vol->secure_ni,AT_INDEX_ROOT,sii_stream,4);
 		if (na) {
 			if ((size_t)na->data_size < (sizeof(struct SII)
-					+ sizeof(INDEX_ENTRY_HEADER))) {
+						+ sizeof(INDEX_ENTRY_HEADER))) {
 				ntfs_log_error("Creating the first security_id\n");
 				securid = const_cpu_to_le32(FIRST_SECURITY_ID);
 			}
@@ -774,10 +774,10 @@ static le32 entersecurityattr(ntfs_volume *vol,
 		gap = (-size) & (ALIGN_SDS_ENTRY - 1);
 		offs += gap + size;
 		if ((offs + attrsz + sizeof(SECURITY_DESCRIPTOR_HEADER) - 1)
-	 	   & ALIGN_SDS_BLOCK) {
+				& ALIGN_SDS_BLOCK) {
 			offs = ((offs + attrsz
-				 + sizeof(SECURITY_DESCRIPTOR_HEADER) - 1)
-			 	| (ALIGN_SDS_BLOCK - 1)) + 1;
+						+ sizeof(SECURITY_DESCRIPTOR_HEADER) - 1)
+					| (ALIGN_SDS_BLOCK - 1)) + 1;
 		}
 		if (!(offs & (ALIGN_SDS_BLOCK - 1)))
 			entersecurity_stuff(vol, offs);
@@ -794,10 +794,10 @@ static le32 entersecurityattr(ntfs_volume *vol,
 		 *    will persist with no significant consequence
 		 */
 		if (entersecurity_data(vol, attr, attrsz, hash, securid, offs, gap)
-		    || entersecurity_indexes(vol, attrsz, hash, securid, offs))
+				|| entersecurity_indexes(vol, attrsz, hash, securid, offs))
 			securid = const_cpu_to_le32(0);
 	}
-		/* inode now is dirty, synchronize it all */
+	/* inode now is dirty, synchronize it all */
 	ntfs_index_entry_mark_dirty(vol->secure_xsii);
 	ntfs_index_ctx_reinit(vol->secure_xsii);
 	ntfs_index_entry_mark_dirty(vol->secure_xsdh);
@@ -818,7 +818,7 @@ static le32 entersecurityattr(ntfs_volume *vol,
  */
 
 static le32 setsecurityattr(ntfs_volume *vol,
-			const SECURITY_DESCRIPTOR_RELATIVE *attr, s64 attrsz)
+		const SECURITY_DESCRIPTOR_RELATIVE *attr, s64 attrsz)
 {
 	struct SDH *psdh;	/* this is an image of index (le) */
 	union {
@@ -859,11 +859,11 @@ static le32 setsecurityattr(ntfs_volume *vol,
 		key.security_id = const_cpu_to_le32(0);
 		olderrno = errno;
 		found = !ntfs_index_lookup((char*)&key,
-				 sizeof(SDH_INDEX_KEY), xsdh);
+				sizeof(SDH_INDEX_KEY), xsdh);
 		if (!found && (errno != ENOENT))
 			ntfs_log_perror("Inconsistency in index $SDH");
 		else {
-				/* restore errno to avoid misinterpretation */
+			/* restore errno to avoid misinterpretation */
 			errno = olderrno;
 			entry = xsdh->entry;
 			found = FALSE;
@@ -878,13 +878,13 @@ static le32 setsecurityattr(ntfs_volume *vol,
 				psdh = (struct SDH*)entry;
 				if (psdh)
 					size = (size_t) le32_to_cpu(psdh->datasize)
-						 - sizeof(SECURITY_DESCRIPTOR_HEADER);
+						- sizeof(SECURITY_DESCRIPTOR_HEADER);
 				else size = 0;
-			   /* if hash is not the same, the key is not present */
+				/* if hash is not the same, the key is not present */
 				if (psdh && (size > 0)
-				   && (psdh->keyhash == hash)) {
-					   /* if hash is the same */
-					   /* check the whole record */
+						&& (psdh->keyhash == hash)) {
+					/* if hash is the same */
+					/* check the whole record */
 					realign.parts.dataoffsh = psdh->dataoffsh;
 					realign.parts.dataoffsl = psdh->dataoffsl;
 					offs = le64_to_cpu(realign.all)
@@ -892,17 +892,17 @@ static le32 setsecurityattr(ntfs_volume *vol,
 					oldattr = (char*)ntfs_malloc(size);
 					if (oldattr) {
 						rdsize = ntfs_attr_data_read(
-							vol->secure_ni,
-							STREAM_SDS, 4,
-							oldattr, size, offs);
+								vol->secure_ni,
+								STREAM_SDS, 4,
+								oldattr, size, offs);
 						found = (rdsize == size)
 							&& !memcmp(oldattr,attr,size);
 						free(oldattr);
-					  /* if the records do not compare */
-					  /* (hash collision), try next one */
+						/* if the records do not compare */
+						/* (hash collision), try next one */
 						if (!found) {
 							entry = ntfs_index_next(
-								entry,xsdh);
+									entry,xsdh);
 							collision = TRUE;
 						}
 					} else
@@ -921,7 +921,7 @@ static le32 setsecurityattr(ntfs_volume *vol,
 					 * have to build a new one
 					 */
 					securid = entersecurityattr(vol,
-						attr, attrsz, hash);
+							attr, attrsz, hash);
 				}
 			}
 		}
@@ -941,7 +941,7 @@ static le32 setsecurityattr(ntfs_volume *vol,
  */
 
 static int update_secur_descr(ntfs_volume *vol,
-				char *newattr, ntfs_inode *ni)
+		char *newattr, ntfs_inode *ni)
 {
 	int newattrsz;
 	int written;
@@ -964,10 +964,10 @@ static int update_secur_descr(ntfs_volume *vol,
 			/* overwrite value */
 			if (!res) {
 				written = (int)ntfs_attr_pwrite(na, (s64) 0,
-					 (s64) newattrsz, newattr);
+						(s64) newattrsz, newattr);
 				if (written != newattrsz) {
 					ntfs_log_error("Failed to update "
-						"a v1.x security descriptor\n");
+							"a v1.x security descriptor\n");
 					errno = EIO;
 					res = -1;
 				}
@@ -979,13 +979,13 @@ static int update_secur_descr(ntfs_volume *vol,
 			/* this is needed when security data is wanted */
 			/* as v1.x though volume is formatted for v3.x */
 			na = ntfs_attr_open(ni, AT_STANDARD_INFORMATION,
-				AT_UNNAMED, 0);
+					AT_UNNAMED, 0);
 			if (na) {
 				clear_nino_flag(ni, v3_Extensions);
-			/*
-			 * Truncating the record does not sweep extensions
-			 * from copy in memory. Clear security_id to be safe
-			 */
+				/*
+				 * Truncating the record does not sweep extensions
+				 * from copy in memory. Clear security_id to be safe
+				 */
 				ni->security_id = const_cpu_to_le32(0);
 				res = ntfs_attr_truncate(na, (s64)48);
 				ntfs_attr_close(na);
@@ -997,8 +997,8 @@ static int update_secur_descr(ntfs_volume *vol,
 			 * were none
 			 */
 			res = ntfs_attr_add(ni, AT_SECURITY_DESCRIPTOR,
-					    AT_UNNAMED, 0, (u8*)newattr,
-					    (s64) newattrsz);
+					AT_UNNAMED, 0, (u8*)newattr,
+					(s64) newattrsz);
 		}
 #if !FORCE_FORMAT_v1x
 	} else {
@@ -1008,30 +1008,30 @@ static int update_secur_descr(ntfs_volume *vol,
 		le32 securid;
 
 		securid = setsecurityattr(vol,
-			(const SECURITY_DESCRIPTOR_RELATIVE*)newattr,
-			(s64)newattrsz);
+				(const SECURITY_DESCRIPTOR_RELATIVE*)newattr,
+				(s64)newattrsz);
 		if (securid) {
 			na = ntfs_attr_open(ni, AT_STANDARD_INFORMATION,
-				AT_UNNAMED, 0);
+					AT_UNNAMED, 0);
 			if (na) {
 				res = 0;
 				if (!test_nino_flag(ni, v3_Extensions)) {
-			/* expand standard information attribute to v3.x */
+					/* expand standard information attribute to v3.x */
 					res = ntfs_attr_truncate(na,
-					 (s64)sizeof(STANDARD_INFORMATION));
+							(s64)sizeof(STANDARD_INFORMATION));
 					ni->owner_id = const_cpu_to_le32(0);
 					ni->quota_charged = const_cpu_to_le64(0);
 					ni->usn = const_cpu_to_le64(0);
 					ntfs_attr_remove(ni,
-						AT_SECURITY_DESCRIPTOR,
-						AT_UNNAMED, 0);
-			}
+							AT_SECURITY_DESCRIPTOR,
+							AT_UNNAMED, 0);
+				}
 				set_nino_flag(ni, v3_Extensions);
 				ni->security_id = securid;
 				ntfs_attr_close(na);
 			} else {
 				ntfs_log_error("Failed to update "
-					"standard informations\n");
+						"standard informations\n");
 				errno = EIO;
 				res = -1;
 			}
@@ -1067,31 +1067,31 @@ static int update_secur_descr(ntfs_volume *vol,
  */
 
 static int upgrade_secur_desc(ntfs_volume *vol,
-				const char *attr, ntfs_inode *ni)
+		const char *attr, ntfs_inode *ni)
 {
 	int attrsz;
 	int res;
 	le32 securid;
 	ntfs_attr *na;
 
-		/*
-		 * upgrade requires NTFS format v3.x
-		 * also refuse upgrading for special files.
-		 */
+	/*
+	 * upgrade requires NTFS format v3.x
+	 * also refuse upgrading for special files.
+	 */
 
 	if ((vol->major_ver >= 3)
-	    && (!utils_is_metadata(ni))) {
+			&& (!utils_is_metadata(ni))) {
 		attrsz = ntfs_attr_size(attr);
 		securid = setsecurityattr(vol,
-			(const SECURITY_DESCRIPTOR_RELATIVE*)attr,
-			(s64)attrsz);
+				(const SECURITY_DESCRIPTOR_RELATIVE*)attr,
+				(s64)attrsz);
 		if (securid) {
 			na = ntfs_attr_open(ni, AT_STANDARD_INFORMATION,
-				AT_UNNAMED, 0);
+					AT_UNNAMED, 0);
 			if (na) {
-			/* expand standard information attribute to v3.x */
+				/* expand standard information attribute to v3.x */
 				res = ntfs_attr_truncate(na,
-					 (s64)sizeof(STANDARD_INFORMATION));
+						(s64)sizeof(STANDARD_INFORMATION));
 				ni->owner_id = const_cpu_to_le32(0);
 				ni->quota_charged = const_cpu_to_le64(0);
 				ni->usn = const_cpu_to_le64(0);
@@ -1102,13 +1102,13 @@ static int upgrade_secur_desc(ntfs_volume *vol,
 				ntfs_attr_close(na);
 			} else {
 				ntfs_log_error("Failed to upgrade "
-					"standard informations\n");
+						"standard informations\n");
 				errno = EIO;
 				res = -1;
 			}
 		} else
 			res = -1;
-			/* mark node as dirty */
+		/* mark node as dirty */
 		NInoSetDirty(ni);
 	} else
 		res = 1;
@@ -1205,24 +1205,24 @@ static BOOL groupmember(struct SECURITY_CONTEXT *scx, uid_t uid, gid_t gid)
 				cnt = 1;
 				k = 0;
 				while (!ismember
-				    && (k < basecreds.pr_ngroups)
-				    && (cnt > 0)
-				    && (*p != gid)) {
+						&& (k < basecreds.pr_ngroups)
+						&& (cnt > 0)
+						&& (*p != gid)) {
 					k++;
 					cnt--;
 					p++;
 					if (cnt <= 0) {
 						got = read(fd, groups,
-							readset*sizeof(gid_t));
+								readset*sizeof(gid_t));
 						cnt = got/sizeof(gid_t);
 						p = groups;
 					}
 				}
 				if ((cnt > 0)
-				    && (k < basecreds.pr_ngroups))
+						&& (k < basecreds.pr_ngroups))
 					ismember = TRUE;
 			}
-		close(fd);
+			close(fd);
 		}
 	}
 	return (ismember);
@@ -1284,10 +1284,10 @@ static BOOL groupmember(struct SECURITY_CONTEXT *scx, uid_t uid, gid_t gid)
 			matched = 0;
 			p = buf;
 			grp = 0;
-				/*
-				 *  A simple automaton to process lines like
-				 *  Groups: 14 500 513
-				 */
+			/*
+			 *  A simple automaton to process lines like
+			 *  Groups: 14 500 513
+			 */
 			do {
 				c = *p++;
 				if (!c) {
@@ -1334,9 +1334,9 @@ static BOOL groupmember(struct SECURITY_CONTEXT *scx, uid_t uid, gid_t gid)
 					break;
 				}
 			} while (!ismember && c && (state != INEND));
-		close(fd);
-		if (!c)
-			ntfs_log_error("No group record found in %s\n",filename);
+			close(fd);
+			if (!c)
+				ntfs_log_error("No group record found in %s\n",filename);
 		} else
 			ntfs_log_error("Could not open %s\n",filename);
 	}
@@ -1358,7 +1358,7 @@ static BOOL groupmember(struct SECURITY_CONTEXT *scx, uid_t uid, gid_t gid)
  */
 
 static int ntfs_basic_perms(const struct SECURITY_CONTEXT *scx,
-			const struct POSIX_SECURITY *pxdesc)
+		const struct POSIX_SECURITY *pxdesc)
 {
 	int k;
 	int perms;
@@ -1378,7 +1378,7 @@ static int ntfs_basic_perms(const struct SECURITY_CONTEXT *scx,
 				while (group && (group->xid != pace->id))
 					group = group->next;
 				if (group && group->grcnt
-				    && (*(group->groups) == (gid_t)pace->id))
+						&& (*(group->groups) == (gid_t)pace->id))
 					perms |= pace->perms & 7;
 			}
 	}
@@ -1425,18 +1425,18 @@ static int ntfs_basic_perms(const struct SECURITY_CONTEXT *scx,
  */
 
 static struct PERMISSIONS_CACHE *create_caches(struct SECURITY_CONTEXT *scx,
-			u32 securindex)
+		u32 securindex)
 {
 	struct PERMISSIONS_CACHE *cache;
 	unsigned int index1;
 	unsigned int i;
 
 	cache = (struct PERMISSIONS_CACHE*)NULL;
-		/* create the first permissions blocks */
+	/* create the first permissions blocks */
 	index1 = securindex >> CACHE_PERMISSIONS_BITS;
 	cache = (struct PERMISSIONS_CACHE*)
 		ntfs_malloc(sizeof(struct PERMISSIONS_CACHE)
-		      + index1*sizeof(struct CACHED_PERMISSIONS*));
+				+ index1*sizeof(struct CACHED_PERMISSIONS*));
 	if (cache) {
 		cache->head.last = index1;
 		cache->head.p_reads = 0;
@@ -1445,7 +1445,7 @@ static struct PERMISSIONS_CACHE *create_caches(struct SECURITY_CONTEXT *scx,
 		*scx->pseccache = cache;
 		for (i=0; i<=index1; i++)
 			cache->cachetable[i]
-			   = (struct CACHED_PERMISSIONS*)NULL;
+				= (struct CACHED_PERMISSIONS*)NULL;
 	}
 	return (cache);
 }
@@ -1471,9 +1471,9 @@ static void free_caches(struct SECURITY_CONTEXT *scx)
 				for (index2=0; index2<(1<< CACHE_PERMISSIONS_BITS); index2++) {
 					cacheentry = &pseccache->cachetable[index1][index2];
 					if (cacheentry->valid
-					    && cacheentry->pxdesc)
+							&& cacheentry->pxdesc)
 						free(cacheentry->pxdesc);
-					}
+				}
 #endif
 				free(pseccache->cachetable[index1]);
 			}
@@ -1482,42 +1482,42 @@ static void free_caches(struct SECURITY_CONTEXT *scx)
 }
 
 static int compare(const struct CACHED_SECURID *cached,
-			const struct CACHED_SECURID *item)
+		const struct CACHED_SECURID *item)
 {
 #if POSIXACLS
 	size_t csize;
 	size_t isize;
 
-		/* only compare data and sizes */
+	/* only compare data and sizes */
 	csize = (cached->variable ?
-		sizeof(struct POSIX_ACL)
-		+ (((struct POSIX_SECURITY*)cached->variable)->acccnt
-		   + ((struct POSIX_SECURITY*)cached->variable)->defcnt)
+			sizeof(struct POSIX_ACL)
+			+ (((struct POSIX_SECURITY*)cached->variable)->acccnt
+				+ ((struct POSIX_SECURITY*)cached->variable)->defcnt)
 			*sizeof(struct POSIX_ACE) :
-		0);
+			0);
 	isize = (item->variable ?
-		sizeof(struct POSIX_ACL)
-		+ (((struct POSIX_SECURITY*)item->variable)->acccnt
-		   + ((struct POSIX_SECURITY*)item->variable)->defcnt)
+			sizeof(struct POSIX_ACL)
+			+ (((struct POSIX_SECURITY*)item->variable)->acccnt
+				+ ((struct POSIX_SECURITY*)item->variable)->defcnt)
 			*sizeof(struct POSIX_ACE) :
-		0);
+			0);
 	return ((cached->uid != item->uid)
-		 || (cached->gid != item->gid)
-		 || (cached->dmode != item->dmode)
-		 || (csize != isize)
-		 || (csize
-		    && isize
-		    && memcmp(&((struct POSIX_SECURITY*)cached->variable)->acl,
-		       &((struct POSIX_SECURITY*)item->variable)->acl, csize)));
+			|| (cached->gid != item->gid)
+			|| (cached->dmode != item->dmode)
+			|| (csize != isize)
+			|| (csize
+				&& isize
+				&& memcmp(&((struct POSIX_SECURITY*)cached->variable)->acl,
+					&((struct POSIX_SECURITY*)item->variable)->acl, csize)));
 #else
 	return ((cached->uid != item->uid)
-		 || (cached->gid != item->gid)
-		 || (cached->dmode != item->dmode));
+			|| (cached->gid != item->gid)
+			|| (cached->dmode != item->dmode));
 #endif
 }
 
 static int leg_compare(const struct CACHED_PERMISSIONS_LEGACY *cached,
-			const struct CACHED_PERMISSIONS_LEGACY *item)
+		const struct CACHED_PERMISSIONS_LEGACY *item)
 {
 	return (cached->mft_no != item->mft_no);
 }
@@ -1532,7 +1532,7 @@ static int leg_compare(const struct CACHED_PERMISSIONS_LEGACY *cached,
  */
 
 static void resize_cache(struct SECURITY_CONTEXT *scx,
-			u32 securindex)
+		u32 securindex)
 {
 	struct PERMISSIONS_CACHE *oldcache;
 	struct PERMISSIONS_CACHE *newcache;
@@ -1545,24 +1545,24 @@ static void resize_cache(struct SECURITY_CONTEXT *scx,
 	index1 = securindex >> CACHE_PERMISSIONS_BITS;
 	newcnt = index1 + 1;
 	if (newcnt <= ((CACHE_PERMISSIONS_SIZE
-			+ (1 << CACHE_PERMISSIONS_BITS)
-			- 1) >> CACHE_PERMISSIONS_BITS)) {
+					+ (1 << CACHE_PERMISSIONS_BITS)
+					- 1) >> CACHE_PERMISSIONS_BITS)) {
 		/* expand cache beyond current end, do not use realloc() */
 		/* to avoid losing data when there is no more memory */
 		oldcnt = oldcache->head.last + 1;
 		newcache = (struct PERMISSIONS_CACHE*)
 			ntfs_malloc(
-			    sizeof(struct PERMISSIONS_CACHE)
-			      + (newcnt - 1)*sizeof(struct CACHED_PERMISSIONS*));
+					sizeof(struct PERMISSIONS_CACHE)
+					+ (newcnt - 1)*sizeof(struct CACHED_PERMISSIONS*));
 		if (newcache) {
 			memcpy(newcache,oldcache,
-			    sizeof(struct PERMISSIONS_CACHE)
-			      + (oldcnt - 1)*sizeof(struct CACHED_PERMISSIONS*));
+					sizeof(struct PERMISSIONS_CACHE)
+					+ (oldcnt - 1)*sizeof(struct CACHED_PERMISSIONS*));
 			free(oldcache);
-			     /* mark new entries as not valid */
+			/* mark new entries as not valid */
 			for (i=newcache->head.last+1; i<=index1; i++)
 				newcache->cachetable[i]
-					 = (struct CACHED_PERMISSIONS*)NULL;
+					= (struct CACHED_PERMISSIONS*)NULL;
 			newcache->head.last = index1;
 			*scx->pseccache = newcache;
 		}
@@ -1600,7 +1600,7 @@ static struct CACHED_PERMISSIONS *enter_cache(struct SECURITY_CONTEXT *scx,
 
 	/* cacheing is only possible if a security_id has been defined */
 	if (test_nino_flag(ni, v3_Extensions)
-	   && ni->security_id) {
+			&& ni->security_id) {
 		/*
 		 *  Immediately test the most frequent situation
 		 *  where the entry exists
@@ -1610,8 +1610,8 @@ static struct CACHED_PERMISSIONS *enter_cache(struct SECURITY_CONTEXT *scx,
 		index2 = securindex & ((1 << CACHE_PERMISSIONS_BITS) - 1);
 		pcache = *scx->pseccache;
 		if (pcache
-		     && (pcache->head.last >= index1)
-		     && pcache->cachetable[index1]) {
+				&& (pcache->head.last >= index1)
+				&& pcache->cachetable[index1]) {
 			cacheentry = &pcache->cachetable[index1][index2];
 			cacheentry->uid = uid;
 			cacheentry->gid = gid;
@@ -1653,7 +1653,7 @@ static struct CACHED_PERMISSIONS *enter_cache(struct SECURITY_CONTEXT *scx,
 			if (pcache && (index1 <= pcache->head.last)) {
 				cacheblock = (struct CACHED_PERMISSIONS*)
 					malloc(sizeof(struct CACHED_PERMISSIONS)
-						<< CACHE_PERMISSIONS_BITS);
+							<< CACHE_PERMISSIONS_BITS);
 				pcache->cachetable[index1] = cacheblock;
 				for (i=0; i<(1 << CACHE_PERMISSIONS_BITS); i++)
 					cacheblock[i].valid = 0;
@@ -1703,7 +1703,7 @@ static struct CACHED_PERMISSIONS *enter_cache(struct SECURITY_CONTEXT *scx,
 			wanted.mft_no = ni->mft_no;
 			wanted.variable = (void*)pxdesc;
 			wanted.varsize = sizeof(struct POSIX_SECURITY)
-					+ (pxdesc->acccnt + pxdesc->defcnt)*sizeof(struct POSIX_ACE);
+				+ (pxdesc->acccnt + pxdesc->defcnt)*sizeof(struct POSIX_ACE);
 #else
 			wanted.perm.mode = mode & 07777;
 			wanted.perm.inh_fileid = const_cpu_to_le32(0);
@@ -1713,8 +1713,8 @@ static struct CACHED_PERMISSIONS *enter_cache(struct SECURITY_CONTEXT *scx,
 			wanted.varsize = 0;
 #endif
 			legacy = (struct CACHED_PERMISSIONS_LEGACY*)ntfs_enter_cache(
-				scx->vol->legacy_cache, GENERIC(&wanted),
-				(cache_compare)leg_compare);
+					scx->vol->legacy_cache, GENERIC(&wanted),
+					(cache_compare)leg_compare);
 			if (legacy) {
 				cacheentry = &legacy->perm;
 #if POSIXACLS
@@ -1752,22 +1752,22 @@ static struct CACHED_PERMISSIONS *fetch_cache(struct SECURITY_CONTEXT *scx,
 	/* cacheing is only possible if a security_id has been defined */
 	cacheentry = (struct CACHED_PERMISSIONS*)NULL;
 	if (test_nino_flag(ni, v3_Extensions)
-	   && (ni->security_id)) {
+			&& (ni->security_id)) {
 		securindex = le32_to_cpu(ni->security_id);
 		index1 = securindex >> CACHE_PERMISSIONS_BITS;
 		index2 = securindex & ((1 << CACHE_PERMISSIONS_BITS) - 1);
 		pcache = *scx->pseccache;
 		if (pcache
-		     && (pcache->head.last >= index1)
-		     && pcache->cachetable[index1]) {
+				&& (pcache->head.last >= index1)
+				&& pcache->cachetable[index1]) {
 			cacheentry = &pcache->cachetable[index1][index2];
 			/* reject if entry is not valid */
 			if (!cacheentry->valid)
 				cacheentry = (struct CACHED_PERMISSIONS*)NULL;
 			else
 				pcache->head.p_hits++;
-		if (pcache)
-			pcache->head.p_reads++;
+			if (pcache)
+				pcache->head.p_reads++;
 		}
 	}
 #if CACHE_LEGACY_SIZE
@@ -1781,8 +1781,8 @@ static struct CACHED_PERMISSIONS *fetch_cache(struct SECURITY_CONTEXT *scx,
 			wanted.variable = (void*)NULL;
 			wanted.varsize = 0;
 			legacy = (struct CACHED_PERMISSIONS_LEGACY*)ntfs_fetch_cache(
-				scx->vol->legacy_cache, GENERIC(&wanted),
-				(cache_compare)leg_compare);
+					scx->vol->legacy_cache, GENERIC(&wanted),
+					(cache_compare)leg_compare);
 			if (legacy) cacheentry = &legacy->perm;
 		}
 	}
@@ -1824,13 +1824,13 @@ static char *retrievesecurityattr(ntfs_volume *vol, SII_INDEX_KEY id)
 	if (ni && xsii) {
 		ntfs_index_ctx_reinit(xsii);
 		found =
-		    !ntfs_index_lookup((char*)&id,
-				       sizeof(SII_INDEX_KEY), xsii);
+			!ntfs_index_lookup((char*)&id,
+					sizeof(SII_INDEX_KEY), xsii);
 		if (found) {
 			psii = (struct SII*)xsii->entry;
 			size =
-			    (size_t) le32_to_cpu(psii->datasize)
-				 - sizeof(SECURITY_DESCRIPTOR_HEADER);
+				(size_t) le32_to_cpu(psii->datasize)
+				- sizeof(SECURITY_DESCRIPTOR_HEADER);
 			/* work around bad alignment problem */
 			realign.parts.dataoffsh = psii->dataoffsh;
 			realign.parts.dataoffsl = psii->dataoffsl;
@@ -1840,11 +1840,11 @@ static char *retrievesecurityattr(ntfs_volume *vol, SII_INDEX_KEY id)
 			securattr = (char*)ntfs_malloc(size);
 			if (securattr) {
 				rdsize = ntfs_attr_data_read(
-					ni, STREAM_SDS, 4,
-					securattr, size, offs);
+						ni, STREAM_SDS, 4,
+						securattr, size, offs);
 				if ((rdsize != size)
-					|| !ntfs_valid_descr(securattr,
-						rdsize)) {
+						|| !ntfs_valid_descr(securattr,
+							rdsize)) {
 					/* error to be logged by caller */
 					free(securattr);
 					securattr = (char*)NULL;
@@ -1880,41 +1880,41 @@ static char *getsecurityattr(ntfs_volume *vol, ntfs_inode *ni)
 	char *securattr;
 	s64 readallsz;
 
-		/*
-		 * Warning : in some situations, after fixing by chkdsk,
-		 * v3_Extensions are marked present (long standard informations)
-		 * with a default security descriptor inserted in an
-		 * attribute
-		 */
+	/*
+	 * Warning : in some situations, after fixing by chkdsk,
+	 * v3_Extensions are marked present (long standard informations)
+	 * with a default security descriptor inserted in an
+	 * attribute
+	 */
 	if (test_nino_flag(ni, v3_Extensions)
-	    && vol->secure_ni && ni->security_id) {
-			/* get v3.x descriptor in $Secure */
+			&& vol->secure_ni && ni->security_id) {
+		/* get v3.x descriptor in $Secure */
 		securid.security_id = ni->security_id;
 		securattr = retrievesecurityattr(vol,securid);
 		if (!securattr)
 			ntfs_log_error("Bad security descriptor for 0x%lx\n",
 					(long)le32_to_cpu(ni->security_id));
 	} else {
-			/* get v1.x security attribute */
+		/* get v1.x security attribute */
 		readallsz = 0;
 		securattr = ntfs_attr_readall(ni, AT_SECURITY_DESCRIPTOR,
 				AT_UNNAMED, 0, &readallsz);
 		if (securattr && !ntfs_valid_descr(securattr, readallsz)) {
 			ntfs_log_error("Bad security descriptor for inode %lld\n",
-				(long long)ni->mft_no);
+					(long long)ni->mft_no);
 			free(securattr);
 			securattr = (char*)NULL;
 		}
 	}
 	if (!securattr) {
-			/*
-			 * in some situations, there is no security
-			 * descriptor, and chkdsk does not detect or fix
-			 * anything. This could be a normal situation.
-			 * When this happens, simulate a descriptor with
-			 * minimum rights, so that a real descriptor can
-			 * be created by chown or chmod
-			 */
+		/*
+		 * in some situations, there is no security
+		 * descriptor, and chkdsk does not detect or fix
+		 * anything. This could be a normal situation.
+		 * When this happens, simulate a descriptor with
+		 * minimum rights, so that a real descriptor can
+		 * be created by chown or chmod
+		 */
 		ntfs_log_error("No security descriptor found for inode %lld\n",
 				(long long)ni->mft_no);
 		securattr = ntfs_build_descr(0, 0, adminsid, adminsid);
@@ -1934,8 +1934,8 @@ static char *getsecurityattr(ntfs_volume *vol, ntfs_inode *ni)
  */
 
 static int access_check_posix(struct SECURITY_CONTEXT *scx,
-			struct POSIX_SECURITY *pxdesc, mode_t request,
-			uid_t uid, gid_t gid)
+		struct POSIX_SECURITY *pxdesc, mode_t request,
+		uid_t uid, gid_t gid)
 {
 	struct POSIX_ACE *pxace;
 	int userperms;
@@ -1952,34 +1952,34 @@ static int access_check_posix(struct SECURITY_CONTEXT *scx,
 		perms = ntfs_basic_perms(scx, pxdesc);
 	else
 		perms = pxdesc->mode;
-					/* owner and root access */
+	/* owner and root access */
 	if (!scx->uid || (uid == scx->uid)) {
 		if (!scx->uid) {
-					/* root access if owner or other execution */
+			/* root access if owner or other execution */
 			if (perms & 0101)
 				perms |= 01777;
 			else {
-					/* root access if some group execution */
+				/* root access if some group execution */
 				groupperms = 0;
 				mask = 7;
 				for (i=pxdesc->acccnt-1; i>=0 ; i--) {
 					pxace = &pxdesc->acl.ace[i];
 					switch (pxace->tag) {
-					case POSIX_ACL_USER_OBJ :
-					case POSIX_ACL_GROUP_OBJ :
-						groupperms |= pxace->perms;
-						break;
-					case POSIX_ACL_GROUP :
-						if (!noacl)
-							groupperms
-							    |= pxace->perms;
-						break;
-					case POSIX_ACL_MASK :
-						if (!noacl)
-							mask = pxace->perms & 7;
-						break;
-					default :
-						break;
+						case POSIX_ACL_USER_OBJ :
+						case POSIX_ACL_GROUP_OBJ :
+							groupperms |= pxace->perms;
+							break;
+						case POSIX_ACL_GROUP :
+							if (!noacl)
+								groupperms
+									|= pxace->perms;
+							break;
+						case POSIX_ACL_MASK :
+							if (!noacl)
+								mask = pxace->perms & 7;
+							break;
+						default :
+							break;
 					}
 				}
 				perms = (groupperms & mask & 1) | 6;
@@ -1987,14 +1987,14 @@ static int access_check_posix(struct SECURITY_CONTEXT *scx,
 		} else
 			perms &= 07700;
 	} else {
-				/*
-				 * analyze designated users, get mask
-				 * and identify whether we need to check
-				 * the group memberships. The groups are
-				 * not needed when all groups have the
-				 * same permissions as other for the
-				 * requested modes.
-				 */
+		/*
+		 * analyze designated users, get mask
+		 * and identify whether we need to check
+		 * the group memberships. The groups are
+		 * not needed when all groups have the
+		 * same permissions as other for the
+		 * requested modes.
+		 */
 		userperms = -1;
 		groupperms = -1;
 		needgroups = FALSE;
@@ -2002,49 +2002,49 @@ static int access_check_posix(struct SECURITY_CONTEXT *scx,
 		for (i=pxdesc->acccnt-1; i>=0 ; i--) {
 			pxace = &pxdesc->acl.ace[i];
 			switch (pxace->tag) {
-			case POSIX_ACL_USER :
-				if (!noacl
-				    && ((uid_t)pxace->id == scx->uid))
-					userperms = pxace->perms;
-				break;
-			case POSIX_ACL_MASK :
-				if (!noacl)
-					mask = pxace->perms & 7;
-				break;
-			case POSIX_ACL_GROUP_OBJ :
-				if (((pxace->perms & mask) ^ perms)
-				    & (request >> 6) & 7)
-					needgroups = TRUE;
-				break;
-			case POSIX_ACL_GROUP :
-				if (!noacl
-				    && (((pxace->perms & mask) ^ perms)
-					    & (request >> 6) & 7))
-					needgroups = TRUE;
-				break;
-			default :
-				break;
+				case POSIX_ACL_USER :
+					if (!noacl
+							&& ((uid_t)pxace->id == scx->uid))
+						userperms = pxace->perms;
+					break;
+				case POSIX_ACL_MASK :
+					if (!noacl)
+						mask = pxace->perms & 7;
+					break;
+				case POSIX_ACL_GROUP_OBJ :
+					if (((pxace->perms & mask) ^ perms)
+							& (request >> 6) & 7)
+						needgroups = TRUE;
+					break;
+				case POSIX_ACL_GROUP :
+					if (!noacl
+							&& (((pxace->perms & mask) ^ perms)
+								& (request >> 6) & 7))
+						needgroups = TRUE;
+					break;
+				default :
+					break;
 			}
 		}
-					/* designated users */
+		/* designated users */
 		if (userperms >= 0)
 			perms = (perms & 07000) + (userperms & mask);
 		else if (!needgroups)
-				perms &= 07007;
+			perms &= 07007;
 		else {
-					/* owning group */
+			/* owning group */
 			if (!(~(perms >> 3) & request & mask)
-			    && ((gid == scx->gid)
-				|| groupmember(scx, scx->uid, gid)))
+					&& ((gid == scx->gid)
+						|| groupmember(scx, scx->uid, gid)))
 				perms &= 07070;
 			else if (!noacl) {
-					/* other groups */
+				/* other groups */
 				groupperms = -1;
 				somegroup = FALSE;
 				for (i=pxdesc->acccnt-1; i>=0 ; i--) {
 					pxace = &pxdesc->acl.ace[i];
 					if ((pxace->tag == POSIX_ACL_GROUP)
-					    && groupmember(scx, scx->uid, pxace->id)) {
+							&& groupmember(scx, scx->uid, pxace->id)) {
 						if (!(~pxace->perms & request & mask))
 							groupperms = pxace->perms;
 						somegroup = TRUE;
@@ -2074,7 +2074,7 @@ static int access_check_posix(struct SECURITY_CONTEXT *scx,
  */
 
 static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
-		 ntfs_inode * ni, mode_t request)
+		ntfs_inode * ni, mode_t request)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	const struct CACHED_PERMISSIONS *cached;
@@ -2103,14 +2103,14 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
 			securattr = getsecurityattr(scx->vol, ni);
 			if (securattr) {
 				phead = (const SECURITY_DESCRIPTOR_RELATIVE*)
-				    	securattr;
+					securattr;
 				gsid = (const SID*)&
-					   securattr[le32_to_cpu(phead->group)];
+					securattr[le32_to_cpu(phead->group)];
 				gid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
 #if OWNERFROMACL
 				usid = ntfs_acl_owner(securattr);
 				pxdesc = ntfs_build_permissions_posix(scx->mapping,securattr,
-						 usid, gsid, isdir);
+						usid, gsid, isdir);
 				if (pxdesc)
 					perm = pxdesc->mode & 07777;
 				else
@@ -2118,9 +2118,9 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
 				uid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
 #else
 				usid = (const SID*)&
-					    securattr[le32_to_cpu(phead->owner)];
+					securattr[le32_to_cpu(phead->owner)];
 				pxdesc = ntfs_build_permissions_posix(scx,securattr,
-						 usid, gsid, isdir);
+						usid, gsid, isdir);
 				if (pxdesc)
 					perm = pxdesc->mode & 07777;
 				else
@@ -2137,18 +2137,18 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
 				 * and upgrade option is selected
 				 */
 				if (!test_nino_flag(ni, v3_Extensions)
-				   && (perm >= 0)
-				   && (scx->vol->secure_flags
-				     & (1 << SECURITY_ADDSECURIDS))) {
+						&& (perm >= 0)
+						&& (scx->vol->secure_flags
+							& (1 << SECURITY_ADDSECURIDS))) {
 					upgrade_secur_desc(scx->vol,
-						securattr, ni);
+							securattr, ni);
 					/*
 					 * fetch owner and group for cacheing
 					 * if there is a securid
 					 */
 				}
 				if (test_nino_flag(ni, v3_Extensions)
-				    && (perm >= 0)) {
+						&& (perm >= 0)) {
 					enter_cache(scx, ni, uid,
 							gid, pxdesc);
 				}
@@ -2175,7 +2175,7 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
  */
 
 int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *name, char *value, size_t size)
+		const char *name, char *value, size_t size)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	struct POSIX_SECURITY *pxdesc;
@@ -2192,7 +2192,7 @@ int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 	if (!scx->mapping[MAPUSERS])
 		errno = ENOTSUP;
 	else {
-			/* check whether available in cache */
+		/* check whether available in cache */
 		cached = fetch_cache(scx,ni);
 		if (cached)
 			pxdesc = cached->pxdesc;
@@ -2202,38 +2202,38 @@ int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 				!= const_cpu_to_le16(0);
 			if (securattr) {
 				phead =
-				    (const SECURITY_DESCRIPTOR_RELATIVE*)
-			    			securattr;
+					(const SECURITY_DESCRIPTOR_RELATIVE*)
+					securattr;
 				gsid = (const SID*)&
-					  securattr[le32_to_cpu(phead->group)];
+					securattr[le32_to_cpu(phead->group)];
 #if OWNERFROMACL
 				usid = ntfs_acl_owner(securattr);
 #else
 				usid = (const SID*)&
-					  securattr[le32_to_cpu(phead->owner)];
+					securattr[le32_to_cpu(phead->owner)];
 #endif
 				pxdesc = ntfs_build_permissions_posix(scx->mapping,securattr,
-					  usid, gsid, isdir);
+						usid, gsid, isdir);
 
-					/*
-					 * fetch owner and group for cacheing
-					 */
-				if (pxdesc) {
 				/*
-				 *  Create a security id if there were none
-				 * and upgrade option is selected
+				 * fetch owner and group for cacheing
 				 */
+				if (pxdesc) {
+					/*
+					 *  Create a security id if there were none
+					 * and upgrade option is selected
+					 */
 					if (!test_nino_flag(ni, v3_Extensions)
-					   && (scx->vol->secure_flags
-					     & (1 << SECURITY_ADDSECURIDS))) {
+							&& (scx->vol->secure_flags
+								& (1 << SECURITY_ADDSECURIDS))) {
 						upgrade_secur_desc(scx->vol,
-							 securattr, ni);
+								securattr, ni);
 					}
 #if OWNERFROMACL
 					uid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
 #else
 					if (!(pxdesc->mode & 07777)
-					    && ntfs_same_sid(usid, adminsid)) {
+							&& ntfs_same_sid(usid, adminsid)) {
 						uid = find_tenant(scx,
 								securattr);
 					} else
@@ -2241,8 +2241,8 @@ int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 #endif
 					gid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
 					if (pxdesc->tagsset & POSIX_ACL_EXTENSIONS)
-					enter_cache(scx, ni, uid,
-							gid, pxdesc);
+						enter_cache(scx, ni, uid,
+								gid, pxdesc);
 				}
 				free(securattr);
 			} else
@@ -2253,17 +2253,17 @@ int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 			if (ntfs_valid_posix(pxdesc)) {
 				if (!strcmp(name,"system.posix_acl_default")) {
 					if (ni->mrec->flags
-						    & MFT_RECORD_IS_DIRECTORY)
+							& MFT_RECORD_IS_DIRECTORY)
 						outsize = sizeof(struct POSIX_ACL)
 							+ pxdesc->defcnt*sizeof(struct POSIX_ACE);
 					else {
-					/*
-					 * getting default ACL from plain file :
-					 * return EACCES if size > 0 as
-					 * indicated in the man, but return ok
-					 * if size == 0, so that ls does not
-					 * display an error
-					 */
+						/*
+						 * getting default ACL from plain file :
+						 * return EACCES if size > 0 as
+						 * indicated in the man, but return ok
+						 * if size == 0, so that ls does not
+						 * display an error
+						 */
 						if (size > 0) {
 							outsize = 0;
 							errno = EACCES;
@@ -2273,8 +2273,8 @@ int ntfs_get_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 					if (outsize && (outsize <= size)) {
 						memcpy(value,&pxdesc->acl,sizeof(struct POSIX_ACL));
 						memcpy(&value[sizeof(struct POSIX_ACL)],
-							&pxdesc->acl.ace[pxdesc->firstdef],
-							outsize-sizeof(struct POSIX_ACL));
+								&pxdesc->acl.ace[pxdesc->firstdef],
+								outsize-sizeof(struct POSIX_ACL));
 					}
 				} else {
 					outsize = sizeof(struct POSIX_ACL)
@@ -2335,20 +2335,20 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
 			securattr = getsecurityattr(scx->vol, ni);
 			if (securattr) {
 				phead = (const SECURITY_DESCRIPTOR_RELATIVE*)
-				    	securattr;
+					securattr;
 				gsid = (const SID*)&
-					   securattr[le32_to_cpu(phead->group)];
+					securattr[le32_to_cpu(phead->group)];
 				gid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
 #if OWNERFROMACL
 				usid = ntfs_acl_owner(securattr);
 				perm = ntfs_build_permissions(securattr,
-						 usid, gsid, isdir);
+						usid, gsid, isdir);
 				uid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
 #else
 				usid = (const SID*)&
-					    securattr[le32_to_cpu(phead->owner)];
+					securattr[le32_to_cpu(phead->owner)];
 				perm = ntfs_build_permissions(securattr,
-						 usid, gsid, isdir);
+						usid, gsid, isdir);
 				if (!perm && ntfs_same_sid(usid, adminsid)) {
 					uid = find_tenant(scx, securattr);
 					if (uid)
@@ -2361,18 +2361,18 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
 				 * and upgrade option is selected
 				 */
 				if (!test_nino_flag(ni, v3_Extensions)
-				   && (perm >= 0)
-				   && (scx->vol->secure_flags
-				     & (1 << SECURITY_ADDSECURIDS))) {
+						&& (perm >= 0)
+						&& (scx->vol->secure_flags
+							& (1 << SECURITY_ADDSECURIDS))) {
 					upgrade_secur_desc(scx->vol,
-						securattr, ni);
+							securattr, ni);
 					/*
 					 * fetch owner and group for cacheing
 					 * if there is a securid
 					 */
 				}
 				if (test_nino_flag(ni, v3_Extensions)
-				    && (perm >= 0)) {
+						&& (perm >= 0)) {
 					enter_cache(scx, ni, uid,
 							gid, perm);
 				}
@@ -2393,15 +2393,15 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
 				if (uid == scx->uid)
 					perm &= 07700;
 				else
-				/*
-				 * avoid checking group membership
-				 * when the requested perms for group
-				 * are the same as perms for other
-				 */
+					/*
+					 * avoid checking group membership
+					 * when the requested perms for group
+					 * are the same as perms for other
+					 */
 					if ((gid == scx->gid)
-					  || ((((perm >> 3) ^ perm)
-						& (request >> 6) & 7)
-					    && groupmember(scx, scx->uid, gid)))
+							|| ((((perm >> 3) ^ perm)
+									& (request >> 6) & 7)
+								&& groupmember(scx, scx->uid, gid)))
 						perm &= 07070;
 					else
 						perm &= 07007;
@@ -2421,7 +2421,7 @@ static int ntfs_get_perm(struct SECURITY_CONTEXT *scx,
  */
 
 int ntfs_get_ntfs_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			char *value, size_t size)
+		char *value, size_t size)
 {
 	char *securattr;
 	size_t outsize;
@@ -2460,12 +2460,12 @@ int ntfs_get_owner_mode(struct SECURITY_CONTEXT *scx,
 	if (!scx->mapping[MAPUSERS])
 		perm = 07777;
 	else {
-			/* check whether available in cache */
+		/* check whether available in cache */
 		cached = fetch_cache(scx,ni);
 		if (cached) {
 #if POSIXACLS
 			if (!(scx->vol->secure_flags & (1 << SECURITY_ACL))
-			    && cached->pxdesc)
+					&& cached->pxdesc)
 				perm = ntfs_basic_perms(scx,cached->pxdesc);
 			else
 #endif
@@ -2480,23 +2480,23 @@ int ntfs_get_owner_mode(struct SECURITY_CONTEXT *scx,
 			securattr = getsecurityattr(scx->vol, ni);
 			if (securattr) {
 				phead =
-				    (const SECURITY_DESCRIPTOR_RELATIVE*)
-					    	securattr;
+					(const SECURITY_DESCRIPTOR_RELATIVE*)
+					securattr;
 				gsid = (const SID*)&
-					  securattr[le32_to_cpu(phead->group)];
+					securattr[le32_to_cpu(phead->group)];
 #if OWNERFROMACL
 				usid = ntfs_acl_owner(securattr);
 #else
 				usid = (const SID*)&
-					  securattr[le32_to_cpu(phead->owner)];
+					securattr[le32_to_cpu(phead->owner)];
 #endif
 #if POSIXACLS
 				pxdesc = ntfs_build_permissions_posix(
 						scx->mapping, securattr,
-					usid, gsid, isdir);
+						usid, gsid, isdir);
 				if (pxdesc) {
 					if (!(scx->vol->secure_flags
-					    & (1 << SECURITY_ACL)))
+								& (1 << SECURITY_ACL)))
 						perm = ntfs_basic_perms(scx,
 								pxdesc);
 					else
@@ -2505,21 +2505,21 @@ int ntfs_get_owner_mode(struct SECURITY_CONTEXT *scx,
 					perm = -1;
 #else
 				perm = ntfs_build_permissions(securattr,
-					  usid, gsid, isdir);
+						usid, gsid, isdir);
 #endif
-					/*
-					 * fetch owner and group for cacheing
-					 */
-				if (perm >= 0) {
 				/*
-				 *  Create a security id if there were none
-				 * and upgrade option is selected
+				 * fetch owner and group for cacheing
 				 */
+				if (perm >= 0) {
+					/*
+					 *  Create a security id if there were none
+					 * and upgrade option is selected
+					 */
 					if (!test_nino_flag(ni, v3_Extensions)
-					   && (scx->vol->secure_flags
-					     & (1 << SECURITY_ADDSECURIDS))) {
+							&& (scx->vol->secure_flags
+								& (1 << SECURITY_ADDSECURIDS))) {
 						upgrade_secur_desc(scx->vol,
-							 securattr, ni);
+								securattr, ni);
 					}
 #if OWNERFROMACL
 					stbuf->st_uid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
@@ -2527,7 +2527,7 @@ int ntfs_get_owner_mode(struct SECURITY_CONTEXT *scx,
 					if (!perm && ntfs_same_sid(usid, adminsid)) {
 						stbuf->st_uid =
 							find_tenant(scx,
-								securattr);
+									securattr);
 						if (stbuf->st_uid)
 							perm = 0700;
 					} else
@@ -2535,14 +2535,14 @@ int ntfs_get_owner_mode(struct SECURITY_CONTEXT *scx,
 #endif
 					stbuf->st_gid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
 					stbuf->st_mode =
-					    (stbuf->st_mode & ~07777) + perm;
+						(stbuf->st_mode & ~07777) + perm;
 #if POSIXACLS
 					enter_cache(scx, ni, stbuf->st_uid,
-						stbuf->st_gid, pxdesc);
+							stbuf->st_gid, pxdesc);
 					free(pxdesc);
 #else
 					enter_cache(scx, ni, stbuf->st_uid,
-						stbuf->st_gid, perm);
+							stbuf->st_gid, perm);
 #endif
 				}
 				free(securattr);
@@ -2560,7 +2560,7 @@ int ntfs_get_owner_mode(struct SECURITY_CONTEXT *scx,
  */
 
 static struct POSIX_SECURITY *inherit_posix(struct SECURITY_CONTEXT *scx,
-			ntfs_inode *dir_ni, mode_t mode, BOOL isdir)
+		ntfs_inode *dir_ni, mode_t mode, BOOL isdir)
 {
 	const struct CACHED_PERMISSIONS *cached;
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
@@ -2573,7 +2573,7 @@ static struct POSIX_SECURITY *inherit_posix(struct SECURITY_CONTEXT *scx,
 	gid_t gid;
 
 	pydesc = (struct POSIX_SECURITY*)NULL;
-		/* check whether parent directory is available in cache */
+	/* check whether parent directory is available in cache */
 	cached = fetch_cache(scx,dir_ni);
 	if (cached) {
 		uid = cached->uid;
@@ -2582,29 +2582,29 @@ static struct POSIX_SECURITY *inherit_posix(struct SECURITY_CONTEXT *scx,
 		if (pxdesc) {
 			if (scx->vol->secure_flags & (1 << SECURITY_ACL))
 				pydesc = ntfs_build_inherited_posix(pxdesc,
-					mode, scx->umask, isdir);
+						mode, scx->umask, isdir);
 			else
 				pydesc = ntfs_build_basic_posix(pxdesc,
-					mode, scx->umask, isdir);
+						mode, scx->umask, isdir);
 		}
 	} else {
 		securattr = getsecurityattr(scx->vol, dir_ni);
 		if (securattr) {
 			phead = (const SECURITY_DESCRIPTOR_RELATIVE*)
-			    	securattr;
+				securattr;
 			gsid = (const SID*)&
-				   securattr[le32_to_cpu(phead->group)];
+				securattr[le32_to_cpu(phead->group)];
 			gid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
 #if OWNERFROMACL
 			usid = ntfs_acl_owner(securattr);
 			pxdesc = ntfs_build_permissions_posix(scx->mapping,securattr,
-						 usid, gsid, TRUE);
+					usid, gsid, TRUE);
 			uid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
 #else
 			usid = (const SID*)&
-				    securattr[le32_to_cpu(phead->owner)];
+				securattr[le32_to_cpu(phead->owner)];
 			pxdesc = ntfs_build_permissions_posix(scx->mapping,securattr,
-						 usid, gsid, TRUE);
+					usid, gsid, TRUE);
 			if (pxdesc && ntfs_same_sid(usid, adminsid)) {
 				uid = find_tenant(scx, securattr);
 			} else
@@ -2616,10 +2616,10 @@ static struct POSIX_SECURITY *inherit_posix(struct SECURITY_CONTEXT *scx,
 				 * and upgrade option is selected
 				 */
 				if (!test_nino_flag(dir_ni, v3_Extensions)
-				   && (scx->vol->secure_flags
-				     & (1 << SECURITY_ADDSECURIDS))) {
+						&& (scx->vol->secure_flags
+							& (1 << SECURITY_ADDSECURIDS))) {
 					upgrade_secur_desc(scx->vol,
-						securattr, dir_ni);
+							securattr, dir_ni);
 					/*
 					 * fetch owner and group for cacheing
 					 * if there is a securid
@@ -2630,14 +2630,14 @@ static struct POSIX_SECURITY *inherit_posix(struct SECURITY_CONTEXT *scx,
 							gid, pxdesc);
 				}
 				if (scx->vol->secure_flags
-							& (1 << SECURITY_ACL))
+						& (1 << SECURITY_ACL))
 					pydesc = ntfs_build_inherited_posix(
-						pxdesc, mode,
-						scx->umask, isdir);
+							pxdesc, mode,
+							scx->umask, isdir);
 				else
 					pydesc = ntfs_build_basic_posix(
-						pxdesc, mode,
-						scx->umask, isdir);
+							pxdesc, mode,
+							scx->umask, isdir);
 				free(pxdesc);
 			}
 			free(securattr);
@@ -2683,15 +2683,15 @@ le32 ntfs_alloc_securid(struct SECURITY_CONTEXT *scx,
 		if (isdir) wanted.dmode |= 0x10000;
 		wanted.variable = (void*)pxdesc;
 		wanted.varsize = sizeof(struct POSIX_SECURITY)
-				+ (pxdesc->acccnt + pxdesc->defcnt)*sizeof(struct POSIX_ACE);
+			+ (pxdesc->acccnt + pxdesc->defcnt)*sizeof(struct POSIX_ACE);
 		cached = (const struct CACHED_SECURID*)ntfs_fetch_cache(
 				scx->vol->securid_cache, GENERIC(&wanted),
 				(cache_compare)compare);
-			/* quite simple, if we are lucky */
+		/* quite simple, if we are lucky */
 		if (cached)
 			securid = cached->securid;
 
-			/* not in cache : make sure we can create ids */
+		/* not in cache : make sure we can create ids */
 
 		if (!cached && (scx->vol->major_ver >= 3)) {
 			usid = ntfs_find_usid(scx->mapping[MAPUSERS],uid,(SID*)&defusid);
@@ -2706,8 +2706,8 @@ le32 ntfs_alloc_securid(struct SECURITY_CONTEXT *scx,
 			if (newattr) {
 				newattrsz = ntfs_attr_size(newattr);
 				securid = setsecurityattr(scx->vol,
-					(const SECURITY_DESCRIPTOR_RELATIVE*)newattr,
-					newattrsz);
+						(const SECURITY_DESCRIPTOR_RELATIVE*)newattr,
+						newattrsz);
 				if (securid) {
 					/* update cache, for subsequent use */
 					wanted.securid = securid;
@@ -2723,7 +2723,7 @@ le32 ntfs_alloc_securid(struct SECURITY_CONTEXT *scx,
 				 */
 			}
 		}
-	free(pxdesc);
+		free(pxdesc);
 	}
 #endif
 	return (securid);
@@ -2759,9 +2759,9 @@ int ntfs_set_inherited_posix(struct SECURITY_CONTEXT *scx,
 			usid = gsid = adminsid;
 		}
 		newattr = ntfs_build_descr_posix(scx->mapping, pxdesc,
-					isdir, usid, gsid);
+				isdir, usid, gsid);
 		if (newattr) {
-				/* Adjust Windows read-only flag */
+			/* Adjust Windows read-only flag */
 			res = update_secur_descr(scx->vol, newattr, ni);
 			if (!res && !isdir) {
 				if (mode & S_IWUSR)
@@ -2815,7 +2815,7 @@ le32 ntfs_alloc_securid(struct SECURITY_CONTEXT *scx,
 	securid = const_cpu_to_le32(0);
 
 #if !FORCE_FORMAT_v1x
-		/* check whether target securid is known in cache */
+	/* check whether target securid is known in cache */
 
 	wanted.uid = uid;
 	wanted.gid = gid;
@@ -2826,11 +2826,11 @@ le32 ntfs_alloc_securid(struct SECURITY_CONTEXT *scx,
 	cached = (const struct CACHED_SECURID*)ntfs_fetch_cache(
 			scx->vol->securid_cache, GENERIC(&wanted),
 			(cache_compare)compare);
-		/* quite simple, if we are lucky */
+	/* quite simple, if we are lucky */
 	if (cached)
 		securid = cached->securid;
 
-		/* not in cache : make sure we can create ids */
+	/* not in cache : make sure we can create ids */
 
 	if (!cached && (scx->vol->major_ver >= 3)) {
 		usid = ntfs_find_usid(scx->mapping[MAPUSERS],uid,(SID*)&defusid);
@@ -2844,8 +2844,8 @@ le32 ntfs_alloc_securid(struct SECURITY_CONTEXT *scx,
 		if (newattr) {
 			newattrsz = ntfs_attr_size(newattr);
 			securid = setsecurityattr(scx->vol,
-				(const SECURITY_DESCRIPTOR_RELATIVE*)newattr,
-				newattrsz);
+					(const SECURITY_DESCRIPTOR_RELATIVE*)newattr,
+					newattrsz);
 			if (securid) {
 				/* update cache, for subsequent use */
 				wanted.securid = securid;
@@ -2895,7 +2895,7 @@ int ntfs_set_owner_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 
 	res = 0;
 
-		/* check whether target securid is known in cache */
+	/* check whether target securid is known in cache */
 
 	isdir = (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY) != const_cpu_to_le16(0);
 	wanted.uid = uid;
@@ -2917,11 +2917,11 @@ int ntfs_set_owner_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 		cached = (const struct CACHED_SECURID*)ntfs_fetch_cache(
 				scx->vol->securid_cache, GENERIC(&wanted),
 				(cache_compare)compare);
-			/* quite simple, if we are lucky */
+		/* quite simple, if we are lucky */
 		if (cached) {
 			ni->security_id = cached->securid;
 			NInoSetDirty(ni);
-				/* adjust Windows read-only flag */
+			/* adjust Windows read-only flag */
 			if (!isdir) {
 				if (mode & S_IWUSR)
 					ni->flags &= ~FILE_ATTR_READONLY;
@@ -2933,28 +2933,28 @@ int ntfs_set_owner_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 	} else cached = (struct CACHED_SECURID*)NULL;
 
 	if (!cached) {
-			/*
-			 * Do not use usid and gsid from former attributes,
-			 * but recompute them to get repeatable results
-			 * which can be kept in cache.
-			 */
+		/*
+		 * Do not use usid and gsid from former attributes,
+		 * but recompute them to get repeatable results
+		 * which can be kept in cache.
+		 */
 		usid = ntfs_find_usid(scx->mapping[MAPUSERS],uid,(SID*)&defusid);
 		gsid = ntfs_find_gsid(scx->mapping[MAPGROUPS],gid,(SID*)&defgsid);
 		if (!usid || !gsid) {
 			ntfs_log_error("File made owned by an unmapped user/group %d/%d\n",
-				uid, gid);
+					uid, gid);
 			usid = gsid = adminsid;
 		}
 #if POSIXACLS
 		if (pxdesc)
 			newattr = ntfs_build_descr_posix(scx->mapping, pxdesc,
-					 isdir, usid, gsid);
+					isdir, usid, gsid);
 		else
 			newattr = ntfs_build_descr(mode,
-					 isdir, usid, gsid);
+					isdir, usid, gsid);
 #else
 		newattr = ntfs_build_descr(mode,
-					 isdir, usid, gsid);
+				isdir, usid, gsid);
 #endif
 		if (newattr) {
 			res = update_secur_descr(scx->vol, newattr, ni);
@@ -2988,8 +2988,8 @@ int ntfs_set_owner_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 					legacy.varsize = 0;
 #endif
 					ntfs_invalidate_cache(scx->vol->legacy_cache,
-						GENERIC(&legacy),
-						(cache_compare)leg_compare,0);
+							GENERIC(&legacy),
+							(cache_compare)leg_compare,0);
 				}
 #endif
 			}
@@ -3023,7 +3023,7 @@ BOOL ntfs_allowed_as_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni)
 	int allowed;
 
 	processuid = scx->uid;
-/* TODO : use CAP_FOWNER process capability */
+	/* TODO : use CAP_FOWNER process capability */
 	/*
 	 * Always allow for root
 	 * Also always allow if no mapping has been defined
@@ -3046,9 +3046,9 @@ BOOL ntfs_allowed_as_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni)
 				const SECURITY_DESCRIPTOR_RELATIVE *phead;
 
 				phead = (const SECURITY_DESCRIPTOR_RELATIVE*)
-								oldattr;
+					oldattr;
 				usid = (const SID*)&oldattr
-						[le32_to_cpu(phead->owner)];
+					[le32_to_cpu(phead->owner)];
 #endif
 				uid = ntfs_find_user(scx->mapping[MAPUSERS],
 						usid);
@@ -3056,9 +3056,9 @@ BOOL ntfs_allowed_as_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni)
 				free(oldattr);
 			}
 		}
-/* TODO : use CAP_FOWNER process capability */
+		/* TODO : use CAP_FOWNER process capability */
 		if (gotowner
-		    && (!processuid || (processuid == uid)))
+				&& (!processuid || (processuid == uid)))
 			allowed = TRUE;
 		else {
 			allowed = FALSE;
@@ -3080,8 +3080,8 @@ BOOL ntfs_allowed_as_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni)
  */
 
 int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *name, const char *value, size_t size,
-			int flags)
+		const char *name, const char *value, size_t size,
+		int flags)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	const struct CACHED_PERMISSIONS *cached;
@@ -3109,8 +3109,8 @@ int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 	isdir = (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY) != const_cpu_to_le16(0);
 	newpxdesc = (struct POSIX_SECURITY*)NULL;
 	if ((!value
-		|| (((const struct POSIX_ACL*)value)->version == POSIX_VERSION))
-	    && (!deflt || isdir || (!size && !value))) {
+				|| (((const struct POSIX_ACL*)value)->version == POSIX_VERSION))
+			&& (!deflt || isdir || (!size && !value))) {
 		cached = fetch_cache(scx, ni);
 		if (cached) {
 			uid = cached->uid;
@@ -3119,7 +3119,7 @@ int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 			if (oldpxdesc) {
 				newpxdesc = ntfs_replace_acl(oldpxdesc,
 						(const struct POSIX_ACL*)value,count,deflt);
-				}
+			}
 		} else {
 			oldattr = getsecurityattr(scx->vol, ni);
 			if (oldattr) {
@@ -3133,18 +3133,18 @@ int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 				uid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
 				gid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
 				oldpxdesc = ntfs_build_permissions_posix(scx->mapping,
-					oldattr, usid, gsid, isdir);
+						oldattr, usid, gsid, isdir);
 				if (oldpxdesc) {
 					if (deflt)
 						exist = oldpxdesc->defcnt > 0;
 					else
 						exist = oldpxdesc->acccnt > 3;
 					if ((exist && (flags & XATTR_CREATE))
-					  || (!exist && (flags & XATTR_REPLACE))) {
+							|| (!exist && (flags & XATTR_REPLACE))) {
 						errno = (exist ? EEXIST : ENODATA);
 					} else {
 						newpxdesc = ntfs_replace_acl(oldpxdesc,
-							(const struct POSIX_ACL*)value,count,deflt);
+								(const struct POSIX_ACL*)value,count,deflt);
 					}
 					free(oldpxdesc);
 				}
@@ -3156,18 +3156,18 @@ int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 
 	if (newpxdesc) {
 		processuid = scx->uid;
-/* TODO : use CAP_FOWNER process capability */
+		/* TODO : use CAP_FOWNER process capability */
 		if (!processuid || (uid == processuid)) {
-				/*
-				 * clear setgid if file group does
-				 * not match process group
-				 */
+			/*
+			 * clear setgid if file group does
+			 * not match process group
+			 */
 			if (processuid && (gid != scx->gid)
-			    && !groupmember(scx, scx->uid, gid)) {
+					&& !groupmember(scx, scx->uid, gid)) {
 				newpxdesc->mode &= ~S_ISGID;
 			}
 			res = ntfs_set_owner_mode(scx, ni, uid, gid,
-				newpxdesc->mode, newpxdesc);
+					newpxdesc->mode, newpxdesc);
 		} else
 			errno = EPERM;
 		free(newpxdesc);
@@ -3182,10 +3182,10 @@ int ntfs_set_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
  */
 
 int ntfs_remove_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *name)
+		const char *name)
 {
 	return (ntfs_set_posix_acl(scx, ni, name,
-			(const char*)NULL, 0, 0));
+				(const char*)NULL, 0, 0));
 }
 
 #endif
@@ -3197,17 +3197,17 @@ int ntfs_remove_posix_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
  */
 
 int ntfs_set_ntfs_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			const char *value, size_t size,	int flags)
+		const char *value, size_t size,	int flags)
 {
 	char *attr;
 	int res;
 
 	res = -1;
 	if ((size > 0)
-	   && !(flags & XATTR_CREATE)
-	   && ntfs_valid_descr(value,size)
-	   && (ntfs_attr_size(value) == size)) {
-			/* need copying in order to write */
+			&& !(flags & XATTR_CREATE)
+			&& ntfs_valid_descr(value,size)
+			&& (ntfs_attr_size(value) == size)) {
+		/* need copying in order to write */
 		attr = (char*)ntfs_malloc(size);
 		if (attr) {
 			memcpy(attr,value,size);
@@ -3227,15 +3227,15 @@ int ntfs_set_ntfs_acl(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 			 * failed.
 			 */
 			if ((ni->mrec->flags & MFT_RECORD_IS_DIRECTORY)
-			   && !ni->security_id) {
+					&& !ni->security_id) {
 				struct CACHED_PERMISSIONS_LEGACY legacy;
 
 				legacy.mft_no = ni->mft_no;
 				legacy.variable = (char*)NULL;
 				legacy.varsize = 0;
 				ntfs_invalidate_cache(scx->vol->legacy_cache,
-					GENERIC(&legacy),
-					(cache_compare)leg_compare,0);
+						GENERIC(&legacy),
+						(cache_compare)leg_compare,0);
 			}
 #endif
 			free(attr);
@@ -3284,7 +3284,7 @@ int ntfs_set_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni, mode_t mode)
 #if POSIXACLS
 		oldpxdesc = cached->pxdesc;
 		if (oldpxdesc) {
-				/* must copy before merging */
+			/* must copy before merging */
 			pxsize = sizeof(struct POSIX_SECURITY)
 				+ (oldpxdesc->acccnt + oldpxdesc->defcnt)*sizeof(struct POSIX_ACE);
 			newpxdesc = (struct POSIX_SECURITY*)malloc(pxsize);
@@ -3312,7 +3312,7 @@ int ntfs_set_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni, mode_t mode)
 #if POSIXACLS
 			isdir = (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY) != const_cpu_to_le16(0);
 			newpxdesc = ntfs_build_permissions_posix(scx->mapping,
-				oldattr, usid, gsid, isdir);
+					oldattr, usid, gsid, isdir);
 			if (!newpxdesc || ntfs_merge_mode_posix(newpxdesc, mode))
 				res = -1;
 #endif
@@ -3323,23 +3323,23 @@ int ntfs_set_mode(struct SECURITY_CONTEXT *scx, ntfs_inode *ni, mode_t mode)
 
 	if (!res) {
 		processuid = scx->uid;
-/* TODO : use CAP_FOWNER process capability */
+		/* TODO : use CAP_FOWNER process capability */
 		if (!processuid || (uid == processuid)) {
-				/*
-				 * clear setgid if file group does
-				 * not match process group
-				 */
+			/*
+			 * clear setgid if file group does
+			 * not match process group
+			 */
 			if (processuid && (gid != scx->gid)
-			    && !groupmember(scx, scx->uid, gid))
+					&& !groupmember(scx, scx->uid, gid))
 				mode &= ~S_ISGID;
 #if POSIXACLS
 			if (newpxdesc) {
 				newpxdesc->mode = mode;
 				res = ntfs_set_owner_mode(scx, ni, uid, gid,
-					mode, newpxdesc);
+						mode, newpxdesc);
 			} else
 				res = ntfs_set_owner_mode(scx, ni, uid, gid,
-					mode, newpxdesc);
+						mode, newpxdesc);
 #else
 			res = ntfs_set_owner_mode(scx, ni, uid, gid, mode);
 #endif
@@ -3424,7 +3424,7 @@ int ntfs_sd_add_everyone(ntfs_inode *ni)
 	ace->sid.identifier_authority.value[5] = 1;
 
 	ret = ntfs_attr_add(ni, AT_SECURITY_DESCRIPTOR, AT_UNNAMED, 0, (u8*)sd,
-			    sd_len);
+			sd_len);
 	if (ret)
 		ntfs_log_perror("Failed to add initial SECURITY_DESCRIPTOR");
 
@@ -3459,9 +3459,9 @@ int ntfs_allowed_access(struct SECURITY_CONTEXT *scx,
 	 * Also always allow if no mapping has been defined
 	 */
 	if (!scx->mapping[MAPUSERS]
-	    || (!scx->uid
-		&& (!(accesstype & S_IEXEC)
-		    || (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY))))
+			|| (!scx->uid
+				&& (!(accesstype & S_IEXEC)
+					|| (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY))))
 		allow = 1;
 	else {
 		perm = ntfs_get_perm(scx, ni, accesstype);
@@ -3476,34 +3476,34 @@ int ntfs_allowed_access(struct SECURITY_CONTEXT *scx,
 				break;
 			case S_IWRITE + S_IEXEC:
 				allow = ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0)
-				    && ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
+					&& ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
 				break;
 			case S_IREAD:
 				allow = (perm & (S_IRUSR | S_IRGRP | S_IROTH)) != 0;
 				break;
 			case S_IREAD + S_IEXEC:
 				allow = ((perm & (S_IRUSR | S_IRGRP | S_IROTH)) != 0)
-				    && ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
+					&& ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
 				break;
 			case S_IREAD + S_IWRITE:
 				allow = ((perm & (S_IRUSR | S_IRGRP | S_IROTH)) != 0)
-				    && ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0);
+					&& ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0);
 				break;
 			case S_IWRITE + S_IEXEC + S_ISVTX:
 				if (perm & S_ISVTX) {
 					if ((ntfs_get_owner_mode(scx,ni,&stbuf) >= 0)
-					    && (stbuf.st_uid == scx->uid))
+							&& (stbuf.st_uid == scx->uid))
 						allow = 1;
 					else
 						allow = 2;
 				} else
 					allow = ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0)
-					    && ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
+						&& ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
 				break;
 			case S_IREAD + S_IWRITE + S_IEXEC:
 				allow = ((perm & (S_IRUSR | S_IRGRP | S_IROTH)) != 0)
-				    && ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0)
-				    && ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
+					&& ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0)
+					&& ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
 				break;
 			default :
 				res = EINVAL;
@@ -3542,14 +3542,14 @@ int ntfs_allowed_create(struct SECURITY_CONTEXT *scx,
 	else
 		perm = ntfs_get_perm(scx, dir_ni, S_IWRITE + S_IEXEC);
 	if (!scx->mapping[MAPUSERS]
-	    || !scx->uid) {
+			|| !scx->uid) {
 		allow = 1;
 	} else {
 		perm = ntfs_get_perm(scx, dir_ni, S_IWRITE + S_IEXEC);
 		if (perm >= 0) {
 			res = EACCES;
 			allow = ((perm & (S_IWUSR | S_IWGRP | S_IWOTH)) != 0)
-				    && ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
+				&& ((perm & (S_IXUSR | S_IXGRP | S_IXOTH)) != 0);
 			if (!allow)
 				errno = res;
 		} else
@@ -3557,7 +3557,7 @@ int ntfs_allowed_create(struct SECURITY_CONTEXT *scx,
 	}
 	*pgid = scx->gid;
 	*pdsetgid = 0;
-		/* return directory group if S_ISGID is set */
+	/* return directory group if S_ISGID is set */
 	if (allow && (perm & S_ISGID)) {
 		if (ntfs_get_owner_mode(scx, dir_ni, &stbuf) >= 0) {
 			*pdsetgid = stbuf.st_mode & S_ISGID;
@@ -3602,21 +3602,21 @@ BOOL old_ntfs_allowed_dir_access(struct SECURITY_CONTEXT *scx,
 		dir_ni = ntfs_pathname_to_inode(scx->vol, NULL, dirpath);
 		if (dir_ni) {
 			allow = ntfs_allowed_access(scx,
-				 dir_ni, accesstype);
+					dir_ni, accesstype);
 			ntfs_inode_close(dir_ni);
-				/*
-				 * for an not-owned sticky directory, have to
-				 * check whether file itself is owned
-				 */
+			/*
+			 * for an not-owned sticky directory, have to
+			 * check whether file itself is owned
+			 */
 			if ((accesstype == (S_IWRITE + S_IEXEC + S_ISVTX))
-			   && (allow == 2)) {
+					&& (allow == 2)) {
 				ni = ntfs_pathname_to_inode(scx->vol, NULL,
-					 path);
+						path);
 				allow = FALSE;
 				if (ni) {
 					allow = (ntfs_get_owner_mode(scx,ni,&stbuf) >= 0)
 						&& (stbuf.st_uid == scx->uid);
-				ntfs_inode_close(ni);
+					ntfs_inode_close(ni);
 				}
 			}
 		}
@@ -3634,7 +3634,7 @@ BOOL old_ntfs_allowed_dir_access(struct SECURITY_CONTEXT *scx,
  */
 
 int ntfs_set_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			uid_t uid, gid_t gid)
+		uid_t uid, gid_t gid)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *phead;
 	const struct CACHED_PERMISSIONS *cached;
@@ -3695,7 +3695,7 @@ int ntfs_set_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 				res = -1;
 #else
 			mode = perm = ntfs_build_permissions(oldattr,
-					 usid, gsid, isdir);
+					usid, gsid, isdir);
 			if (perm >= 0) {
 				fileuid = ntfs_find_user(scx->mapping[MAPUSERS],usid);
 				filegid = ntfs_find_group(scx->mapping[MAPGROUPS],gsid);
@@ -3710,9 +3710,9 @@ int ntfs_set_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 		/* check requested by root */
 		/* or chgrp requested by owner to an owned group */
 		if (!scx->uid
-		   || ((((int)uid < 0) || (uid == fileuid))
-		      && ((gid == scx->gid) || groupmember(scx, scx->uid, gid))
-		      && (fileuid == scx->uid))) {
+				|| ((((int)uid < 0) || (uid == fileuid))
+					&& ((gid == scx->gid) || groupmember(scx, scx->uid, gid))
+					&& (fileuid == scx->uid))) {
 			/* replace by the new usid and gsid */
 			/* or reuse old gid and sid for cacheing */
 			if ((int)uid < 0)
@@ -3721,13 +3721,13 @@ int ntfs_set_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 				gid = filegid;
 #if !defined(__sun) || !defined (__SVR4)
 			/* clear setuid and setgid if owner has changed */
-                        /* unless request originated by root */
+			/* unless request originated by root */
 			if (uid && (fileuid != uid))
 				mode &= 01777;
 #endif
 #if POSIXACLS
 			res = ntfs_set_owner_mode(scx, ni, uid, gid,
-				mode, pxdesc);
+					mode, pxdesc);
 #else
 			res = ntfs_set_owner_mode(scx, ni, uid, gid, mode);
 #endif
@@ -3758,7 +3758,7 @@ int ntfs_set_owner(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
  */
 
 int ntfs_set_ownmod(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
-			uid_t uid, gid_t gid, const mode_t mode)
+		uid_t uid, gid_t gid, const mode_t mode)
 {
 	const struct CACHED_PERMISSIONS *cached;
 	char *oldattr;
@@ -3785,7 +3785,7 @@ int ntfs_set_ownmod(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 #if POSIXACLS
 		oldpxdesc = cached->pxdesc;
 		if (oldpxdesc) {
-				/* must copy before merging */
+			/* must copy before merging */
 			pxsize = sizeof(struct POSIX_SECURITY)
 				+ (oldpxdesc->acccnt + oldpxdesc->defcnt)*sizeof(struct POSIX_ACE);
 			newpxdesc = (struct POSIX_SECURITY*)malloc(pxsize);
@@ -3832,9 +3832,9 @@ int ntfs_set_ownmod(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 		/* check requested by root */
 		/* or chgrp requested by owner to an owned group */
 		if (!scx->uid
-		   || ((((int)uid < 0) || (uid == fileuid))
-		      && ((gid == scx->gid) || groupmember(scx, scx->uid, gid))
-		      && (fileuid == scx->uid))) {
+				|| ((((int)uid < 0) || (uid == fileuid))
+					&& ((gid == scx->gid) || groupmember(scx, scx->uid, gid))
+					&& (fileuid == scx->uid))) {
 			/* replace by the new usid and gsid */
 			/* or reuse old gid and sid for cacheing */
 			if ((int)uid < 0)
@@ -3843,7 +3843,7 @@ int ntfs_set_ownmod(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
 				gid = filegid;
 #if POSIXACLS
 			res = ntfs_set_owner_mode(scx, ni, uid, gid,
-				mode, newpxdesc);
+					mode, newpxdesc);
 #else
 			res = ntfs_set_owner_mode(scx, ni, uid, gid, mode);
 #endif
@@ -3872,7 +3872,7 @@ int ntfs_set_ownmod(struct SECURITY_CONTEXT *scx, ntfs_inode *ni,
  */
 
 static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
-			const char *parentattr, BOOL fordir)
+		const char *parentattr, BOOL fordir)
 {
 	const SECURITY_DESCRIPTOR_RELATIVE *pphead;
 	const ACL *ppacl;
@@ -3899,7 +3899,7 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
 		usid = ntfs_find_usid(scx->mapping[MAPUSERS], scx->uid, (SID*)&defusid);
 		gsid = ntfs_find_gsid(scx->mapping[MAPGROUPS], scx->gid, (SID*)&defgsid);
 #if OWNERFROMACL
-			/* Get approximation of parent owner when cannot map */
+		/* Get approximation of parent owner when cannot map */
 		if (!gsid)
 			gsid = adminsid;
 		if (!usid) {
@@ -3908,7 +3908,7 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
 				gsid = usid;
 		}
 #else
-			/* Define owner as root when cannot map */
+		/* Define owner as root when cannot map */
 		if (!usid)
 			usid = adminsid;
 		if (!gsid)
@@ -3941,14 +3941,14 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
 			gsid = (const SID*)&parentattr[offgroup];
 		}
 	}
-		/*
-		 * new attribute is smaller than parent's
-		 * except for differences in SIDs which appear in
-		 * owner, group and possible grants and denials in
-		 * generic creator-owner and creator-group ACEs.
-		 * For directories, an ACE may be duplicated for
-		 * access and inheritance, so we double the count.
-		 */
+	/*
+	 * new attribute is smaller than parent's
+	 * except for differences in SIDs which appear in
+	 * owner, group and possible grants and denials in
+	 * generic creator-owner and creator-group ACEs.
+	 * For directories, an ACE may be duplicated for
+	 * access and inheritance, so we double the count.
+	 */
 	usidsz = ntfs_sid_size(usid);
 	gsidsz = ntfs_sid_size(gsid);
 	newattrsz = parentattrsz + 3*usidsz + 3*gsidsz;
@@ -3960,20 +3960,20 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
 		pnhead->revision = SECURITY_DESCRIPTOR_REVISION;
 		pnhead->alignment = 0;
 		pnhead->control = (pphead->control
-			& (SE_DACL_AUTO_INHERITED | SE_SACL_AUTO_INHERITED))
-				| SE_SELF_RELATIVE;
+				& (SE_DACL_AUTO_INHERITED | SE_SACL_AUTO_INHERITED))
+			| SE_SELF_RELATIVE;
 		pos = sizeof(SECURITY_DESCRIPTOR_RELATIVE);
-			/*
-			 * locate and inherit DACL
-			 * do not test SE_DACL_PRESENT (wrong for "DR Watson")
-			 */
+		/*
+		 * locate and inherit DACL
+		 * do not test SE_DACL_PRESENT (wrong for "DR Watson")
+		 */
 		pnhead->dacl = const_cpu_to_le32(0);
 		if (pphead->dacl) {
 			offpacl = le32_to_cpu(pphead->dacl);
 			ppacl = (const ACL*)&parentattr[offpacl];
 			pnacl = (ACL*)&newattr[pos];
 			aclsz = ntfs_inherit_acl(ppacl, pnacl, usid, gsid,
-				fordir, pphead->control
+					fordir, pphead->control
 					& SE_DACL_AUTO_INHERITED);
 			if (aclsz) {
 				pnhead->dacl = cpu_to_le32(pos);
@@ -3981,16 +3981,16 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
 				pnhead->control |= SE_DACL_PRESENT;
 			}
 		}
-			/*
-			 * locate and inherit SACL
-			 */
+		/*
+		 * locate and inherit SACL
+		 */
 		pnhead->sacl = const_cpu_to_le32(0);
 		if (pphead->sacl) {
 			offpacl = le32_to_cpu(pphead->sacl);
 			ppacl = (const ACL*)&parentattr[offpacl];
 			pnacl = (ACL*)&newattr[pos];
 			aclsz = ntfs_inherit_acl(ppacl, pnacl, usid, gsid,
-				fordir, pphead->control
+					fordir, pphead->control
 					& SE_SACL_AUTO_INHERITED);
 			if (aclsz) {
 				pnhead->sacl = cpu_to_le32(pos);
@@ -3998,20 +3998,20 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
 				pnhead->control |= SE_SACL_PRESENT;
 			}
 		}
-			/*
-			 * inherit or redefine owner
-			 */
+		/*
+		 * inherit or redefine owner
+		 */
 		memcpy(&newattr[pos],usid,usidsz);
 		pnhead->owner = cpu_to_le32(pos);
 		pos += usidsz;
-			/*
-			 * inherit or redefine group
-			 */
+		/*
+		 * inherit or redefine group
+		 */
 		memcpy(&newattr[pos],gsid,gsidsz);
 		pnhead->group = cpu_to_le32(pos);
 		pos += gsidsz;
 		securid = setsecurityattr(scx->vol,
-			(SECURITY_DESCRIPTOR_RELATIVE*)newattr, pos);
+				(SECURITY_DESCRIPTOR_RELATIVE*)newattr, pos);
 		free(newattr);
 	} else
 		securid = const_cpu_to_le32(0);
@@ -4035,7 +4035,7 @@ static le32 build_inherited_id(struct SECURITY_CONTEXT *scx,
  */
 
 le32 ntfs_inherited_id(struct SECURITY_CONTEXT *scx,
-			ntfs_inode *dir_ni, BOOL fordir)
+		ntfs_inode *dir_ni, BOOL fordir)
 {
 	struct CACHED_PERMISSIONS *cached;
 	char *parentattr;
@@ -4043,27 +4043,27 @@ le32 ntfs_inherited_id(struct SECURITY_CONTEXT *scx,
 
 	securid = const_cpu_to_le32(0);
 	cached = (struct CACHED_PERMISSIONS*)NULL;
-		/*
-		 * Try to get inherited id from cache, possible when
-		 * the current process owns the parent directory
-		 */
+	/*
+	 * Try to get inherited id from cache, possible when
+	 * the current process owns the parent directory
+	 */
 	if (test_nino_flag(dir_ni, v3_Extensions)
 			&& dir_ni->security_id) {
 		cached = fetch_cache(scx, dir_ni);
 		if (cached
-		    && (cached->uid == scx->uid) && (cached->gid == scx->gid))
+				&& (cached->uid == scx->uid) && (cached->gid == scx->gid))
 			securid = (fordir ? cached->inh_dirid
 					: cached->inh_fileid);
 	}
-		/*
-		 * Not cached or not available in cache, compute it all
-		 * Note : if parent directory has no id, it is not cacheable
-		 */
+	/*
+	 * Not cached or not available in cache, compute it all
+	 * Note : if parent directory has no id, it is not cacheable
+	 */
 	if (!securid) {
 		parentattr = getsecurityattr(scx->vol, dir_ni);
 		if (parentattr) {
 			securid = build_inherited_id(scx,
-						parentattr, fordir);
+					parentattr, fordir);
 			free(parentattr);
 			/*
 			 * Store the result into cache for further use
@@ -4072,8 +4072,8 @@ le32 ntfs_inherited_id(struct SECURITY_CONTEXT *scx,
 			if (securid) {
 				cached = fetch_cache(scx, dir_ni);
 				if (cached
-				    && (cached->uid == scx->uid)
-				    && (cached->gid == scx->gid)) {
+						&& (cached->uid == scx->uid)
+						&& (cached->gid == scx->gid)) {
 					if (fordir)
 						cached->inh_dirid = securid;
 					else
@@ -4092,7 +4092,7 @@ le32 ntfs_inherited_id(struct SECURITY_CONTEXT *scx,
  */
 
 static int link_single_group(struct MAPPING *usermapping, struct passwd *user,
-			gid_t gid)
+		gid_t gid)
 {
 	struct group *group;
 	char **grmem;
@@ -4113,7 +4113,7 @@ static int link_single_group(struct MAPPING *usermapping, struct passwd *user,
 				groups = (gid_t*)malloc(sizeof(gid_t));
 			else
 				groups = (gid_t*)realloc(groups,
-					(grcnt+1)*sizeof(gid_t));
+						(grcnt+1)*sizeof(gid_t));
 			if (groups)
 				groups[grcnt++]	= gid;
 			else {
@@ -4158,11 +4158,11 @@ static int link_group_members(struct SECURITY_CONTEXT *scx)
 					groupmapping && !res;
 					groupmapping=groupmapping->next) {
 				if (link_single_group(usermapping, user,
-				    groupmapping->xid))
+							groupmapping->xid))
 					res = -1;
-				}
+			}
 			if (!res && link_single_group(usermapping,
-					 user, (gid_t)0))
+						user, (gid_t)0))
 				res = -1;
 		}
 	}
@@ -4175,7 +4175,7 @@ static int link_group_members(struct SECURITY_CONTEXT *scx)
  */
 
 static int ntfs_do_default_mapping(struct SECURITY_CONTEXT *scx,
-			 uid_t uid, gid_t gid, const SID *usid)
+		uid_t uid, gid_t gid, const SID *usid)
 {
 	struct MAPPING *usermapping = NULL;
 	struct MAPPING *groupmapping = NULL;
@@ -4307,7 +4307,7 @@ static int basicread(void *fileid, char *buf, size_t size, off_t offs __attribut
 static int localread(void *fileid, char *buf, size_t size, off_t offs)
 {
 	return (ntfs_attr_data_read((ntfs_inode*)fileid,
-			AT_UNNAMED, 0, buf, size, offs));
+				AT_UNNAMED, 0, buf, size, offs));
 }
 
 /*
@@ -4323,7 +4323,7 @@ static int localread(void *fileid, char *buf, size_t size, off_t offs)
  */
 
 int ntfs_build_mapping(struct SECURITY_CONTEXT *scx, const char *usermap_path,
-			BOOL allowdef)
+		BOOL allowdef)
 {
 	struct MAPLIST *item;
 	struct MAPLIST *firstitem;
@@ -4394,10 +4394,10 @@ int ntfs_build_mapping(struct SECURITY_CONTEXT *scx, const char *usermap_path,
 			firstitem = item;
 		}
 	} else {
-			/* no mapping file, try a default mapping */
+		/* no mapping file, try a default mapping */
 		if (allowdef) {
 			if (!ntfs_do_default_mapping(scx,
-					0, 0, (const SID*)&defmap))
+						0, 0, (const SID*)&defmap))
 				ntfs_log_info("Using default user mapping\n");
 		}
 	}
@@ -4443,7 +4443,7 @@ int ntfs_get_ntfs_attrib(ntfs_inode *ni, char *value, size_t size)
  */
 
 int ntfs_set_ntfs_attrib(ntfs_inode *ni,
-			const char *value, size_t size,	int flags)
+		const char *value, size_t size,	int flags)
 {
 	u32 attrib;
 	le32 settable;
@@ -4464,21 +4464,21 @@ int ntfs_set_ntfs_attrib(ntfs_inode *ni,
 				 */
 				settable |= FILE_ATTR_COMPRESSED;
 				if ((ni->flags ^ cpu_to_le32(attrib))
-				             & FILE_ATTR_COMPRESSED) {
+						& FILE_ATTR_COMPRESSED) {
 					if (ni->flags & FILE_ATTR_COMPRESSED)
 						dirflags = const_cpu_to_le16(0);
 					else
 						dirflags = ATTR_IS_COMPRESSED;
 					res = ntfs_attr_set_flags(ni,
-						AT_INDEX_ROOT,
-					        NTFS_INDEX_I30, 4,
-						dirflags,
-						ATTR_COMPRESSION_MASK);
+							AT_INDEX_ROOT,
+							NTFS_INDEX_I30, 4,
+							dirflags,
+							ATTR_COMPRESSION_MASK);
 				}
 			}
 			if (!res) {
 				ni->flags = (ni->flags & ~settable)
-					 | (cpu_to_le32(attrib) & settable);
+					| (cpu_to_le32(attrib) & settable);
 				NInoFileNameSetDirty(ni);
 				NInoSetDirty(ni);
 			}
@@ -4610,7 +4610,7 @@ static BOOL feedsecurityattr(const char *attr, u32 selection,
 	phead = (const SECURITY_DESCRIPTOR_RELATIVE*)attr;
 	size = sizeof(SECURITY_DESCRIPTOR_RELATIVE);
 
-		/* locate DACL if requested and available */
+	/* locate DACL if requested and available */
 	if (phead->dacl && (selection & DACL_SECURITY_INFORMATION)) {
 		offdacl = le32_to_cpu(phead->dacl);
 		pdacl = (const ACL*)&attr[offdacl];
@@ -4620,10 +4620,10 @@ static BOOL feedsecurityattr(const char *attr, u32 selection,
 	} else
 		offdacl = daclsz = 0;
 
-		/* locate owner if requested and available */
+	/* locate owner if requested and available */
 	offowner = le32_to_cpu(phead->owner);
 	if (offowner && (selection & OWNER_SECURITY_INFORMATION)) {
-			/* find end of USID */
+		/* find end of USID */
 		pusid = (const SID*)&attr[offowner];
 		usidsz = ntfs_sid_size(pusid);
 		size += usidsz;
@@ -4631,10 +4631,10 @@ static BOOL feedsecurityattr(const char *attr, u32 selection,
 	} else
 		offowner = usidsz = 0;
 
-		/* locate group if requested and available */
+	/* locate group if requested and available */
 	offgroup = le32_to_cpu(phead->group);
 	if (offgroup && (selection & GROUP_SECURITY_INFORMATION)) {
-			/* find end of GSID */
+		/* find end of GSID */
 		pgsid = (const SID*)&attr[offgroup];
 		gsidsz = ntfs_sid_size(pgsid);
 		size += gsidsz;
@@ -4642,9 +4642,9 @@ static BOOL feedsecurityattr(const char *attr, u32 selection,
 	} else
 		offgroup = gsidsz = 0;
 
-		/* locate SACL if requested and available */
+	/* locate SACL if requested and available */
 	if (phead->sacl && (selection & SACL_SECURITY_INFORMATION)) {
-			/* find end of SACL */
+		/* find end of SACL */
 		offsacl = le32_to_cpu(phead->sacl);
 		psacl = (const ACL*)&attr[offsacl];
 		saclsz = le16_to_cpu(psacl->size);
@@ -4653,11 +4653,11 @@ static BOOL feedsecurityattr(const char *attr, u32 selection,
 	} else
 		offsacl = saclsz = 0;
 
-		/*
-		 * Check having enough size in destination buffer
-		 * (required size is returned nevertheless so that
-		 * the request can be reissued with adequate size)
-		 */
+	/*
+	 * Check having enough size in destination buffer
+	 * (required size is returned nevertheless so that
+	 * the request can be reissued with adequate size)
+	 */
 	if (size > buflen) {
 		*psize = size;
 		errno = EINVAL;
@@ -4669,16 +4669,16 @@ static BOOL feedsecurityattr(const char *attr, u32 selection,
 			control |= phead->control & SE_GROUP_DEFAULTED;
 		if (selection & DACL_SECURITY_INFORMATION)
 			control |= phead->control
-					& (SE_DACL_PRESENT
-					   | SE_DACL_DEFAULTED
-					   | SE_DACL_AUTO_INHERITED
-					   | SE_DACL_PROTECTED);
+				& (SE_DACL_PRESENT
+						| SE_DACL_DEFAULTED
+						| SE_DACL_AUTO_INHERITED
+						| SE_DACL_PROTECTED);
 		if (selection & SACL_SECURITY_INFORMATION)
 			control |= phead->control
-					& (SE_SACL_PRESENT
-					   | SE_SACL_DEFAULTED
-					   | SE_SACL_AUTO_INHERITED
-					   | SE_SACL_PROTECTED);
+				& (SE_SACL_PRESENT
+						| SE_SACL_DEFAULTED
+						| SE_SACL_AUTO_INHERITED
+						| SE_SACL_PROTECTED);
 		/*
 		 * copy header and feed new flags, even if no detailed data
 		 */
@@ -4766,10 +4766,10 @@ static BOOL mergesecurityattr(ntfs_volume *vol, const char *oldattr,
 		targhead = (SECURITY_DESCRIPTOR_RELATIVE*)target;
 		pos = sizeof(SECURITY_DESCRIPTOR_RELATIVE);
 		control = SE_SELF_RELATIVE;
-			/*
-			 * copy new DACL if selected
-			 * or keep old DACL if any
-			 */
+		/*
+		 * copy new DACL if selected
+		 * or keep old DACL if any
+		 */
 		if ((selection & DACL_SECURITY_INFORMATION) ?
 				newhead->dacl : oldhead->dacl) {
 			if (selection & DACL_SECURITY_INFORMATION) {
@@ -4787,21 +4787,21 @@ static BOOL mergesecurityattr(ntfs_volume *vol, const char *oldattr,
 			targhead->dacl = const_cpu_to_le32(0);
 		if (selection & DACL_SECURITY_INFORMATION) {
 			control |= newhead->control
-					& (SE_DACL_PRESENT
-					   | SE_DACL_DEFAULTED
-					   | SE_DACL_PROTECTED);
+				& (SE_DACL_PRESENT
+						| SE_DACL_DEFAULTED
+						| SE_DACL_PROTECTED);
 			if (newhead->control & SE_DACL_AUTO_INHERIT_REQ)
 				control |= SE_DACL_AUTO_INHERITED;
 		} else
 			control |= oldhead->control
-					& (SE_DACL_PRESENT
-					   | SE_DACL_DEFAULTED
-					   | SE_DACL_AUTO_INHERITED
-					   | SE_DACL_PROTECTED);
-			/*
-			 * copy new SACL if selected
-			 * or keep old SACL if any
-			 */
+				& (SE_DACL_PRESENT
+						| SE_DACL_DEFAULTED
+						| SE_DACL_AUTO_INHERITED
+						| SE_DACL_PROTECTED);
+		/*
+		 * copy new SACL if selected
+		 * or keep old SACL if any
+		 */
 		if ((selection & SACL_SECURITY_INFORMATION) ?
 				newhead->sacl : oldhead->sacl) {
 			if (selection & SACL_SECURITY_INFORMATION) {
@@ -4819,21 +4819,21 @@ static BOOL mergesecurityattr(ntfs_volume *vol, const char *oldattr,
 			targhead->sacl = const_cpu_to_le32(0);
 		if (selection & SACL_SECURITY_INFORMATION) {
 			control |= newhead->control
-					& (SE_SACL_PRESENT
-					   | SE_SACL_DEFAULTED
-					   | SE_SACL_PROTECTED);
+				& (SE_SACL_PRESENT
+						| SE_SACL_DEFAULTED
+						| SE_SACL_PROTECTED);
 			if (newhead->control & SE_SACL_AUTO_INHERIT_REQ)
 				control |= SE_SACL_AUTO_INHERITED;
 		} else
 			control |= oldhead->control
-					& (SE_SACL_PRESENT
-					   | SE_SACL_DEFAULTED
-					   | SE_SACL_AUTO_INHERITED
-					   | SE_SACL_PROTECTED);
-			/*
-			 * copy new OWNER if selected
-			 * or keep old OWNER if any
-			 */
+				& (SE_SACL_PRESENT
+						| SE_SACL_DEFAULTED
+						| SE_SACL_AUTO_INHERITED
+						| SE_SACL_PROTECTED);
+		/*
+		 * copy new OWNER if selected
+		 * or keep old OWNER if any
+		 */
 		if ((selection & OWNER_SECURITY_INFORMATION) ?
 				newhead->owner : oldhead->owner) {
 			if (selection & OWNER_SECURITY_INFORMATION) {
@@ -4853,22 +4853,22 @@ static BOOL mergesecurityattr(ntfs_volume *vol, const char *oldattr,
 			control |= newhead->control & SE_OWNER_DEFAULTED;
 		else
 			control |= oldhead->control & SE_OWNER_DEFAULTED;
-			/*
-			 * copy new GROUP if selected
-			 * or keep old GROUP if any
-			 */
+		/*
+		 * copy new GROUP if selected
+		 * or keep old GROUP if any
+		 */
 		if ((selection & GROUP_SECURITY_INFORMATION) ?
 				newhead->group : oldhead->group) {
 			if (selection & GROUP_SECURITY_INFORMATION) {
 				offgroup = le32_to_cpu(newhead->group);
 				pgroup = (const SID*)&newattr[offgroup];
 				control |= newhead->control
-						 & SE_GROUP_DEFAULTED;
+					& SE_GROUP_DEFAULTED;
 			} else {
 				offgroup = le32_to_cpu(oldhead->group);
 				pgroup = (const SID*)&oldattr[offgroup];
 				control |= oldhead->control
-						 & SE_GROUP_DEFAULTED;
+					& SE_GROUP_DEFAULTED;
 			}
 			size = ntfs_sid_size(pgroup);
 			memcpy(&target[pos], pgroup, size);
@@ -4925,11 +4925,11 @@ int ntfs_get_file_security(struct SECURITY_API *scapi,
 			attr = getsecurityattr(scapi->security.vol, ni);
 			if (attr) {
 				if (feedsecurityattr(attr,selection,
-						buf,buflen,psize)) {
+							buf,buflen,psize)) {
 					if (test_nino_flag(ni, v3_Extensions)
-					    && ni->security_id)
+							&& ni->security_id)
 						res = le32_to_cpu(
-							ni->security_id);
+								ni->security_id);
 					else
 						res = -1;
 				}
@@ -4982,25 +4982,25 @@ int ntfs_set_file_security(struct SECURITY_API *scapi,
 				&& !phead->owner
 				&& !(phead->control & SE_OWNER_DEFAULTED))
 			|| ((selection & GROUP_SECURITY_INFORMATION)
-				&& !phead->group
-				&& !(phead->control & SE_GROUP_DEFAULTED));
+					&& !phead->group
+					&& !(phead->control & SE_GROUP_DEFAULTED));
 		if (!missing
-		    && (phead->control & SE_SELF_RELATIVE)
-		    && ntfs_valid_descr(attr, attrsz)) {
+				&& (phead->control & SE_SELF_RELATIVE)
+				&& ntfs_valid_descr(attr, attrsz)) {
 			ni = ntfs_pathname_to_inode(scapi->security.vol,
-				NULL, path);
+					NULL, path);
 			if (ni) {
 				oldattr = getsecurityattr(scapi->security.vol,
 						ni);
 				if (oldattr) {
 					if (mergesecurityattr(
-						scapi->security.vol,
-						oldattr, attr,
-						selection, ni)) {
+								scapi->security.vol,
+								oldattr, attr,
+								selection, ni)) {
 						if (test_nino_flag(ni,
-							    v3_Extensions))
+									v3_Extensions))
 							res = le32_to_cpu(
-							    ni->security_id);
+									ni->security_id);
 						else
 							res = -1;
 					}
@@ -5094,21 +5094,21 @@ BOOL ntfs_set_file_attributes(struct SECURITY_API *scapi,
 				 */
 				settable |= FILE_ATTR_COMPRESSED;
 				if ((ni->flags ^ cpu_to_le32(attrib))
-				             & FILE_ATTR_COMPRESSED) {
+						& FILE_ATTR_COMPRESSED) {
 					if (ni->flags & FILE_ATTR_COMPRESSED)
 						dirflags = const_cpu_to_le16(0);
 					else
 						dirflags = ATTR_IS_COMPRESSED;
 					res = ntfs_attr_set_flags(ni,
-						AT_INDEX_ROOT,
-					        NTFS_INDEX_I30, 4,
-						dirflags,
-						ATTR_COMPRESSION_MASK);
+							AT_INDEX_ROOT,
+							NTFS_INDEX_I30, 4,
+							dirflags,
+							ATTR_COMPRESSION_MASK);
 				}
 			}
 			if (!res) {
 				ni->flags = (ni->flags & ~settable)
-					 | (cpu_to_le32(attrib) & settable);
+					| (cpu_to_le32(attrib) & settable);
 				NInoSetDirty(ni);
 				NInoFileNameSetDirty(ni);
 			}
@@ -5162,7 +5162,7 @@ int ntfs_read_sds(struct SECURITY_API *scapi,
 	if (scapi && (scapi->magic == MAGIC_API)) {
 		if (scapi->security.vol->secure_ni)
 			got = ntfs_attr_data_read(scapi->security.vol->secure_ni,
-				STREAM_SDS, 4, buf, size, offset);
+					STREAM_SDS, 4, buf, size, offset);
 		else
 			errno = EOPNOTSUPP;
 	} else
@@ -5357,7 +5357,7 @@ int ntfs_get_group(struct SECURITY_API *scapi, const SID *gsid)
  */
 
 struct SECURITY_API *ntfs_initialize_file_security(const char *device,
-				unsigned long flags)
+		unsigned long flags)
 {
 	ntfs_volume *vol;
 	unsigned long mntflag;
@@ -5373,7 +5373,7 @@ struct SECURITY_API *ntfs_initialize_file_security(const char *device,
 			scapi = (struct SECURITY_API*)
 				ntfs_malloc(sizeof(struct SECURITY_API));
 			if (!ntfs_volume_get_free_space(vol)
-			    && scapi) {
+					&& scapi) {
 				scapi->magic = MAGIC_API;
 				scapi->seccache = (struct PERMISSIONS_CACHE*)NULL;
 				scx = &scapi->security;
@@ -5382,7 +5382,7 @@ struct SECURITY_API *ntfs_initialize_file_security(const char *device,
 				scx->gid = getgid();
 				scx->pseccache = &scapi->seccache;
 				scx->vol->secure_flags = 0;
-					/* accept no mapping and no $Secure */
+				/* accept no mapping and no $Secure */
 				ntfs_build_mapping(scx,(const char*)NULL,TRUE);
 			} else {
 				if (scapi)
@@ -5417,7 +5417,7 @@ BOOL ntfs_leave_file_security(struct SECURITY_API *scapi)
 		vol = scapi->security.vol;
 		ntfs_destroy_security_context(&scapi->security);
 		free(scapi);
- 		if (!ntfs_umount(vol, 0))
+		if (!ntfs_umount(vol, 0))
 			ok = TRUE;
 	}
 	return (ok);

--- a/libntfs/unistr.c
+++ b/libntfs/unistr.c
@@ -133,7 +133,7 @@ BOOL ntfs_names_are_equal(const ntfschar *s1, size_t s1_len,
 	if (ic == CASE_SENSITIVE)
 		return ntfs_ucsncmp(s1, s2, s1_len) ? FALSE: TRUE;
 	return ntfs_ucsncasecmp(s1, s2, s1_len, upcase, upcase_size) ? FALSE:
-								       TRUE;
+		TRUE;
 }
 
 /*
@@ -549,7 +549,7 @@ fail:
  * Return -1 with errno set if string has invalid byte sequence or too long.
  */
 static int ntfs_utf16_to_utf8(const ntfschar *ins, const int ins_len,
-			      char **outs, int outs_len)
+		char **outs, int outs_len)
 {
 #if defined(__APPLE__) || defined(__DARWIN__)
 #ifdef ENABLE_NFCONV
@@ -587,8 +587,8 @@ static int ntfs_utf16_to_utf8(const ntfschar *ins, const int ins_len,
 	t = *outs;
 
 	for (i = 0; i < ins_len && ins[i]; i++) {
-	    unsigned short c = le16_to_cpu(ins[i]);
-			/* size not double-checked */
+		unsigned short c = le16_to_cpu(ins[i]);
+		/* size not double-checked */
 		if (halfpair) {
 			if ((c >= 0xdc00) && (c < 0xe000)) {
 				*t++ = 0xf0 + (((halfpair + 64) >> 8) & 7);
@@ -616,14 +616,14 @@ static int ntfs_utf16_to_utf8(const ntfschar *ins, const int ins_len,
 			}
 		} else if (c < 0x80) {
 			*t++ = c;
-	    	} else {
+		} else {
 			if (c < 0x800) {
-			   	*t++ = (0xc0 | ((c >> 6) & 0x3f));
-			        *t++ = 0x80 | (c & 0x3f);
+				*t++ = (0xc0 | ((c >> 6) & 0x3f));
+				*t++ = 0x80 | (c & 0x3f);
 			} else if (c < 0xd800) {
-			   	*t++ = 0xe0 | (c >> 12);
-			   	*t++ = 0x80 | ((c >> 6) & 0x3f);
-		        	*t++ = 0x80 | (c & 0x3f);
+				*t++ = 0xe0 | (c >> 12);
+				*t++ = 0x80 | ((c >> 6) & 0x3f);
+				*t++ = 0x80 | (c & 0x3f);
 			} else if (c < 0xdc00)
 				halfpair = c;
 #if ALLOW_BROKEN_UNICODE
@@ -636,10 +636,10 @@ static int ntfs_utf16_to_utf8(const ntfschar *ins, const int ins_len,
 			else if (c >= 0xe000) {
 				*t++ = 0xe0 | (c >> 12);
 				*t++ = 0x80 | ((c >> 6) & 0x3f);
-			        *t++ = 0x80 | (c & 0x3f);
+				*t++ = 0x80 | (c & 0x3f);
 			} else
 				goto fail;
-	        }
+		}
 	}
 #if ALLOW_BROKEN_UNICODE
 	if (halfpair) { /* ending with a single surrogate */
@@ -743,52 +743,52 @@ fail:
  */
 static int utf8_to_unicode(u32 *wc, const char *s)
 {
-    	unsigned int byte = *((const unsigned char *)s);
+	unsigned int byte = *((const unsigned char *)s);
 
-					/* single byte */
+	/* single byte */
 	if (byte == 0) {
 		*wc = (u32) 0;
 		return 0;
 	} else if (byte < 0x80) {
 		*wc = (u32) byte;
 		return 1;
-					/* double byte */
+		/* double byte */
 	} else if (byte < 0xc2) {
 		goto fail;
 	} else if (byte < 0xE0) {
 		if ((s[1] & 0xC0) == 0x80) {
 			*wc = ((u32)(byte & 0x1F) << 6)
-			    | ((u32)(s[1] & 0x3F));
+				| ((u32)(s[1] & 0x3F));
 			return 2;
 		} else
 			goto fail;
-					/* three-byte */
+		/* three-byte */
 	} else if (byte < 0xF0) {
 		if (((s[1] & 0xC0) == 0x80) && ((s[2] & 0xC0) == 0x80)) {
 			*wc = ((u32)(byte & 0x0F) << 12)
-			    | ((u32)(s[1] & 0x3F) << 6)
-			    | ((u32)(s[2] & 0x3F));
+				| ((u32)(s[1] & 0x3F) << 6)
+				| ((u32)(s[2] & 0x3F));
 			/* Check valid ranges */
 #if ALLOW_BROKEN_UNICODE
 			if (((*wc >= 0x800) && (*wc <= 0xD7FF))
-			  || ((*wc >= 0xD800) && (*wc <= 0xDFFF))
-			  || ((*wc >= 0xe000) && (*wc <= 0xFFFF)))
+					|| ((*wc >= 0xD800) && (*wc <= 0xDFFF))
+					|| ((*wc >= 0xe000) && (*wc <= 0xFFFF)))
 				return 3;
 #else
 			if (((*wc >= 0x800) && (*wc <= 0xD7FF))
-			  || ((*wc >= 0xe000) && (*wc <= 0xFFFD)))
+					|| ((*wc >= 0xe000) && (*wc <= 0xFFFD)))
 				return 3;
 #endif /* ALLOW_BROKEN_UNICODE */
 		}
 		goto fail;
-					/* four-byte */
+		/* four-byte */
 	} else if (byte < 0xF5) {
 		if (((s[1] & 0xC0) == 0x80) && ((s[2] & 0xC0) == 0x80)
-		  && ((s[3] & 0xC0) == 0x80)) {
+				&& ((s[3] & 0xC0) == 0x80)) {
 			*wc = ((u32)(byte & 0x07) << 18)
-			    | ((u32)(s[1] & 0x3F) << 12)
-			    | ((u32)(s[2] & 0x3F) << 6)
-			    | ((u32)(s[3] & 0x3F));
+				| ((u32)(s[1] & 0x3F) << 12)
+				| ((u32)(s[2] & 0x3F) << 6)
+				| ((u32)(s[3] & 0x3F));
 			/* Check valid ranges */
 			if ((*wc <= 0x10ffff) && (*wc >= 0x10000))
 				return 4;
@@ -1113,7 +1113,7 @@ int ntfs_mbstoucs(const char *ins, ntfschar **outs)
 		}
 		/* Make sure we are not overflowing the NTFS Unicode set. */
 		if ((unsigned long)wc >= (unsigned long)(1 <<
-				(8 * sizeof(ntfschar)))) {
+					(8 * sizeof(ntfschar)))) {
 			errno = EILSEQ;
 			goto err_out;
 		}
@@ -1148,7 +1148,7 @@ err_out:
  */
 
 char *ntfs_uppercase_mbs(const char *low,
-			const ntfschar *upcase, u32 upcase_size)
+		const ntfschar *upcase, u32 upcase_size)
 {
 	int size;
 	char *upp;
@@ -1182,7 +1182,7 @@ char *ntfs_uppercase_mbs(const char *low,
 					*t++ = 0x80 | ((wc >> 6) & 0x3f);
 					*t++ = 0x80 | (wc & 0x3f);
 				}
-			s += n;
+				s += n;
 			}
 		} while (n > 0);
 		if (n < 0) {
@@ -1220,51 +1220,51 @@ void ntfs_upcase_table_build(ntfschar *uc, u32 uc_len)
 	 *	This is the table as defined by Windows XP
 	 */
 	static int uc_run_table[][3] = { /* Start, End, Add */
-	{0x0061, 0x007B,  -32}, {0x0451, 0x045D, -80}, {0x1F70, 0x1F72,  74},
-	{0x00E0, 0x00F7,  -32}, {0x045E, 0x0460, -80}, {0x1F72, 0x1F76,  86},
-	{0x00F8, 0x00FF,  -32}, {0x0561, 0x0587, -48}, {0x1F76, 0x1F78, 100},
-	{0x0256, 0x0258, -205}, {0x1F00, 0x1F08,   8}, {0x1F78, 0x1F7A, 128},
-	{0x028A, 0x028C, -217}, {0x1F10, 0x1F16,   8}, {0x1F7A, 0x1F7C, 112},
-	{0x03AC, 0x03AD,  -38}, {0x1F20, 0x1F28,   8}, {0x1F7C, 0x1F7E, 126},
-	{0x03AD, 0x03B0,  -37}, {0x1F30, 0x1F38,   8}, {0x1FB0, 0x1FB2,   8},
-	{0x03B1, 0x03C2,  -32}, {0x1F40, 0x1F46,   8}, {0x1FD0, 0x1FD2,   8},
-	{0x03C2, 0x03C3,  -31}, {0x1F51, 0x1F52,   8}, {0x1FE0, 0x1FE2,   8},
-	{0x03C3, 0x03CC,  -32}, {0x1F53, 0x1F54,   8}, {0x1FE5, 0x1FE6,   7},
-	{0x03CC, 0x03CD,  -64}, {0x1F55, 0x1F56,   8}, {0x2170, 0x2180, -16},
-	{0x03CD, 0x03CF,  -63}, {0x1F57, 0x1F58,   8}, {0x24D0, 0x24EA, -26},
-	{0x0430, 0x0450,  -32}, {0x1F60, 0x1F68,   8}, {0xFF41, 0xFF5B, -32},
-	{0}
+		{0x0061, 0x007B,  -32}, {0x0451, 0x045D, -80}, {0x1F70, 0x1F72,  74},
+		{0x00E0, 0x00F7,  -32}, {0x045E, 0x0460, -80}, {0x1F72, 0x1F76,  86},
+		{0x00F8, 0x00FF,  -32}, {0x0561, 0x0587, -48}, {0x1F76, 0x1F78, 100},
+		{0x0256, 0x0258, -205}, {0x1F00, 0x1F08,   8}, {0x1F78, 0x1F7A, 128},
+		{0x028A, 0x028C, -217}, {0x1F10, 0x1F16,   8}, {0x1F7A, 0x1F7C, 112},
+		{0x03AC, 0x03AD,  -38}, {0x1F20, 0x1F28,   8}, {0x1F7C, 0x1F7E, 126},
+		{0x03AD, 0x03B0,  -37}, {0x1F30, 0x1F38,   8}, {0x1FB0, 0x1FB2,   8},
+		{0x03B1, 0x03C2,  -32}, {0x1F40, 0x1F46,   8}, {0x1FD0, 0x1FD2,   8},
+		{0x03C2, 0x03C3,  -31}, {0x1F51, 0x1F52,   8}, {0x1FE0, 0x1FE2,   8},
+		{0x03C3, 0x03CC,  -32}, {0x1F53, 0x1F54,   8}, {0x1FE5, 0x1FE6,   7},
+		{0x03CC, 0x03CD,  -64}, {0x1F55, 0x1F56,   8}, {0x2170, 0x2180, -16},
+		{0x03CD, 0x03CF,  -63}, {0x1F57, 0x1F58,   8}, {0x24D0, 0x24EA, -26},
+		{0x0430, 0x0450,  -32}, {0x1F60, 0x1F68,   8}, {0xFF41, 0xFF5B, -32},
+		{0}
 	};
 	static int uc_dup_table[][2] = { /* Start, End */
-	{0x0100, 0x012F}, {0x01A0, 0x01A6}, {0x03E2, 0x03EF}, {0x04CB, 0x04CC},
-	{0x0132, 0x0137}, {0x01B3, 0x01B7}, {0x0460, 0x0481}, {0x04D0, 0x04EB},
-	{0x0139, 0x0149}, {0x01CD, 0x01DD}, {0x0490, 0x04BF}, {0x04EE, 0x04F5},
-	{0x014A, 0x0178}, {0x01DE, 0x01EF}, {0x04BF, 0x04BF}, {0x04F8, 0x04F9},
-	{0x0179, 0x017E}, {0x01F4, 0x01F5}, {0x04C1, 0x04C4}, {0x1E00, 0x1E95},
-	{0x018B, 0x018B}, {0x01FA, 0x0218}, {0x04C7, 0x04C8}, {0x1EA0, 0x1EF9},
-	{0}
+		{0x0100, 0x012F}, {0x01A0, 0x01A6}, {0x03E2, 0x03EF}, {0x04CB, 0x04CC},
+		{0x0132, 0x0137}, {0x01B3, 0x01B7}, {0x0460, 0x0481}, {0x04D0, 0x04EB},
+		{0x0139, 0x0149}, {0x01CD, 0x01DD}, {0x0490, 0x04BF}, {0x04EE, 0x04F5},
+		{0x014A, 0x0178}, {0x01DE, 0x01EF}, {0x04BF, 0x04BF}, {0x04F8, 0x04F9},
+		{0x0179, 0x017E}, {0x01F4, 0x01F5}, {0x04C1, 0x04C4}, {0x1E00, 0x1E95},
+		{0x018B, 0x018B}, {0x01FA, 0x0218}, {0x04C7, 0x04C8}, {0x1EA0, 0x1EF9},
+		{0}
 	};
 	static int uc_byte_table[][2] = { /* Offset, Value */
-	{0x00FF, 0x0178}, {0x01AD, 0x01AC}, {0x01F3, 0x01F1}, {0x0269, 0x0196},
-	{0x0183, 0x0182}, {0x01B0, 0x01AF}, {0x0253, 0x0181}, {0x026F, 0x019C},
-	{0x0185, 0x0184}, {0x01B9, 0x01B8}, {0x0254, 0x0186}, {0x0272, 0x019D},
-	{0x0188, 0x0187}, {0x01BD, 0x01BC}, {0x0259, 0x018F}, {0x0275, 0x019F},
-	{0x018C, 0x018B}, {0x01C6, 0x01C4}, {0x025B, 0x0190}, {0x0283, 0x01A9},
-	{0x0192, 0x0191}, {0x01C9, 0x01C7}, {0x0260, 0x0193}, {0x0288, 0x01AE},
-	{0x0199, 0x0198}, {0x01CC, 0x01CA}, {0x0263, 0x0194}, {0x0292, 0x01B7},
-	{0x01A8, 0x01A7}, {0x01DD, 0x018E}, {0x0268, 0x0197},
-	{0}
+		{0x00FF, 0x0178}, {0x01AD, 0x01AC}, {0x01F3, 0x01F1}, {0x0269, 0x0196},
+		{0x0183, 0x0182}, {0x01B0, 0x01AF}, {0x0253, 0x0181}, {0x026F, 0x019C},
+		{0x0185, 0x0184}, {0x01B9, 0x01B8}, {0x0254, 0x0186}, {0x0272, 0x019D},
+		{0x0188, 0x0187}, {0x01BD, 0x01BC}, {0x0259, 0x018F}, {0x0275, 0x019F},
+		{0x018C, 0x018B}, {0x01C6, 0x01C4}, {0x025B, 0x0190}, {0x0283, 0x01A9},
+		{0x0192, 0x0191}, {0x01C9, 0x01C7}, {0x0260, 0x0193}, {0x0288, 0x01AE},
+		{0x0199, 0x0198}, {0x01CC, 0x01CA}, {0x0263, 0x0194}, {0x0292, 0x01B7},
+		{0x01A8, 0x01A7}, {0x01DD, 0x018E}, {0x0268, 0x0197},
+		{0}
 	};
 
-/*
- *		Changes which were applied to later Windows versions
- *
- *   md5 for $UpCase from Winxp : 6fa3db2468275286210751e869d36373
- *                        Vista : 2f03b5a69d486ff3864cecbd07f24440
- *                        Win8 :  7ff498a44e45e77374cc7c962b1b92f2
- */
+	/*
+	 *		Changes which were applied to later Windows versions
+	 *
+	 *   md5 for $UpCase from Winxp : 6fa3db2468275286210751e869d36373
+	 *                        Vista : 2f03b5a69d486ff3864cecbd07f24440
+	 *                        Win8 :  7ff498a44e45e77374cc7c962b1b92f2
+	 */
 	static const struct NEWUPPERCASE newuppercase[] = {
-						/* from Windows 6.0 (Vista) */
+		/* from Windows 6.0 (Vista) */
 		{ 0x37b, 0x37d, 0x82, 1, 6, 0 },
 		{ 0x1f80, 0x1f87, 0x8, 1, 6, 0 },
 		{ 0x1f90, 0x1f97, 0x8, 1, 6, 0 },
@@ -1305,7 +1305,7 @@ void ntfs_upcase_table_build(ntfschar *uc, u32 uc_len)
 		{ 0x1fb3, 0x1fb3, 0x9, 1, 6, 0 },
 		{ 0x214e, 0x214e, -0x1c, 1, 6, 0 },
 		{ 0x2184, 0x2184, -0x1, 1, 6, 0 },
-						/* from Windows 6.1 (Win7) */
+		/* from Windows 6.1 (Win7) */
 		{ 0x23a, 0x23e,  0x0, 4, 6, 1 },
 		{ 0x250, 0x250,  0x2a1f, 2, 6, 1 },
 		{ 0x251, 0x251,  0x2a1c, 2, 6, 1 },
@@ -1315,7 +1315,7 @@ void ntfs_upcase_table_build(ntfschar *uc, u32 uc_len)
 		{ 0x3c2, 0x3c2,  0x0, 2, 6, 1 },
 		{ 0x3d7, 0x3d7, -0x8, 2, 6, 1 },
 		{ 0x515, 0x523, -0x1, 2, 6, 1 },
-			/* below, -0x75fc stands for 0x8a04 and truncation */
+		/* below, -0x75fc stands for 0x8a04 and truncation */
 		{ 0x1d79, 0x1d79, -0x75fc, 2, 6, 1 },
 		{ 0x1efb, 0x1eff, -0x1, 2, 6, 1 },
 		{ 0x1fc3, 0x1ff3,  0x9, 48, 6, 1 },
@@ -1331,7 +1331,7 @@ void ntfs_upcase_table_build(ntfschar *uc, u32 uc_len)
 		{ 0xa77a, 0xa77c, -0x1, 2, 6, 1 },
 		{ 0xa77f, 0xa787, -0x1, 2, 6, 1 },
 		{ 0xa78c, 0xa78c, -0x1, 2, 6, 1 },
-							/* end mark */
+		/* end mark */
 		{ 0 }
 	} ;
 
@@ -1360,8 +1360,8 @@ void ntfs_upcase_table_build(ntfschar *uc, u32 uc_len)
 	for (r=0; newuppercase[r].first; r++) {
 		puc = &newuppercase[r];
 		if ((puc->osmajor < UPCASE_MAJOR)
-		  || ((puc->osmajor == UPCASE_MAJOR)
-		     && (puc->osminor <= UPCASE_MINOR))) {
+				|| ((puc->osmajor == UPCASE_MAJOR)
+					&& (puc->osminor <= UPCASE_MINOR))) {
 			off = puc->diff;
 			for (i = puc->first; i <= puc->last; i += puc->step)
 				uc[i] = cpu_to_le16(i + off);
@@ -1492,23 +1492,23 @@ BOOL ntfs_forbidden_chars(const ntfschar *name, int len, BOOL strict)
 	int ch;
 	int i;
 	static const u32 mainset = (1L << ('\"' - 0x20))
-			| (1L << ('*' - 0x20))
-			| (1L << ('/' - 0x20))
-			| (1L << (':' - 0x20))
-			| (1L << ('<' - 0x20))
-			| (1L << ('>' - 0x20))
-			| (1L << ('?' - 0x20));
+		| (1L << ('*' - 0x20))
+		| (1L << ('/' - 0x20))
+		| (1L << (':' - 0x20))
+		| (1L << ('<' - 0x20))
+		| (1L << ('>' - 0x20))
+		| (1L << ('?' - 0x20));
 
 	forbidden = (len == 0) ||
-		    (strict && (name[len-1] == const_cpu_to_le16(' ') ||
-				name[len-1] == const_cpu_to_le16('.')));
+		(strict && (name[len-1] == const_cpu_to_le16(' ') ||
+					name[len-1] == const_cpu_to_le16('.')));
 	for (i=0; i<len; i++) {
 		ch = le16_to_cpu(name[i]);
 		if ((ch < 0x20)
-		    || ((ch < 0x40)
-			&& ((1L << (ch - 0x20)) & mainset))
-		    || (ch == '\\')
-		    || (ch == '|'))
+				|| ((ch < 0x40)
+					&& ((1L << (ch - 0x20)) & mainset))
+				|| (ch == '\\')
+				|| (ch == '|'))
 			forbidden = TRUE;
 	}
 	if (forbidden)
@@ -1531,23 +1531,23 @@ BOOL ntfs_forbidden_chars(const ntfschar *name, int len, BOOL strict)
  */
 
 BOOL ntfs_forbidden_names(ntfs_volume *vol, const ntfschar *name, int len,
-			  BOOL strict)
+		BOOL strict)
 {
 	BOOL forbidden;
 	int h;
 	static const ntfschar dot = const_cpu_to_le16('.');
 	static const ntfschar con[] = { const_cpu_to_le16('c'),
-			const_cpu_to_le16('o'), const_cpu_to_le16('n') };
+		const_cpu_to_le16('o'), const_cpu_to_le16('n') };
 	static const ntfschar prn[] = { const_cpu_to_le16('p'),
-			const_cpu_to_le16('r'), const_cpu_to_le16('n') };
+		const_cpu_to_le16('r'), const_cpu_to_le16('n') };
 	static const ntfschar aux[] = { const_cpu_to_le16('a'),
-			const_cpu_to_le16('u'), const_cpu_to_le16('x') };
+		const_cpu_to_le16('u'), const_cpu_to_le16('x') };
 	static const ntfschar nul[] = { const_cpu_to_le16('n'),
-			const_cpu_to_le16('u'), const_cpu_to_le16('l') };
+		const_cpu_to_le16('u'), const_cpu_to_le16('l') };
 	static const ntfschar com[] = { const_cpu_to_le16('c'),
-			const_cpu_to_le16('o'), const_cpu_to_le16('m') };
+		const_cpu_to_le16('o'), const_cpu_to_le16('m') };
 	static const ntfschar lpt[] = { const_cpu_to_le16('l'),
-			const_cpu_to_le16('p'), const_cpu_to_le16('t') };
+		const_cpu_to_le16('p'), const_cpu_to_le16('t') };
 
 	forbidden = ntfs_forbidden_chars(name, len, strict);
 	if (!forbidden && (len >= 3)) {
@@ -1556,46 +1556,46 @@ BOOL ntfs_forbidden_names(ntfs_volume *vol, const ntfschar *name, int len,
 		 * may be one of CO PR AU NU LP or lowercase variants.
 		 */
 		h = ((le16_to_cpu(name[0]) & 31)*48)
-				^ ((le16_to_cpu(name[1]) & 31)*165);
+			^ ((le16_to_cpu(name[1]) & 31)*165);
 		if ((h % 23) == 17) {
 			/* do a full check, depending on the third char */
 			switch (le16_to_cpu(name[2]) & ~0x20) {
 			case 'N' :
 				if (((len == 3) || (name[3] == dot))
-				    && (!ntfs_ucsncasecmp(name, con, 3,
-						vol->upcase, vol->upcase_len)
-					|| !ntfs_ucsncasecmp(name, prn, 3,
-						vol->upcase, vol->upcase_len)))
+						&& (!ntfs_ucsncasecmp(name, con, 3,
+								vol->upcase, vol->upcase_len)
+							|| !ntfs_ucsncasecmp(name, prn, 3,
+								vol->upcase, vol->upcase_len)))
 					forbidden = TRUE;
 				break;
 			case 'X' :
 				if (((len == 3) || (name[3] == dot))
-				    && !ntfs_ucsncasecmp(name, aux, 3,
-						vol->upcase, vol->upcase_len))
+						&& !ntfs_ucsncasecmp(name, aux, 3,
+							vol->upcase, vol->upcase_len))
 					forbidden = TRUE;
 				break;
 			case 'L' :
 				if (((len == 3) || (name[3] == dot))
-				    && !ntfs_ucsncasecmp(name, nul, 3,
-						vol->upcase, vol->upcase_len))
+						&& !ntfs_ucsncasecmp(name, nul, 3,
+							vol->upcase, vol->upcase_len))
 					forbidden = TRUE;
 				break;
 			case 'M' :
 				if ((len > 3)
-				    && (le16_to_cpu(name[3]) >= '1')
-				    && (le16_to_cpu(name[3]) <= '9')
-				    && ((len == 4) || (name[4] == dot))
-				    && !ntfs_ucsncasecmp(name, com, 3,
-						vol->upcase, vol->upcase_len))
+						&& (le16_to_cpu(name[3]) >= '1')
+						&& (le16_to_cpu(name[3]) <= '9')
+						&& ((len == 4) || (name[4] == dot))
+						&& !ntfs_ucsncasecmp(name, com, 3,
+							vol->upcase, vol->upcase_len))
 					forbidden = TRUE;
 				break;
 			case 'T' :
 				if ((len > 3)
-				    && (le16_to_cpu(name[3]) >= '1')
-				    && (le16_to_cpu(name[3]) <= '9')
-				    && ((len == 4) || (name[4] == dot))
-				    && !ntfs_ucsncasecmp(name, lpt, 3,
-						vol->upcase, vol->upcase_len))
+						&& (le16_to_cpu(name[3]) >= '1')
+						&& (le16_to_cpu(name[3]) <= '9')
+						&& ((len == 4) || (name[4] == dot))
+						&& !ntfs_ucsncasecmp(name, lpt, 3,
+							vol->upcase, vol->upcase_len))
 					forbidden = TRUE;
 				break;
 			}
@@ -1616,8 +1616,8 @@ BOOL ntfs_forbidden_names(ntfs_volume *vol, const ntfschar *name, int len,
  */
 
 BOOL ntfs_collapsible_chars(ntfs_volume *vol,
-			const ntfschar *shortname, int shortlen,
-			const ntfschar *longname, int longlen)
+		const ntfschar *shortname, int shortlen,
+		const ntfschar *longname, int longlen)
 {
 	BOOL collapsible;
 	unsigned int ch;
@@ -1629,10 +1629,10 @@ BOOL ntfs_collapsible_chars(ntfs_volume *vol,
 		ch = le16_to_cpu(longname[i]);
 		cs = le16_to_cpu(shortname[i]);
 		if ((cs != ch)
-		    && ((ch >= vol->upcase_len)
-			|| (cs >= vol->upcase_len)
-			|| (vol->upcase[cs] != vol->upcase[ch])))
-				collapsible = FALSE;
+				&& ((ch >= vol->upcase_len)
+					|| (cs >= vol->upcase_len)
+					|| (vol->upcase[cs] != vol->upcase[ch])))
+			collapsible = FALSE;
 	}
 	return (collapsible);
 }
@@ -1646,7 +1646,7 @@ int ntfs_set_char_encoding(const char *locale)
 {
 	use_utf8 = 0;
 	if (!locale || strstr(locale,"utf8") || strstr(locale,"UTF8")
-	    || strstr(locale,"utf-8") || strstr(locale,"UTF-8"))
+			|| strstr(locale,"utf-8") || strstr(locale,"UTF-8"))
 		use_utf8 = 1;
 	else
 		if (setlocale(LC_ALL, locale))
@@ -1654,7 +1654,7 @@ int ntfs_set_char_encoding(const char *locale)
 		else {
 			ntfs_log_error("Invalid locale, encoding to UTF-8\n");
 			use_utf8 = 1;
-	 	}
+		}
 	return 0; /* always successful */
 }
 
@@ -1689,7 +1689,7 @@ int ntfs_macosx_normalize_utf8(const char *utf8_string, char **target,
 
 	/* Convert the UTF-8 string to a CFString. */
 	cfSourceString = CFStringCreateWithCString(kCFAllocatorDefault,
-		utf8_string, kCFStringEncodingUTF8);
+			utf8_string, kCFStringEncodingUTF8);
 	if (cfSourceString == NULL) {
 		ntfs_log_error("CFStringCreateWithCString failed!\n");
 		return -2;
@@ -1698,7 +1698,7 @@ int ntfs_macosx_normalize_utf8(const char *utf8_string, char **target,
 	/* Create a mutable string from cfSourceString that we are free to
 	 * modify. */
 	cfMutableString = CFStringCreateMutableCopy(kCFAllocatorDefault, 0,
-		cfSourceString);
+			cfSourceString);
 	CFRelease(cfSourceString); /* End-of-life. */
 	if (cfMutableString == NULL) {
 		ntfs_log_error("CFStringCreateMutableCopy failed!\n");
@@ -1707,45 +1707,45 @@ int ntfs_macosx_normalize_utf8(const char *utf8_string, char **target,
 
 	/* Normalize the mutable string to the desired normalization form. */
 	CFStringNormalize(cfMutableString, (composed != 0 ?
-		kCFStringNormalizationFormC : kCFStringNormalizationFormD));
+				kCFStringNormalizationFormC : kCFStringNormalizationFormD));
 
 	/* Store the resulting string in a '\0'-terminated UTF-8 encoded char*
 	 * buffer. */
 	rangeToProcess = CFRangeMake(0, CFStringGetLength(cfMutableString));
 	if (CFStringGetBytes(cfMutableString, rangeToProcess,
-		kCFStringEncodingUTF8, 0, false, NULL, 0,
-		&requiredBufferLength) > 0)
+				kCFStringEncodingUTF8, 0, false, NULL, 0,
+				&requiredBufferLength) > 0)
 	{
 		resultLength = sizeof(char) * (requiredBufferLength + 1);
 		result = ntfs_calloc(resultLength);
 
 		if (result != NULL) {
 			if (CFStringGetBytes(cfMutableString, rangeToProcess,
-				kCFStringEncodingUTF8, 0, false,
-				(UInt8*) result, resultLength - 1,
-				&requiredBufferLength) <= 0)
+						kCFStringEncodingUTF8, 0, false,
+						(UInt8*) result, resultLength - 1,
+						&requiredBufferLength) <= 0)
 			{
 				ntfs_log_error("Could not perform UTF-8 "
-					"conversion of normalized "
-					"CFMutableString.\n");
+						"conversion of normalized "
+						"CFMutableString.\n");
 				free(result);
 				result = NULL;
 			}
 		}
 		else {
 			ntfs_log_error("Could not perform a ntfs_calloc of %d "
-				"bytes for char *result.\n", resultLength);
+					"bytes for char *result.\n", resultLength);
 		}
 	}
 	else {
 		ntfs_log_error("Could not perform check for required length of "
-			"UTF-8 conversion of normalized CFMutableString.\n");
+				"UTF-8 conversion of normalized CFMutableString.\n");
 	}
 
 	CFRelease(cfMutableString);
 
 	if (result != NULL) {
-	 	*target = result;
+		*target = result;
 		return resultLength - 1;
 	}
 	else {

--- a/libntfs/unix_io.c
+++ b/libntfs/unix_io.c
@@ -143,7 +143,7 @@ static int ntfs_device_unix_io_open(struct ntfs_device *dev, int flags)
 	*(int*)dev->d_private = open(dev->d_name, flags);
 	if (*(int*)dev->d_private == -1) {
 		err = errno;
-			/* if permission error and rw, retry read-only */
+		/* if permission error and rw, retry read-only */
 		if ((err == EACCES) && ((flags & O_RDWR) == O_RDWR))
 			err = EROFS;
 
@@ -154,7 +154,7 @@ static int ntfs_device_unix_io_open(struct ntfs_device *dev, int flags)
 		goto err_out;
 	}
 #ifdef HAVE_LINUX_FS_H
-		/* Check whether the device was forced read-only */
+	/* Check whether the device was forced read-only */
 	if (NDevBlock(dev) && ((flags & O_RDWR) == O_RDWR)) {
 		int r;
 		int state;
@@ -165,7 +165,7 @@ static int ntfs_device_unix_io_open(struct ntfs_device *dev, int flags)
 			if (close(DEV_FD(dev)))
 				err = errno;
 			goto err_out;
-   		}
+		}
 	}
 #endif
 

--- a/libntfs/volume.c
+++ b/libntfs/volume.c
@@ -306,14 +306,14 @@ static int ntfs_mft_load(ntfs_volume *vol)
 	}
 
 	if (le32_to_cpu(ctx->attr->value_length) <
-	    offsetof(STANDARD_INFORMATION, owner_id)) {
+			offsetof(STANDARD_INFORMATION, owner_id)) {
 		ntfs_log_error("Corrupt STANDARD_INFORMATION in $MFT record\n");
 		goto error_exit;
 	}
 
 	/* Find the $ATTRIBUTE_LIST attribute in $MFT if present. */
 	if (ntfs_attr_lookup(AT_ATTRIBUTE_LIST, AT_UNNAMED, 0, 0, 0, NULL, 0,
-			ctx)) {
+				ctx)) {
 		if (errno != ENOENT) {
 			ntfs_log_error("$MFT has corrupt attribute list.\n");
 			goto io_error_exit;
@@ -324,7 +324,7 @@ static int ntfs_mft_load(ntfs_volume *vol)
 	l = ntfs_get_attribute_value_length(ctx->attr);
 	if (l <= 0 || l > 0x40000) {
 		ntfs_log_error("$MFT/$ATTR_LIST invalid length (%lld).\n",
-			       (long long)l);
+				(long long)l);
 		goto io_error_exit;
 	}
 	vol->mft_ni->attr_list_size = l;
@@ -338,7 +338,7 @@ static int ntfs_mft_load(ntfs_volume *vol)
 		goto io_error_exit;
 	}
 	if ((l != vol->mft_ni->attr_list_size)
-	    || (l < (s64)offsetof(ATTR_LIST_ENTRY, name))) {
+			|| (l < (s64)offsetof(ATTR_LIST_ENTRY, name))) {
 		ntfs_log_error("Partial read of $MFT/$ATTR_LIST (%lld != "
 				"%u or < %d).\n", (long long)l,
 				vol->mft_ni->attr_list_size,
@@ -365,7 +365,7 @@ mft_has_no_attr_list:
 	highest_vcn = next_vcn = 0;
 	a = NULL;
 	while (!ntfs_attr_lookup(AT_DATA, AT_UNNAMED, 0, 0, next_vcn, NULL, 0,
-			ctx)) {
+				ctx)) {
 		runlist_element *nrl;
 
 		a = ctx->attr;
@@ -378,7 +378,7 @@ mft_has_no_attr_list:
 		if (a->flags & ATTR_COMPRESSION_MASK ||
 				a->flags & ATTR_IS_ENCRYPTED) {
 			ntfs_log_error("$MFT must be uncompressed and "
-				       "unencrypted.\n");
+					"unencrypted.\n");
 			goto io_error_exit;
 		}
 		/*
@@ -420,7 +420,7 @@ mft_has_no_attr_list:
 	if (highest_vcn && highest_vcn != last_vcn - 1) {
 		ntfs_log_error("Failed to load runlist for $MFT/$DATA.\n");
 		ntfs_log_error("highest_vcn = 0x%llx, last_vcn - 1 = 0x%llx\n",
-			       (long long)highest_vcn, (long long)last_vcn - 1);
+				(long long)highest_vcn, (long long)last_vcn - 1);
 		goto io_error_exit;
 	}
 
@@ -434,7 +434,7 @@ mft_has_no_attr_list:
 
 	/* Check if filename is "$MFT" */
 	fn = (FILE_NAME_ATTR *)((u8 *)ctx->attr +
-				le16_to_cpu(ctx->attr->value_offset));
+			le16_to_cpu(ctx->attr->value_offset));
 	filename = ntfs_attr_name_get(fn->file_name, fn->file_name_length);
 	if (!filename || strcmp(filename, "$MFT")) {
 		ntfs_log_error("filename of $MFT record is not '$MFT'(%s)\n",
@@ -541,7 +541,7 @@ static int ntfs_mftmirr_load(ntfs_volume *vol)
 
 	/* Check if filename is "$MFTMirr" */
 	fn = (FILE_NAME_ATTR *)((u8 *)ctx->attr +
-				le16_to_cpu(ctx->attr->value_offset));
+			le16_to_cpu(ctx->attr->value_offset));
 	filename = ntfs_attr_name_get(fn->file_name, fn->file_name_length);
 	if (!filename || strcmp(filename, "$MFTMirr")) {
 		ntfs_log_error("filename of $MFT record is not '$MFTMirr'(%s)\n",
@@ -605,8 +605,8 @@ static int ntfsck_fix_boot_sector(ntfs_volume *vol, char *full_bs,
 		/* alignment problem on Sparc, even doing memcpy() */
 		sector_size_le = cpu_to_le16(sector_size);
 		if (!memcmp(&sector_size_le, &bs->bpb.bytes_per_sector, 2) &&
-		    ntfs_boot_sector_is_ntfs(bs) &&
-		    !ntfs_boot_sector_parse(vol, bs)) {
+				ntfs_boot_sector_is_ntfs(bs) &&
+				!ntfs_boot_sector_parse(vol, bs)) {
 			s64 bw;
 
 			ntfs_log_info("The alternate bootsector is usable\n");
@@ -659,15 +659,15 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 	}
 
 	if ((ntfs_boot->jump[0] != 0xeb) ||
-	    ((ntfs_boot->jump[1] != 0x52) && (ntfs_boot->jump[1] != 0x5b)) ||
-	    (ntfs_boot->jump[2] != 0x90)) {
+			((ntfs_boot->jump[1] != 0x52) && (ntfs_boot->jump[1] != 0x5b)) ||
+			(ntfs_boot->jump[2] != 0x90)) {
 		ntfs_log_error("Boot sector: Bad jump.\n");
 		ntfs_free(ntfs_boot);
 		return 1;
 	}
 
 	if (ntfs_boot_sector_is_ntfs(ntfs_boot) &&
-	    (ntfs_boot_sector_parse(vol, ntfs_boot) == 0))
+			(ntfs_boot_sector_parse(vol, ntfs_boot) == 0))
 		goto out;
 
 	if (NVolFsck(vol)) {
@@ -681,21 +681,21 @@ static BOOL ntfsck_verify_boot_sector(ntfs_volume *vol)
 			shown_sectors = sle64_to_cpu(ntfs_boot->number_of_sectors);
 			/* first try the actual last sector */
 			if ((actual_sectors > 0) &&
-			    !ntfsck_fix_boot_sector(vol, (char *)ntfs_boot, actual_sectors,
-						    actual_sectors, sector_size))
+					!ntfsck_fix_boot_sector(vol, (char *)ntfs_boot, actual_sectors,
+						actual_sectors, sector_size))
 				res = 0;
 
 			/* then try the shown last sector, if less than actual */
 			if (res && (shown_sectors > 0) &&
-			    (shown_sectors < actual_sectors) &&
-			    !ntfsck_fix_boot_sector(vol, (char *)ntfs_boot, shown_sectors,
-						    shown_sectors, sector_size))
+					(shown_sectors < actual_sectors) &&
+					!ntfsck_fix_boot_sector(vol, (char *)ntfs_boot, shown_sectors,
+						shown_sectors, sector_size))
 				res = 0;
 
 			/* then try reducing the number of sectors to actual value */
 			if (res && (shown_sectors > actual_sectors) &&
-			    !ntfsck_fix_boot_sector(vol, (char *)ntfs_boot, 0, actual_sectors,
-						    sector_size))
+					!ntfsck_fix_boot_sector(vol, (char *)ntfs_boot, 0, actual_sectors,
+						sector_size))
 				res = 0;
 			if (res) {
 				ntfs_log_error("Boot sector: failed to fix boot sector\n");
@@ -793,9 +793,9 @@ static int ntfs_recover_mft_from_mftmirr(ntfs_volume *vol, const u64 mftno)
 		return -ENOMEM;
 
 	if (ntfs_mst_pread(vol->dev,
-			   (vol->mftmirr_lcn << vol->cluster_size_bits) +
+				(vol->mftmirr_lcn << vol->cluster_size_bits) +
 				mftno * vol->mft_record_size,
-			   1, vol->mft_record_size, mrec) != 1) {
+				1, vol->mft_record_size, mrec) != 1) {
 		err = -EIO;
 		goto err_out;
 	}
@@ -857,11 +857,11 @@ ntfs_volume *ntfs_volume_startup(struct ntfs_device *dev,
 	vol->locase = (ntfschar*)NULL;
 	NVolSetCaseSensitive(vol);
 
-		/* by default, all files are shown and not marked hidden */
+	/* by default, all files are shown and not marked hidden */
 	NVolSetShowSysFiles(vol);
 	NVolSetShowHidFiles(vol);
 	NVolClearHideDotFiles(vol);
-		/* set default compression */
+	/* set default compression */
 #if DEFAULT_COMPRESSION
 	NVolSetCompression(vol);
 #else
@@ -934,7 +934,7 @@ ntfs_volume *ntfs_volume_startup(struct ntfs_device *dev,
 	mft_lcn = (8192 + 2 * vol->cluster_size - 1) / vol->cluster_size;
 	if (mft_lcn * vol->cluster_size < 16 * 1024)
 		mft_lcn = (16 * 1024 + vol->cluster_size - 1) /
-				vol->cluster_size;
+			vol->cluster_size;
 	if (vol->mft_zone_start <= mft_lcn)
 		vol->mft_zone_start = 0;
 	ntfs_log_debug("mft_zone_start = 0x%llx\n", (long long)vol->mft_zone_start);
@@ -994,8 +994,8 @@ reload_mft_mirr:
 	/* Need to setup $MFTMirr so we can use the write functions, too. */
 	if (ntfs_mftmirr_load(vol) < 0) {
 		if (try_recover_mft == FALSE) {
-		fsck_err_found();
-		if (ntfs_fix_problem(vol, PR_MOUNT_LOAD_MFTMIRR_FAILURE, &pctx)) {
+			fsck_err_found();
+			if (ntfs_fix_problem(vol, PR_MOUNT_LOAD_MFTMIRR_FAILURE, &pctx)) {
 				if (!ntfs_recover_mft_from_mftmirr(vol, 1)) {
 					ntfs_log_info("Try to reload $MFTMirr after updating it using $MFT\n");
 					try_recover_mft = TRUE;
@@ -1045,21 +1045,21 @@ static int ntfs_volume_check_logfile(ntfs_volume *vol)
 
 	if (!ntfs_check_logfile(na, &rp))
 		err = EOPNOTSUPP;
-		/*
-		 * If the latest restart page was identified as version
-		 * 2.0, then Windows may have kept a cached copy of
-		 * metadata for fast restarting, and we should not mount.
-		 * Hibernation will be seen the same way on a non
-		 * Windows-system partition, so we have to use the same
-		 * error code (EPERM).
-		 * The restart page may also be identified as version 2.0
-		 * when access to the file system is terminated abruptly
-		 * by unplugging or power cut, so mounting is also rejected
-		 * after such an event.
-		 */
+	/*
+	 * If the latest restart page was identified as version
+	 * 2.0, then Windows may have kept a cached copy of
+	 * metadata for fast restarting, and we should not mount.
+	 * Hibernation will be seen the same way on a non
+	 * Windows-system partition, so we have to use the same
+	 * error code (EPERM).
+	 * The restart page may also be identified as version 2.0
+	 * when access to the file system is terminated abruptly
+	 * by unplugging or power cut, so mounting is also rejected
+	 * after such an event.
+	 */
 	if (rp
-	    && (rp->major_ver == const_cpu_to_le16(2))
-	    && (rp->minor_ver == const_cpu_to_le16(0))) {
+			&& (rp->major_ver == const_cpu_to_le16(2))
+			&& (rp->minor_ver == const_cpu_to_le16(0))) {
 		ntfs_log_error("Metadata kept in Windows cache, refused to mount.\n");
 		err = EPERM;
 	}
@@ -1172,18 +1172,18 @@ int ntfs_volume_check_hiberfile(ntfs_volume *vol, int verbose)
 	if (bytes_read < NTFS_HIBERFILE_HEADER_SIZE) {
 		if (verbose)
 			ntfs_log_error("Hibernated non-system partition, "
-				       "refused to mount.\n");
+					"refused to mount.\n");
 		errno = EPERM;
 		goto out;
 	}
 	if ((memcmp(buf, "hibr", 4) == 0)
-	   ||  (memcmp(buf, "HIBR", 4) == 0)) {
+			||  (memcmp(buf, "HIBR", 4) == 0)) {
 		if (verbose)
 			ntfs_log_error("Windows is hibernated, refused to mount.\n");
 		errno = EPERM;
 		goto out;
 	}
-        /* All right, all header bytes are zero */
+	/* All right, all header bytes are zero */
 	errno = 0;
 out:
 	if (na)
@@ -1239,16 +1239,16 @@ static int fix_txf_data(ntfs_volume *vol)
 						TXF_DATA, 9, &txf_data_size);
 				if (txf_data) {
 					if (ntfs_attr_truncate(na, 0)
-					    || (ntfs_attr_pwrite(na, 0,
-						 txf_data_size, txf_data)
-							!= txf_data_size))
+							|| (ntfs_attr_pwrite(na, 0,
+									txf_data_size, txf_data)
+								!= txf_data_size))
 						res = -1;
 					free(txf_data);
 				}
-			if (res)
-				ntfs_log_error("Failed to make $TXF_DATA resident\n");
-			else
-				ntfs_log_error("$TXF_DATA made resident\n");
+				if (res)
+					ntfs_log_error("Failed to make $TXF_DATA resident\n");
+				else
+					ntfs_log_error("$TXF_DATA made resident\n");
 			}
 			ntfs_attr_close(na);
 		}
@@ -1320,8 +1320,8 @@ ntfs_volume *ntfs_device_mount(struct ntfs_device *dev, ntfs_mount_flags flags)
 			ntfs_log_perror("Failed to read $MFT");
 		else {
 			ntfs_log_error("Failed to read $MFT, unexpected length "
-				       "(%lld != %d).\n", (long long)l,
-				       vol->mftmirr_size);
+					"(%lld != %d).\n", (long long)l,
+					vol->mftmirr_size);
 			errno = EIO;
 		}
 		goto error_exit;
@@ -1363,8 +1363,8 @@ ntfs_volume *ntfs_device_mount(struct ntfs_device *dev, ntfs_mount_flags flags)
 		if (!ntfs_mft_record_check(vol, FILE_MFT + i, mrec)) {
 			if (!memcmp(mrec, mrec2, vol->mft_record_size))
 				continue;
-		fsck_err_found();
-		if (ntfs_fix_problem(vol, PR_MOUNT_MFT_MFTMIRR_MISMATCH, &pctx)) {
+			fsck_err_found();
+			if (ntfs_fix_problem(vol, PR_MOUNT_MFT_MFTMIRR_MISMATCH, &pctx)) {
 				if (ntfs_recover_mft(vol, mrec, vol->mftmirr_lcn, FILE_MFT + i)) {
 					ntfs_log_perror("Error correcting $MFTMirror record : %d", i);
 					goto io_error_exit;
@@ -1459,8 +1459,8 @@ skip_compare_mft:
 	l = ntfs_attr_pread(na, 0, na->data_size, vol->upcase);
 	if (l != na->data_size) {
 		ntfs_log_error("Failed to read $UpCase, unexpected length "
-			       "(%lld != %lld).\n", (long long)l,
-			       (long long)na->data_size);
+				"(%lld != %lld).\n", (long long)l,
+				(long long)na->data_size);
 		errno = EIO;
 		goto error_close;
 	}
@@ -1473,9 +1473,9 @@ skip_compare_mft:
 	/* Consistency check of $UpCase, restricted to plain ASCII chars */
 	k = 0x20;
 	while ((k < vol->upcase_len)
-	    && (k < 0x7f)
-	    && (le16_to_cpu(vol->upcase[k])
-			== ((k < 'a') || (k > 'z') ? k : k + 'A' - 'a')))
+			&& (k < 0x7f)
+			&& (le16_to_cpu(vol->upcase[k])
+				== ((k < 'a') || (k > 'z') ? k : k + 'A' - 'a')))
 		k++;
 	if (k < 0x7f) {
 		ntfs_log_error("Corrupted file $UpCase\n");
@@ -1499,7 +1499,7 @@ skip_compare_mft:
 
 	/* Find the $VOLUME_INFORMATION attribute. */
 	if (ntfs_attr_lookup(AT_VOLUME_INFORMATION, AT_UNNAMED, 0, 0, 0, NULL,
-			0, ctx)) {
+				0, ctx)) {
 		ntfs_log_perror("$VOLUME_INFORMATION attribute not found in "
 				"$Volume");
 		goto error_exit;
@@ -1508,7 +1508,7 @@ skip_compare_mft:
 	/* Has to be resident. */
 	if (a->non_resident) {
 		ntfs_log_error("Attribute $VOLUME_INFORMATION must be "
-			       "resident but it isn't.\n");
+				"resident but it isn't.\n");
 		errno = EIO;
 		goto error_exit;
 	}
@@ -1518,7 +1518,7 @@ skip_compare_mft:
 	if ((char*)vinf + le32_to_cpu(a->value_length) > (char*)ctx->mrec +
 			le32_to_cpu(ctx->mrec->bytes_in_use) ||
 			le16_to_cpu(a->value_offset) + le32_to_cpu(
-			a->value_length) > le32_to_cpu(a->length)) {
+				a->value_length) > le32_to_cpu(a->length)) {
 		ntfs_log_error("$VOLUME_INFORMATION in $Volume is corrupt.\n");
 		errno = EIO;
 		goto error_exit;
@@ -1534,7 +1534,7 @@ skip_compare_mft:
 	 */
 	ntfs_attr_reinit_search_ctx(ctx);
 	if (ntfs_attr_lookup(AT_VOLUME_NAME, AT_UNNAMED, 0, 0, 0, NULL, 0,
-			ctx)) {
+				ctx)) {
 		if (errno != ENOENT) {
 			ntfs_log_perror("Failed to lookup of $VOLUME_NAME in "
 					"$Volume failed");
@@ -1569,7 +1569,7 @@ skip_compare_mft:
 			ntfs_log_perror("Volume name could not be converted "
 					"to current locale");
 			ntfs_log_debug("Forcing name into ASCII by replacing "
-				"non-ASCII characters with underscores.\n");
+					"non-ASCII characters with underscores.\n");
 			vol->vol_name = ntfs_malloc(u + 1);
 			if (!vol->vol_name)
 				goto error_exit;
@@ -1602,7 +1602,7 @@ skip_compare_mft:
 	/* Check we don't overflow 24-bits. */
 	if ((u64)na->data_size > 0xffffffLL) {
 		ntfs_log_error("Attribute definition table is too big (max "
-			       "24-bit allowed).\n");
+				"24-bit allowed).\n");
 		errno = EINVAL;
 		goto error_close;
 	}
@@ -1615,8 +1615,8 @@ skip_compare_mft:
 	l = ntfs_attr_pread(na, 0, na->data_size, vol->attrdef);
 	if (l != na->data_size) {
 		ntfs_log_error("Failed to read $AttrDef, unexpected length "
-			       "(%lld != %lld).\n", (long long)l,
-			       (long long)na->data_size);
+				"(%lld != %lld).\n", (long long)l,
+				(long long)na->data_size);
 		errno = EIO;
 		goto error_close;
 	}
@@ -1637,12 +1637,12 @@ skip_compare_mft:
 	 */
 	if (!(flags & (NTFS_MNT_RDONLY | NTFS_MNT_FORENSIC))) {
 		if (!(flags & NTFS_MNT_IGNORE_HIBERFILE) &&
-		    ntfs_volume_check_hiberfile(vol, 1) < 0) {
+				ntfs_volume_check_hiberfile(vol, 1) < 0) {
 			if (flags & NTFS_MNT_MAY_RDONLY)
 				need_fallback_ro = TRUE;
 			else
 				goto error_exit;
-			}
+		}
 		if (ntfs_volume_check_logfile(vol) < 0) {
 			/* Always reject cached metadata for now */
 			if (!(flags & NTFS_MNT_RECOVER) || (errno == EPERM)) {
@@ -1652,7 +1652,7 @@ skip_compare_mft:
 					goto error_exit;
 			} else {
 				ntfs_log_info("The file system wasn't safely "
-					      "closed on Windows. Fixing.\n");
+						"closed on Windows. Fixing.\n");
 				if (ntfs_logfile_reset(vol))
 					goto error_exit;
 			}
@@ -1695,8 +1695,8 @@ error_exit:
  */
 
 int ntfs_set_shown_files(ntfs_volume *vol,
-			BOOL show_sys_files, BOOL show_hid_files,
-			BOOL hide_dot_files)
+		BOOL show_sys_files, BOOL show_hid_files,
+		BOOL hide_dot_files)
 {
 	int res;
 
@@ -1729,7 +1729,7 @@ int ntfs_set_ignore_case(ntfs_volume *vol)
 	res = -1;
 	if (vol && vol->upcase) {
 		vol->locase = ntfs_locase_table_build(vol->upcase,
-					vol->upcase_len);
+				vol->upcase_len);
 		if (vol->locase) {
 			NVolClearCaseSensitive(vol);
 			res = 0;
@@ -2106,16 +2106,16 @@ int ntfs_volume_write_flags(ntfs_volume *vol, const le16 flags)
 		return -1;
 
 	if (ntfs_attr_lookup(AT_VOLUME_INFORMATION, AT_UNNAMED, 0, 0, 0, NULL,
-			0, ctx)) {
+				0, ctx)) {
 		ntfs_log_error("Attribute $VOLUME_INFORMATION was not found "
-			       "in $Volume!\n");
+				"in $Volume!\n");
 		goto err_out;
 	}
 	a = ctx->attr;
 	/* Sanity check. */
 	if (a->non_resident) {
 		ntfs_log_error("Attribute $VOLUME_INFORMATION must be resident "
-			       "but it isn't.\n");
+				"but it isn't.\n");
 		errno = EIO;
 		goto err_out;
 	}
@@ -2127,7 +2127,7 @@ int ntfs_volume_write_flags(ntfs_volume *vol, const le16 flags)
 			le16_to_cpu(a->value_offset) +
 			le32_to_cpu(a->value_length) > le32_to_cpu(a->length)) {
 		ntfs_log_error("Attribute $VOLUME_INFORMATION in $Volume is "
-			       "corrupt!\n");
+				"corrupt!\n");
 		errno = EIO;
 		goto err_out;
 	}
@@ -2220,7 +2220,7 @@ int ntfs_set_locale(void)
 	if (!locale) {
 		locale = setlocale(LC_ALL, NULL);
 		ntfs_log_error("Couldn't set local environment, using default "
-			       "'%s'.\n", locale);
+				"'%s'.\n", locale);
 		return 1;
 	}
 	return 0;
@@ -2275,7 +2275,7 @@ int ntfs_volume_rename(ntfs_volume *vol, const ntfschar *label, int label_len)
 
 	if (NVolReadOnly(vol)) {
 		ntfs_log_error("Refusing to change label on read-only mounted "
-			"volume.\n");
+				"volume.\n");
 		errno = EROFS;
 		return -1;
 	}
@@ -2294,17 +2294,17 @@ int ntfs_volume_rename(ntfs_volume *vol, const ntfschar *label, int label_len)
 		if (errno != ENOENT) {
 			err = errno;
 			ntfs_log_perror("Lookup of $VOLUME_NAME attribute "
-				"failed");
+					"failed");
 			goto err_out;
 		}
 
 		/* The volume name attribute does not exist.  Need to add it. */
 		if (ntfs_attr_add(vol->vol_ni, AT_VOLUME_NAME, AT_UNNAMED, 0,
-			(const u8*) label, label_len))
+					(const u8*) label, label_len))
 		{
 			err = errno;
 			ntfs_log_perror("Encountered error while adding "
-				"$VOLUME_NAME attribute");
+					"$VOLUME_NAME attribute");
 			goto err_out;
 		}
 	}
@@ -2322,7 +2322,7 @@ int ntfs_volume_rename(ntfs_volume *vol, const ntfschar *label, int label_len)
 			if (ntfs_attr_truncate(na, label_len)) {
 				err = errno;
 				ntfs_log_perror("Error resizing resident "
-					"attribute");
+						"attribute");
 				goto err_out;
 			}
 		}
@@ -2332,13 +2332,13 @@ int ntfs_volume_rename(ntfs_volume *vol, const ntfschar *label, int label_len)
 			if (written == -1) {
 				err = errno;
 				ntfs_log_perror("Error when writing "
-					"$VOLUME_NAME data");
+						"$VOLUME_NAME data");
 				goto err_out;
 			}
 			else if (written != label_len) {
 				err = EIO;
 				ntfs_log_error("Partial write when writing "
-					"$VOLUME_NAME data.");
+						"$VOLUME_NAME data.");
 				goto err_out;
 
 			}

--- a/libntfs/win32_io.c
+++ b/libntfs/win32_io.c
@@ -46,12 +46,12 @@ typedef unsigned long long DWORD64;
 #endif
 
 typedef struct {
-        DWORD data1;     /* The first eight hexadecimal digits of the GUID. */
-        WORD data2;     /* The first group of four hexadecimal digits. */
-        WORD data3;     /* The second group of four hexadecimal digits. */
-        char data4[8];    /* The first two bytes are the third group of four
-                           hexadecimal digits. The remaining six bytes are the
-                           final 12 hexadecimal digits. */
+	DWORD data1;     /* The first eight hexadecimal digits of the GUID. */
+	WORD data2;     /* The first group of four hexadecimal digits. */
+	WORD data3;     /* The second group of four hexadecimal digits. */
+	char data4[8];    /* The first two bytes are the third group of four
+						 hexadecimal digits. The remaining six bytes are the
+						 final 12 hexadecimal digits. */
 } GUID;
 
 #include <winioctl.h>
@@ -135,26 +135,26 @@ static LPFN_SETFILEPOINTEREX fnSetFilePointerEx = NULL;
 #endif
 
 enum { /* see http://msdn.microsoft.com/en-us/library/cc704588(v=prot.10).aspx */
-   STATUS_UNKNOWN = -1,
-   STATUS_SUCCESS =              0x00000000,
-   STATUS_BUFFER_OVERFLOW =      0x80000005,
-   STATUS_INVALID_HANDLE =       0xC0000008,
-   STATUS_INVALID_PARAMETER =    0xC000000D,
-   STATUS_INVALID_DEVICE_REQUEST = 0xC0000010,
-   STATUS_END_OF_FILE =          0xC0000011,
-   STATUS_CONFLICTING_ADDRESSES = 0xC0000018,
-   STATUS_NO_MATCH =             0xC000001E,
-   STATUS_ACCESS_DENIED =        0xC0000022,
-   STATUS_BUFFER_TOO_SMALL =     0xC0000023,
-   STATUS_OBJECT_TYPE_MISMATCH = 0xC0000024,
-   STATUS_FILE_NOT_FOUND =       0xC0000028,
-   STATUS_OBJECT_NAME_INVALID =  0xC0000033,
-   STATUS_OBJECT_NAME_NOT_FOUND = 0xC0000034,
-   STATUS_SHARING_VIOLATION =    0xC0000043,
-   STATUS_INVALID_PARAMETER_1 =  0xC00000EF,
-   STATUS_IO_DEVICE_ERROR =      0xC0000185,
-   STATUS_GUARD_PAGE_VIOLATION = 0x80000001
- } ;
+	STATUS_UNKNOWN = -1,
+	STATUS_SUCCESS =              0x00000000,
+	STATUS_BUFFER_OVERFLOW =      0x80000005,
+	STATUS_INVALID_HANDLE =       0xC0000008,
+	STATUS_INVALID_PARAMETER =    0xC000000D,
+	STATUS_INVALID_DEVICE_REQUEST = 0xC0000010,
+	STATUS_END_OF_FILE =          0xC0000011,
+	STATUS_CONFLICTING_ADDRESSES = 0xC0000018,
+	STATUS_NO_MATCH =             0xC000001E,
+	STATUS_ACCESS_DENIED =        0xC0000022,
+	STATUS_BUFFER_TOO_SMALL =     0xC0000023,
+	STATUS_OBJECT_TYPE_MISMATCH = 0xC0000024,
+	STATUS_FILE_NOT_FOUND =       0xC0000028,
+	STATUS_OBJECT_NAME_INVALID =  0xC0000033,
+	STATUS_OBJECT_NAME_NOT_FOUND = 0xC0000034,
+	STATUS_SHARING_VIOLATION =    0xC0000043,
+	STATUS_INVALID_PARAMETER_1 =  0xC00000EF,
+	STATUS_IO_DEVICE_ERROR =      0xC0000185,
+	STATUS_GUARD_PAGE_VIOLATION = 0x80000001
+} ;
 
 typedef u32 NTSTATUS; /* do not let the compiler choose the size */
 #ifdef __x86_64__
@@ -174,7 +174,7 @@ typedef struct _IO_STATUS_BLOCK {
 		NTSTATUS Status;
 		PVOID    Pointer;
 	};
-  	ULONG_PTR Information;
+	ULONG_PTR Information;
 } IO_STATUS_BLOCK, *PIO_STATUS_BLOCK;
 
 typedef struct _UNICODE_STRING {
@@ -213,67 +213,67 @@ typedef struct _OBJECT_ATTRIBUTES {
 typedef void (WINAPI *PIO_APC_ROUTINE)(void*, PIO_STATUS_BLOCK, ULONG);
 
 extern WINAPI NTSTATUS NtOpenFile(
-	PHANDLE FileHandle,
-	ACCESS_MASK DesiredAccess,
-	POBJECT_ATTRIBUTES ObjectAttributes,
-	PIO_STATUS_BLOCK IoStatusBlock,
-	ULONG ShareAccess,
-	ULONG OpenOptions
-);
+		PHANDLE FileHandle,
+		ACCESS_MASK DesiredAccess,
+		POBJECT_ATTRIBUTES ObjectAttributes,
+		PIO_STATUS_BLOCK IoStatusBlock,
+		ULONG ShareAccess,
+		ULONG OpenOptions
+		);
 
 extern WINAPI NTSTATUS NtReadFile(
-	HANDLE FileHandle,
-	HANDLE Event,
-	PIO_APC_ROUTINE ApcRoutine,
-	PVOID ApcContext,
-	PIO_STATUS_BLOCK IoStatusBlock,
-	PVOID Buffer,
-	ULONG Length,
-	PLARGE_INTEGER ByteOffset,
-	PULONG Key
-);
+		HANDLE FileHandle,
+		HANDLE Event,
+		PIO_APC_ROUTINE ApcRoutine,
+		PVOID ApcContext,
+		PIO_STATUS_BLOCK IoStatusBlock,
+		PVOID Buffer,
+		ULONG Length,
+		PLARGE_INTEGER ByteOffset,
+		PULONG Key
+		);
 
 extern WINAPI NTSTATUS NtWriteFile(
-	HANDLE FileHandle,
-	HANDLE Event,
-	PIO_APC_ROUTINE ApcRoutine,
-	PVOID ApcContext,
-	PIO_STATUS_BLOCK IoStatusBlock,
-	LPCVOID Buffer,
-	ULONG Length,
-	PLARGE_INTEGER ByteOffset,
-	PULONG Key
-);
+		HANDLE FileHandle,
+		HANDLE Event,
+		PIO_APC_ROUTINE ApcRoutine,
+		PVOID ApcContext,
+		PIO_STATUS_BLOCK IoStatusBlock,
+		LPCVOID Buffer,
+		ULONG Length,
+		PLARGE_INTEGER ByteOffset,
+		PULONG Key
+		);
 
 extern NTSTATUS WINAPI NtClose(
-	HANDLE Handle
-);
+		HANDLE Handle
+		);
 
 extern NTSTATUS WINAPI NtDeviceIoControlFile(
-	HANDLE FileHandle,
-	HANDLE Event,
-	PIO_APC_ROUTINE ApcRoutine,
-	PVOID ApcContext,
-	PIO_STATUS_BLOCK IoStatusBlock,
-	ULONG IoControlCode,
-	PVOID InputBuffer,
-	ULONG InputBufferLength,
-	PVOID OutputBuffer,
-	ULONG OutputBufferLength
-);
+		HANDLE FileHandle,
+		HANDLE Event,
+		PIO_APC_ROUTINE ApcRoutine,
+		PVOID ApcContext,
+		PIO_STATUS_BLOCK IoStatusBlock,
+		ULONG IoControlCode,
+		PVOID InputBuffer,
+		ULONG InputBufferLength,
+		PVOID OutputBuffer,
+		ULONG OutputBufferLength
+		);
 
 extern NTSTATUS	WINAPI NtFsControlFile(
-	HANDLE FileHandle,
-	HANDLE Event,
-	PIO_APC_ROUTINE ApcRoutine,
-	PVOID ApcContext,
-	PIO_STATUS_BLOCK IoStatusBlock,
-	ULONG FsControlCode,
-	PVOID InputBuffer,
-	ULONG InputBufferLength,
-	PVOID OutputBuffer,
-	ULONG OutputBufferLength
-);
+		HANDLE FileHandle,
+		HANDLE Event,
+		PIO_APC_ROUTINE ApcRoutine,
+		PVOID ApcContext,
+		PIO_STATUS_BLOCK IoStatusBlock,
+		ULONG FsControlCode,
+		PVOID InputBuffer,
+		ULONG InputBufferLength,
+		PVOID OutputBuffer,
+		ULONG OutputBufferLength
+		);
 
 /**
  * struct win32_fd -
@@ -410,8 +410,8 @@ static void ntfs_device_win32_init_imports(void)
 	if (!fnSetFilePointerEx) {
 		if (kernel32)
 			fnSetFilePointerEx = (LPFN_SETFILEPOINTEREX)
-					GetProcAddress(kernel32,
-					"SetFilePointerEx");
+				GetProcAddress(kernel32,
+						"SetFilePointerEx");
 		/*
 		 * If we did not get kernel32.dll or it is not Win2k+, emulate
 		 * SetFilePointerEx().
@@ -427,15 +427,15 @@ static void ntfs_device_win32_init_imports(void)
 		return;
 	if (!fnFindFirstVolume)
 		fnFindFirstVolume = (LPFN_FINDFIRSTVOLUME)
-				GetProcAddress(kernel32, "FindFirstVolume"
-				FNPOSTFIX);
+			GetProcAddress(kernel32, "FindFirstVolume"
+					FNPOSTFIX);
 	if (!fnFindNextVolume)
 		fnFindNextVolume = (LPFN_FINDNEXTVOLUME)
-				GetProcAddress(kernel32, "FindNextVolume"
-				FNPOSTFIX);
+			GetProcAddress(kernel32, "FindNextVolume"
+					FNPOSTFIX);
 	if (!fnFindVolumeClose)
 		fnFindVolumeClose = (LPFN_FINDVOLUMECLOSE)
-				GetProcAddress(kernel32, "FindVolumeClose");
+			GetProcAddress(kernel32, "FindVolumeClose");
 }
 
 /**
@@ -449,19 +449,19 @@ static __inline__ int ntfs_device_unix_status_flags_to_win32(int flags)
 	int win_mode;
 
 	switch (flags & O_ACCMODE) {
-	case O_RDONLY:
-		win_mode = GENERIC_READ;
-		break;
-	case O_WRONLY:
-		win_mode = GENERIC_WRITE;
-		break;
-	case O_RDWR:
-		win_mode = GENERIC_READ | GENERIC_WRITE;
-		break;
-	default:
-		/* error */
-		ntfs_log_trace("Unknown status flags.\n");
-		win_mode = 0;
+		case O_RDONLY:
+			win_mode = GENERIC_READ;
+			break;
+		case O_WRONLY:
+			win_mode = GENERIC_WRITE;
+			break;
+		case O_RDWR:
+			win_mode = GENERIC_READ | GENERIC_WRITE;
+			break;
+		default:
+			/* error */
+			ntfs_log_trace("Unknown status flags.\n");
+			win_mode = 0;
 	}
 	return win_mode;
 }
@@ -510,7 +510,7 @@ static int ntfs_device_win32_lock(HANDLE handle)
 	DWORD i;
 
 	if (!DeviceIoControl(handle, FSCTL_LOCK_VOLUME, NULL, 0, NULL, 0, &i,
-			NULL)) {
+				NULL)) {
 		errno = ntfs_w32error_to_errno(GetLastError());
 		ntfs_log_trace("Couldn't lock volume.\n");
 		return -1;
@@ -531,7 +531,7 @@ static int ntfs_device_win32_unlock(HANDLE handle)
 	DWORD i;
 
 	if (!DeviceIoControl(handle, FSCTL_UNLOCK_VOLUME, NULL, 0, NULL, 0, &i,
-			NULL)) {
+				NULL)) {
 		errno = ntfs_w32error_to_errno(GetLastError());
 		ntfs_log_trace("Couldn't unlock volume.\n");
 		return -1;
@@ -548,9 +548,9 @@ static int ntfs_device_win32_setlock(HANDLE handle, ULONG code)
 	io_status.Status = STATUS_SUCCESS;
 	io_status.Information = 0;
 	res = NtFsControlFile(handle,(HANDLE)NULL,
-				(PIO_APC_ROUTINE)NULL,(void*)NULL,
-				&io_status, code,
-				(char*)NULL,0,(char*)NULL,0);
+			(PIO_APC_ROUTINE)NULL,(void*)NULL,
+			&io_status, code,
+			(char*)NULL,0,(char*)NULL,0);
 	if (res != STATUS_SUCCESS)
 		errno = ntfs_ntstatus_to_errno(res);
 	return (res == STATUS_SUCCESS ? 0 : -1);
@@ -574,7 +574,7 @@ static int ntfs_device_win32_dismount(HANDLE handle)
 	DWORD i;
 
 	if (!DeviceIoControl(handle, FSCTL_DISMOUNT_VOLUME, NULL, 0, NULL, 0,
-			&i, NULL)) {
+				&i, NULL)) {
 		errno = ntfs_w32error_to_errno(GetLastError());
 		ntfs_log_trace("Couldn't dismount volume.\n");
 		return -1;
@@ -600,7 +600,7 @@ static s64 ntfs_device_win32_getsize(HANDLE handle)
 	hiword = 0;
 	loword = SetFilePointer(handle, 0, &hiword, 2);
 	if ((loword == INVALID_SET_FILE_POINTER)
-	    && (GetLastError() != NO_ERROR)) {
+			&& (GetLastError() != NO_ERROR)) {
 		errno = ntfs_w32error_to_errno(GetLastError());
 		ntfs_log_trace("Couldn't get file size.\n");
 		return -1;
@@ -624,7 +624,7 @@ static s64 ntfs_device_win32_getdisklength(HANDLE handle)
 	DWORD i;
 
 	if (!DeviceIoControl(handle, IOCTL_DISK_GET_LENGTH_INFO, NULL, 0, &buf,
-			sizeof(buf), &i, NULL)) {
+				sizeof(buf), &i, NULL)) {
 		errno = ntfs_w32error_to_errno(GetLastError());
 		ntfs_log_trace("Couldn't get disk length.\n");
 		return -1;
@@ -656,7 +656,7 @@ static s64 ntfs_device_win32_getntfssize(HANDLE handle)
 	NTFS_VOLUME_DATA_BUFFER buf;
 
 	if (!DeviceIoControl(handle, FSCTL_GET_NTFS_VOLUME_DATA, NULL, 0, &buf,
-			sizeof(buf), &i, NULL)) {
+				sizeof(buf), &i, NULL)) {
 		errno = ntfs_w32error_to_errno(GetLastError());
 		ntfs_log_trace("Couldn't get NTFS volume length.\n");
 		return -1;
@@ -691,35 +691,35 @@ static int ntfs_device_win32_getgeo(HANDLE handle, win32_fd *fd)
 	DWORD i;
 	BOOL rvl;
 	BYTE b[sizeof(DISK_GEOMETRY) + sizeof(DISK_PARTITION_INFO) +
-			sizeof(DISK_DETECTION_INFO) + 512];
+		sizeof(DISK_DETECTION_INFO) + 512];
 
 	rvl = DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_GEOMETRY_EX, NULL,
 			0, &b, sizeof(b), &i, NULL);
 	if (rvl) {
 		ntfs_log_debug("GET_DRIVE_GEOMETRY_EX detected.\n");
 		DISK_DETECTION_INFO *ddi = (PDISK_DETECTION_INFO)
-				(((PBYTE)(&((PDISK_GEOMETRY_EX)b)->Data)) +
-				(((PDISK_PARTITION_INFO)
-				(&((PDISK_GEOMETRY_EX)b)->Data))->
-				SizeOfPartitionInfo));
+			(((PBYTE)(&((PDISK_GEOMETRY_EX)b)->Data)) +
+			 (((PDISK_PARTITION_INFO)
+			   (&((PDISK_GEOMETRY_EX)b)->Data))->
+			  SizeOfPartitionInfo));
 		fd->geo_cylinders = ((DISK_GEOMETRY*)&b)->Cylinders.QuadPart;
 		fd->geo_sectors = ((DISK_GEOMETRY*)&b)->SectorsPerTrack;
 		fd->geo_size = ((DISK_GEOMETRY_EX*)&b)->DiskSize.QuadPart;
 		fd->geo_sector_size = NTFS_BLOCK_SIZE;
 		switch (ddi->DetectionType) {
-		case DetectInt13:
-			fd->geo_cylinders = ddi->Int13.MaxCylinders;
-			fd->geo_sectors = ddi->Int13.SectorsPerTrack;
-			fd->geo_heads = ddi->Int13.MaxHeads;
-			return 0;
-		case DetectExInt13:
-			fd->geo_cylinders = ddi->ExInt13.ExCylinders;
-			fd->geo_sectors = ddi->ExInt13.ExSectorsPerTrack;
-			fd->geo_heads = ddi->ExInt13.ExHeads;
-			return 0;
-		case DetectNone:
-		default:
-			break;
+			case DetectInt13:
+				fd->geo_cylinders = ddi->Int13.MaxCylinders;
+				fd->geo_sectors = ddi->Int13.SectorsPerTrack;
+				fd->geo_heads = ddi->Int13.MaxHeads;
+				return 0;
+			case DetectExInt13:
+				fd->geo_cylinders = ddi->ExInt13.ExCylinders;
+				fd->geo_sectors = ddi->ExInt13.ExSectorsPerTrack;
+				fd->geo_heads = ddi->ExInt13.ExHeads;
+				return 0;
+			case DetectNone:
+			default:
+				break;
 		}
 	} else
 		fd->geo_heads = -1;
@@ -730,8 +730,8 @@ static int ntfs_device_win32_getgeo(HANDLE handle, win32_fd *fd)
 		fd->geo_cylinders = ((DISK_GEOMETRY*)&b)->Cylinders.QuadPart;
 		fd->geo_sectors = ((DISK_GEOMETRY*)&b)->SectorsPerTrack;
 		fd->geo_size = fd->geo_cylinders * fd->geo_sectors *
-				((DISK_GEOMETRY*)&b)->TracksPerCylinder *
-				((DISK_GEOMETRY*)&b)->BytesPerSector;
+			((DISK_GEOMETRY*)&b)->TracksPerCylinder *
+			((DISK_GEOMETRY*)&b)->BytesPerSector;
 		fd->geo_sector_size = ((DISK_GEOMETRY*)&b)->BytesPerSector;
 		return 0;
 	}
@@ -767,11 +767,11 @@ static int ntfs_device_win32_getntgeo(HANDLE handle, win32_fd *fd)
 		/* over-estimate the (rounded) number of cylinders */
 		fd->geo_cylinders = geo.Cylinders.QuadPart + 1;
 		fd->geo_sectors = fd->geo_cylinders
-				*geo.TracksPerCylinder*geo.SectorsPerTrack;
+			*geo.TracksPerCylinder*geo.SectorsPerTrack;
 		fd->geo_size = fd->geo_sectors*geo.BytesPerSector;
 		fd->geo_sector_size = geo.BytesPerSector;
 		res = 0;
-			/* try to get the exact sector count */
+		/* try to get the exact sector count */
 		st = NtDeviceIoControlFile(handle, (HANDLE)NULL,
 				(PIO_APC_ROUTINE)NULL, (void*)NULL,
 				&status, IOCTL_GET_DISK_LENGTH_INFO,
@@ -801,7 +801,7 @@ static __inline__ int ntfs_device_win32_open_file(char *filename, win32_fd *fd,
 	int mode;
 
 	if (ntfs_device_win32_simple_open_file(filename, &handle, flags,
-			FALSE)) {
+				FALSE)) {
 		/* open error */
 		return -1;
 	}
@@ -845,7 +845,7 @@ static __inline__ int ntfs_device_win32_open_drive(int drive_id, win32_fd *fd,
 
 	sprintf(filename, "\\\\.\\PhysicalDrive%d", drive_id);
 	if ((err = ntfs_device_win32_simple_open_file(filename, &handle, flags,
-			TRUE))) {
+					TRUE))) {
 		/* open error */
 		return err;
 	}
@@ -912,7 +912,7 @@ static __inline__ int ntfs_device_win32_open_lowlevel(int drive_id,
 	share = (mode == O_RDWR ?
 			0 : FILE_SHARE_READ | FILE_SHARE_WRITE);
 	access = (mode == O_RDWR ?
-			 FILE_READ_DATA | FILE_WRITE_DATA | SYNCHRONIZE
+			FILE_READ_DATA | FILE_WRITE_DATA | SYNCHRONIZE
 			: FILE_READ_DATA | SYNCHRONIZE);
 
 	st = NtOpenFile(&handle, access,
@@ -1009,26 +1009,26 @@ static HANDLE ntfs_device_win32_open_volume_for_partition(unsigned int drive_id,
 
 			/* Check physical locations. */
 			if (DeviceIoControl(handle,
-					IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
-					NULL, 0, extents, EXTENTS_SIZE,
-					&bytesReturned, NULL)) {
+						IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS,
+						NULL, 0, extents, EXTENTS_SIZE,
+						&bytesReturned, NULL)) {
 				if (((VOLUME_DISK_EXTENTS *)extents)->
 						NumberOfDiskExtents == 1) {
 					DISK_EXTENT *extent = &((
-							VOLUME_DISK_EXTENTS *)
+								VOLUME_DISK_EXTENTS *)
 							extents)->Extents[0];
 					if ((extent->DiskNumber==drive_id) &&
 							(extent->StartingOffset.
-							QuadPart==part_offset)
+							 QuadPart==part_offset)
 							&& (extent->
-							ExtentLength.QuadPart
-							== part_length)) {
+								ExtentLength.QuadPart
+								== part_length)) {
 						/*
 						 * Eureka! (Archimedes, 287 BC,
 						 * "I have found it!")
 						 */
 						fnFindVolumeClose(
-							vol_find_handle);
+								vol_find_handle);
 						return handle;
 					}
 				}
@@ -1071,14 +1071,14 @@ static BOOL ntfs_device_win32_find_partition(HANDLE handle, DWORD partition_id,
 	part_count = 8;
 	do {
 		buf_size = sizeof(DRIVE_LAYOUT_INFORMATION) +
-				part_count * sizeof(PARTITION_INFORMATION);
+			part_count * sizeof(PARTITION_INFORMATION);
 		drive_layout = (DRIVE_LAYOUT_INFORMATION*)ntfs_malloc(buf_size);
 		if (!drive_layout) {
 			errno = ENOMEM;
 			return FALSE;
 		}
 		if (DeviceIoControl(handle, IOCTL_DISK_GET_DRIVE_LAYOUT, NULL,
-				0, (BYTE*)drive_layout, buf_size, &i, NULL))
+					0, (BYTE*)drive_layout, buf_size, &i, NULL))
 			break;
 		err = GetLastError();
 		free(drive_layout);
@@ -1100,11 +1100,11 @@ static BOOL ntfs_device_win32_find_partition(HANDLE handle, DWORD partition_id,
 		if (drive_layout->PartitionEntry[i].PartitionNumber ==
 				partition_id) {
 			*part_offset = drive_layout->PartitionEntry[i].
-					StartingOffset.QuadPart;
+				StartingOffset.QuadPart;
 			*part_length = drive_layout->PartitionEntry[i].
-					PartitionLength.QuadPart;
+				PartitionLength.QuadPart;
 			*hidden_sectors = drive_layout->PartitionEntry[i].
-					HiddenSectors;
+				HiddenSectors;
 			free(drive_layout);
 			return TRUE;
 		}
@@ -1137,15 +1137,15 @@ static int ntfs_device_win32_open_partition(int drive_id,
 	sprintf(drive_name, "\\\\.\\PhysicalDrive%d", drive_id);
 	/* Open the entire device without locking, ask questions later */
 	if ((err = ntfs_device_win32_simple_open_file(drive_name, &handle,
-			flags, FALSE))) {
+					flags, FALSE))) {
 		/* error */
 		return err;
 	}
 	if (ntfs_device_win32_find_partition(handle, partition_id, &part_start,
-			&part_length, &hidden_sectors)) {
+				&part_length, &hidden_sectors)) {
 		s64 tmp;
 		HANDLE vol_handle = ntfs_device_win32_open_volume_for_partition(
-			drive_id, part_start, part_length, flags);
+				drive_id, part_start, part_length, flags);
 		/* Store the drive geometry. */
 		ntfs_device_win32_getgeo(handle, fd);
 		fd->handle = handle;
@@ -1218,38 +1218,38 @@ static int ntfs_device_win32_open(struct ntfs_device *dev, int flags)
 	ntfs_device_win32_init_imports();
 	numparams = sscanf(dev->d_name, "/dev/hd%c%u", &drive_char, &part);
 	if (!numparams
-	    && (dev->d_name[1] == ':')
-	    && (dev->d_name[2] == '\0')) {
+			&& (dev->d_name[1] == ':')
+			&& (dev->d_name[2] == '\0')) {
 		drive_char = dev->d_name[0];
 		numparams = 3;
 		drive_id = toupper(drive_char) - 'A';
 	}
 	switch (numparams) {
-	case 0:
-		ntfs_log_debug("win32_open(%s) -> file.\n", dev->d_name);
-		err = ntfs_device_win32_open_file(dev->d_name, &fd, flags);
-		break;
-	case 1:
-		ntfs_log_debug("win32_open(%s) -> drive %d.\n", dev->d_name,
-				drive_id);
-		err = ntfs_device_win32_open_drive(drive_id, &fd, flags);
-		break;
-	case 2:
-		ntfs_log_debug("win32_open(%s) -> drive %d, part %u.\n",
-				dev->d_name, drive_id, part);
-		err = ntfs_device_win32_open_partition(drive_id, part, &fd,
-				flags);
-		break;
-	case 3:
-		ntfs_log_debug("win32_open(%s) -> drive %c:\n",
-				dev->d_name, drive_char);
-		err = ntfs_device_win32_open_lowlevel(drive_id, &fd,
-				flags);
-		break;
-	default:
-		ntfs_log_debug("win32_open(%s) -> unknwon file format.\n",
-				dev->d_name);
-		err = -1;
+		case 0:
+			ntfs_log_debug("win32_open(%s) -> file.\n", dev->d_name);
+			err = ntfs_device_win32_open_file(dev->d_name, &fd, flags);
+			break;
+		case 1:
+			ntfs_log_debug("win32_open(%s) -> drive %d.\n", dev->d_name,
+					drive_id);
+			err = ntfs_device_win32_open_drive(drive_id, &fd, flags);
+			break;
+		case 2:
+			ntfs_log_debug("win32_open(%s) -> drive %d, part %u.\n",
+					dev->d_name, drive_id, part);
+			err = ntfs_device_win32_open_partition(drive_id, part, &fd,
+					flags);
+			break;
+		case 3:
+			ntfs_log_debug("win32_open(%s) -> drive %c:\n",
+					dev->d_name, drive_char);
+			err = ntfs_device_win32_open_lowlevel(drive_id, &fd,
+					flags);
+			break;
+		default:
+			ntfs_log_debug("win32_open(%s) -> unknwon file format.\n",
+					dev->d_name);
+			err = -1;
 	}
 	if (err)
 		return err;
@@ -1287,29 +1287,29 @@ static s64 ntfs_device_win32_seek(struct ntfs_device *dev, s64 offset,
 
 	ntfs_log_trace("seek offset = 0x%llx, whence = %d.\n", offset, whence);
 	switch (whence) {
-	case SEEK_SET:
-		abs_ofs = offset;
-		break;
-	case SEEK_CUR:
-		abs_ofs = fd->pos + offset;
-		break;
-	case SEEK_END:
-		/* End of partition != end of disk. */
-		if (fd->part_length == -1) {
-			ntfs_log_trace("Position relative to end of disk not "
-					"implemented.\n");
-			errno = EOPNOTSUPP;
+		case SEEK_SET:
+			abs_ofs = offset;
+			break;
+		case SEEK_CUR:
+			abs_ofs = fd->pos + offset;
+			break;
+		case SEEK_END:
+			/* End of partition != end of disk. */
+			if (fd->part_length == -1) {
+				ntfs_log_trace("Position relative to end of disk not "
+						"implemented.\n");
+				errno = EOPNOTSUPP;
+				return -1;
+			}
+			abs_ofs = fd->part_length + offset;
+			break;
+		default:
+			ntfs_log_trace("Wrong mode %d.\n", whence);
+			errno = EINVAL;
 			return -1;
-		}
-		abs_ofs = fd->part_length + offset;
-		break;
-	default:
-		ntfs_log_trace("Wrong mode %d.\n", whence);
-		errno = EINVAL;
-		return -1;
 	}
 	if ((abs_ofs < 0)
-	    || (fd->ntdll && (abs_ofs > fd->part_length))) {
+			|| (fd->ntdll && (abs_ofs > fd->part_length))) {
 		ntfs_log_trace("Seeking outsize seekable area.\n");
 		errno = EINVAL;
 		return -1;
@@ -1396,14 +1396,14 @@ static s64 ntfs_device_win32_pio(win32_fd *fd, const s64 pos,
 		if (!res) {
 			errno = ntfs_w32error_to_errno(GetLastError());
 			ntfs_log_trace("%sFile() failed.\n", write ?
-							"Write" : "Read");
+					"Write" : "Read");
 			return -1;
 		}
 		if (rbuf && !pos) {
 			/* get the sector size from the boot sector */
 			char *boot = (char*)rbuf;
 			fd->geo_sector_size = (boot[11] & 255)
-						+ ((boot[12] & 255) << 8);
+				+ ((boot[12] & 255) << 8);
 		}
 	}
 	return bytes;
@@ -1450,7 +1450,7 @@ static s64 ntfs_device_win32_read(struct ntfs_device *dev, void *b, s64 count)
 	old_pos = fd->pos;
 	old_ofs = ofs = old_pos & (fd->geo_sector_size - 1);
 	to_read = (ofs + count + fd->geo_sector_size - 1) &
-			~(s64)(fd->geo_sector_size - 1);
+		~(s64)(fd->geo_sector_size - 1);
 	/* Impose maximum of 2GB to be on the safe side. */
 	if (to_read > 0x80000000) {
 		int delta = to_read - count;
@@ -1644,7 +1644,7 @@ static s64 ntfs_device_win32_write(struct ntfs_device *dev, const void *b,
 	old_pos = fd->pos;
 	old_ofs = ofs = old_pos & (fd->geo_sector_size - 1);
 	to_write = (ofs + count + fd->geo_sector_size - 1) &
-			~(s64)(fd->geo_sector_size - 1);
+		~(s64)(fd->geo_sector_size - 1);
 	/* Impose maximum of 2GB to be on the safe side. */
 	if (to_write > 0x80000000) {
 		int delta = to_write - count;
@@ -1774,17 +1774,17 @@ static int ntfs_device_win32_stat(struct ntfs_device *dev, struct stat *buf)
 		st_mode = S_IFBLK;
 	else
 		switch (GetFileType(fd->handle)) {
-		case FILE_TYPE_CHAR:
-			st_mode = S_IFCHR;
-			break;
-		case FILE_TYPE_DISK:
-			st_mode = S_IFREG;
-			break;
-		case FILE_TYPE_PIPE:
-			st_mode = S_IFIFO;
-			break;
-		default:
-			st_mode = 0;
+			case FILE_TYPE_CHAR:
+				st_mode = S_IFCHR;
+				break;
+			case FILE_TYPE_DISK:
+				st_mode = S_IFREG;
+				break;
+			case FILE_TYPE_PIPE:
+				st_mode = S_IFIFO;
+				break;
+			default:
+				st_mode = 0;
 		}
 	memset(buf, 0, sizeof(struct stat));
 	buf->st_mode = st_mode;
@@ -1837,7 +1837,7 @@ static __inline__ int ntfs_win32_blksszget(struct ntfs_device *dev,int *argp)
 	DISK_GEOMETRY dg;
 
 	if (DeviceIoControl(fd->handle, IOCTL_DISK_GET_DRIVE_GEOMETRY, NULL, 0,
-			&dg, sizeof(DISK_GEOMETRY), &bytesReturned, NULL)) {
+				&dg, sizeof(DISK_GEOMETRY), &bytesReturned, NULL)) {
 		/* success */
 		*argp = dg.BytesPerSector;
 		return 0;
@@ -1909,7 +1909,7 @@ static s64 ntfs_device_win32_pread(struct ntfs_device *dev, void *b,
 	s64 got;
 	win32_fd *fd;
 
-		/* read the fast way if sector aligned */
+	/* read the fast way if sector aligned */
 	fd = (win32_fd*)dev->d_private;
 	if (!((count | offset) & (fd->geo_sector_size - 1))) {
 		got = ntfs_device_win32_pio(fd, offset, count, b, (void*)NULL);
@@ -1929,7 +1929,7 @@ static s64 ntfs_device_win32_pwrite(struct ntfs_device *dev, const void *b,
 	s64 put;
 	win32_fd *fd;
 
-		/* write the fast way if sector aligned */
+	/* write the fast way if sector aligned */
 	fd = (win32_fd*)dev->d_private;
 	if (!((count | offset) & (fd->geo_sector_size - 1))) {
 		put = ntfs_device_win32_pio(fd, offset, count, (void*)NULL, b);
@@ -1999,15 +1999,15 @@ static int win32_ftruncate(HANDLE handle, s64 size)
 		ok = FALSE;
 	else {
 		SetLastError(NO_ERROR);
-			/* save original position */
+		/* save original position */
 		ohsize = 0;
 		olsize = SetFilePointer(handle, 0, &ohsize, 1);
 		hsize = size >> 32;
 		lsize = size & 0xffffffff;
 		ok = (SetFilePointer(handle, lsize, &hsize, 0) == (DWORD)lsize)
-		    && (GetLastError() == NO_ERROR)
-		    && SetEndOfFile(handle);
-			/* restore original position, even if above failed */
+			&& (GetLastError() == NO_ERROR)
+			&& SetEndOfFile(handle);
+		/* restore original position, even if above failed */
 		SetFilePointer(handle, olsize, &ohsize, 0);
 		if (GetLastError() != NO_ERROR)
 			ok = FALSE;

--- a/libntfs/xattrs.c
+++ b/libntfs/xattrs.c
@@ -152,7 +152,7 @@ static void fix_big_endian(char *p, int size)
  */
 
 static int le_acl_to_cpu(const struct LE_POSIX_ACL *le_acl, size_t size,
-				struct POSIX_ACL *acl)
+		struct POSIX_ACL *acl)
 {
 	int i;
 	int cnt;
@@ -174,7 +174,7 @@ static int le_acl_to_cpu(const struct LE_POSIX_ACL *le_acl, size_t size,
  */
 
 int cpu_to_le_acl(const struct POSIX_ACL *acl, size_t size,
-			struct LE_POSIX_ACL *le_acl)
+		struct LE_POSIX_ACL *le_acl)
 {
 	int i;
 	int cnt;
@@ -200,7 +200,7 @@ int cpu_to_le_acl(const struct POSIX_ACL *acl, size_t size,
  */
 
 enum SYSTEMXATTRS ntfs_xattr_system_type(const char *name,
-			ntfs_volume *vol)
+		ntfs_volume *vol)
 {
 	struct XATTRNAME *p;
 	enum SYSTEMXATTRS ret;
@@ -222,9 +222,9 @@ enum SYSTEMXATTRS ntfs_xattr_system_type(const char *name,
 	}
 #else /* XATTR_MAPPINGS */
 	if (!p->name
-	    && vol
-	    && vol->efs_raw
-	    && !strcmp(nf_ns_alt_xattr_efsinfo,name))
+			&& vol
+			&& vol->efs_raw
+			&& !strcmp(nf_ns_alt_xattr_efsinfo,name))
 		ret = XATTR_NTFS_EFSINFO;
 #endif /* XATTR_MAPPINGS */
 	return (ret);
@@ -249,7 +249,7 @@ static int basicread(void *fileid, char *buf, size_t size, off_t offs __attribut
 static int localread(void *fileid, char *buf, size_t size, off_t offs)
 {
 	return (ntfs_attr_data_read((ntfs_inode*)fileid,
-			AT_UNNAMED, 0, buf, size, offs));
+				AT_UNNAMED, 0, buf, size, offs));
 }
 
 /*
@@ -260,7 +260,7 @@ static int localread(void *fileid, char *buf, size_t size, off_t offs)
  *	Returns pointer to item, or NULL when there is no more
  *	Note : errors are logged, but not returned
 // TODO partially share with acls.c
- */
+*/
 
 static struct XATTRMAPPING *getmappingitem(FILEREADER reader, void *fileid,
 		off_t *poffs, char *buf, int *psrc, s64 *psize)
@@ -280,12 +280,12 @@ static struct XATTRMAPPING *getmappingitem(FILEREADER reader, void *fileid,
 	do {
 		gotend = 0;
 		while ((src < *psize)
-		       && (buf[src] != '\n')) {
-				/* ignore spaces */
+				&& (buf[src] != '\n')) {
+			/* ignore spaces */
 			if ((dst < LINESZ)
-			    && (buf[src] != '\r')
-			    && (buf[src] != '\t')
-			    && (buf[src] != ' '))
+					&& (buf[src] != '\r')
+					&& (buf[src] != '\t')
+					&& (buf[src] != ' '))
 				maptext[dst++] = buf[src];
 			src++;
 		}
@@ -302,7 +302,7 @@ static struct XATTRMAPPING *getmappingitem(FILEREADER reader, void *fileid,
 	} while (*psize && ((maptext[0] == '#') || !gotend));
 	item = (struct XATTRMAPPING*)NULL;
 	if (gotend) {
-			/* decompose into system name and user name */
+		/* decompose into system name and user name */
 		ps = maptext;
 		pu = strchr(maptext,':');
 		if (pu) {
@@ -310,7 +310,7 @@ static struct XATTRMAPPING *getmappingitem(FILEREADER reader, void *fileid,
 			pe = strchr(pu,':');
 			if (pe)
 				*pe = 0;
-				/* check name validity */
+			/* check name validity */
 			if ((strlen(pu) < 6) || strncmp(pu,"user.",5))
 				pu = (char*)NULL;
 			xattr = ntfs_xattr_system_type(ps,
@@ -320,8 +320,8 @@ static struct XATTRMAPPING *getmappingitem(FILEREADER reader, void *fileid,
 		}
 		if (pu) {
 			item = (struct XATTRMAPPING*)ntfs_malloc(
-				sizeof(struct XATTRMAPPING)
-				+ strlen(pu));
+					sizeof(struct XATTRMAPPING)
+					+ strlen(pu));
 			if (item) {
 				item->xattr = xattr;
 				strcpy(item->name,pu);
@@ -351,7 +351,7 @@ static struct XATTRMAPPING *getmappingitem(FILEREADER reader, void *fileid,
  */
 
 static struct XATTRMAPPING *ntfs_read_xattr_mapping(FILEREADER reader,
-				void *fileid)
+		void *fileid)
 {
 	char buf[BUFSZ];
 	struct XATTRMAPPING *item;
@@ -371,13 +371,13 @@ static struct XATTRMAPPING *ntfs_read_xattr_mapping(FILEREADER reader,
 		src = 0;
 		do {
 			item = getmappingitem(reader, fileid, &offs,
-				buf, &src, &size);
+					buf, &src, &size);
 			if (item) {
 				/* check no double mapping */
 				duplicated = FALSE;
 				for (current=firstitem; current; current=current->next)
 					if ((current->xattr == item->xattr)
-					    || !strcmp(current->name,item->name))
+							|| !strcmp(current->name,item->name))
 						duplicated = TRUE;
 				if (duplicated) {
 					free(item);
@@ -404,7 +404,7 @@ static struct XATTRMAPPING *ntfs_read_xattr_mapping(FILEREADER reader,
  */
 
 struct XATTRMAPPING *ntfs_xattr_build_mapping(ntfs_volume *vol,
-			const char *xattrmap_path)
+		const char *xattrmap_path)
 {
 	struct XATTRMAPPING *firstmapping;
 	struct XATTRMAPPING *mapping;
@@ -480,9 +480,9 @@ void ntfs_xattr_free_mapping(struct XATTRMAPPING *mapping)
  */
 
 int ntfs_xattr_system_getxattr(struct SECURITY_CONTEXT *scx,
-			enum SYSTEMXATTRS attr,
-			ntfs_inode *ni, ntfs_inode *dir_ni,
-			char *value, size_t size)
+		enum SYSTEMXATTRS attr,
+		ntfs_inode *ni, ntfs_inode *dir_ni,
+		char *value, size_t size)
 {
 	int res;
 	int i;
@@ -502,10 +502,10 @@ int ntfs_xattr_system_getxattr(struct SECURITY_CONTEXT *scx,
 		acl = (struct POSIX_ACL*)ntfs_malloc(size);
 		if (acl) {
 			res = ntfs_get_posix_acl(scx, ni,
-				nf_ns_xattr_posix_access, (char*)acl, size);
+					nf_ns_xattr_posix_access, (char*)acl, size);
 			if (res > 0) {
 				if (cpu_to_le_acl(acl,res,
-						(struct LE_POSIX_ACL*)value))
+							(struct LE_POSIX_ACL*)value))
 					res = -errno;
 			}
 			free(acl);
@@ -516,10 +516,10 @@ int ntfs_xattr_system_getxattr(struct SECURITY_CONTEXT *scx,
 		acl = (struct POSIX_ACL*)ntfs_malloc(size);
 		if (acl) {
 			res = ntfs_get_posix_acl(scx, ni,
-				nf_ns_xattr_posix_default, (char*)acl, size);
+					nf_ns_xattr_posix_default, (char*)acl, size);
 			if (res > 0) {
 				if (cpu_to_le_acl(acl,res,
-						(struct LE_POSIX_ACL*)value))
+							(struct LE_POSIX_ACL*)value))
 					res = -errno;
 			}
 			free(acl);
@@ -607,9 +607,9 @@ int ntfs_xattr_system_getxattr(struct SECURITY_CONTEXT *scx,
  */
 
 int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
-			enum SYSTEMXATTRS attr,
-			ntfs_inode *ni, ntfs_inode *dir_ni,
-			const char *value, size_t size, int flags)
+		enum SYSTEMXATTRS attr,
+		ntfs_inode *ni, ntfs_inode *dir_ni,
+		const char *value, size_t size, int flags)
 {
 	int res;
 	int i;
@@ -630,10 +630,10 @@ int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
 		acl = (struct POSIX_ACL*)ntfs_malloc(size);
 		if (acl) {
 			if (!le_acl_to_cpu((const struct LE_POSIX_ACL*)value,
-					size, acl)) {
+						size, acl)) {
 				res = ntfs_set_posix_acl(scx ,ni ,
-					nf_ns_xattr_posix_access,
-					(char*)acl, size, flags);
+						nf_ns_xattr_posix_access,
+						(char*)acl, size, flags);
 			} else
 				res = -errno;
 			free(acl);
@@ -644,10 +644,10 @@ int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
 		acl = (struct POSIX_ACL*)ntfs_malloc(size);
 		if (acl) {
 			if (!le_acl_to_cpu((const struct LE_POSIX_ACL*)value,
-					size, acl)) {
+						size, acl)) {
 				res = ntfs_set_posix_acl(scx ,ni ,
-					nf_ns_xattr_posix_default,
-					(char*)acl, size, flags);
+						nf_ns_xattr_posix_default,
+						(char*)acl, size, flags);
 			} else
 				res = -errno;
 			free(acl);
@@ -657,11 +657,11 @@ int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
 #else
 	case XATTR_POSIX_ACC :
 		res = ntfs_set_posix_acl(scx ,ni , nf_ns_xattr_posix_access,
-					value, size, flags);
+				value, size, flags);
 		break;
 	case XATTR_POSIX_DEF :
 		res = ntfs_set_posix_acl(scx, ni, nf_ns_xattr_posix_default,
-					value, size, flags);
+				value, size, flags);
 		break;
 #endif
 #endif
@@ -692,9 +692,9 @@ int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
 		break;
 	case XATTR_NTFS_DOS_NAME:
 		if (dir_ni)
-		/* warning : this closes both inodes */
+			/* warning : this closes both inodes */
 			res = ntfs_set_ntfs_dos_name(ni, dir_ni, value,
-						size, flags);
+					size, flags);
 		else {
 			errno = EINVAL;
 			res = -errno;
@@ -715,7 +715,7 @@ int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
 		break;
 	case XATTR_NTFS_CRTIME:
 		res = ntfs_inode_set_times(ni, value,
-			(size >= sizeof(u64) ? sizeof(u64) : size), flags);
+				(size >= sizeof(u64) ? sizeof(u64) : size), flags);
 		break;
 	case XATTR_NTFS_CRTIME_BE:
 		if (value && (size >= sizeof(u64))) {
@@ -737,8 +737,8 @@ int ntfs_xattr_system_setxattr(struct SECURITY_CONTEXT *scx,
 }
 
 int ntfs_xattr_system_removexattr(struct SECURITY_CONTEXT *scx,
-			enum SYSTEMXATTRS attr,
-			ntfs_inode *ni, ntfs_inode *dir_ni)
+		enum SYSTEMXATTRS attr,
+		ntfs_inode *ni, ntfs_inode *dir_ni)
 {
 	int res;
 
@@ -748,61 +748,61 @@ int ntfs_xattr_system_removexattr(struct SECURITY_CONTEXT *scx,
 		 * Removal of NTFS ACL, ATTRIB, EFSINFO or TIMES
 		 * is never allowed
 		 */
-	case XATTR_NTFS_ACL :
-	case XATTR_NTFS_ATTRIB :
-	case XATTR_NTFS_ATTRIB_BE :
-	case XATTR_NTFS_EFSINFO :
-	case XATTR_NTFS_TIMES :
-	case XATTR_NTFS_TIMES_BE :
-	case XATTR_NTFS_CRTIME :
-	case XATTR_NTFS_CRTIME_BE :
-		res = -EPERM;
-		break;
+		case XATTR_NTFS_ACL :
+		case XATTR_NTFS_ATTRIB :
+		case XATTR_NTFS_ATTRIB_BE :
+		case XATTR_NTFS_EFSINFO :
+		case XATTR_NTFS_TIMES :
+		case XATTR_NTFS_TIMES_BE :
+		case XATTR_NTFS_CRTIME :
+		case XATTR_NTFS_CRTIME_BE :
+			res = -EPERM;
+			break;
 #if POSIXACLS
-	case XATTR_POSIX_ACC :
-	case XATTR_POSIX_DEF :
-		if (ni) {
-			if (!ntfs_allowed_as_owner(scx, ni)
-			   || ntfs_remove_posix_acl(scx, ni,
-					(attr == XATTR_POSIX_ACC ?
-					nf_ns_xattr_posix_access :
-					nf_ns_xattr_posix_default)))
+		case XATTR_POSIX_ACC :
+		case XATTR_POSIX_DEF :
+			if (ni) {
+				if (!ntfs_allowed_as_owner(scx, ni)
+						|| ntfs_remove_posix_acl(scx, ni,
+							(attr == XATTR_POSIX_ACC ?
+							 nf_ns_xattr_posix_access :
+							 nf_ns_xattr_posix_default)))
+					res = -errno;
+			} else
 				res = -errno;
-		} else
-			res = -errno;
-		break;
+			break;
 #endif
-	case XATTR_NTFS_REPARSE_DATA :
-		if (ni) {
-			if (!ntfs_allowed_as_owner(scx, ni)
-			    || ntfs_remove_ntfs_reparse_data(ni))
+		case XATTR_NTFS_REPARSE_DATA :
+			if (ni) {
+				if (!ntfs_allowed_as_owner(scx, ni)
+						|| ntfs_remove_ntfs_reparse_data(ni))
+					res = -errno;
+			} else
 				res = -errno;
-		} else
-			res = -errno;
-		break;
-	case XATTR_NTFS_OBJECT_ID :
-		if (ni) {
-			if (!ntfs_allowed_as_owner(scx, ni)
-			    || ntfs_remove_ntfs_object_id(ni))
+			break;
+		case XATTR_NTFS_OBJECT_ID :
+			if (ni) {
+				if (!ntfs_allowed_as_owner(scx, ni)
+						|| ntfs_remove_ntfs_object_id(ni))
+					res = -errno;
+			} else
 				res = -errno;
-		} else
-			res = -errno;
-		break;
-	case XATTR_NTFS_DOS_NAME:
-		if (ni && dir_ni) {
-			if (ntfs_remove_ntfs_dos_name(ni,dir_ni))
+			break;
+		case XATTR_NTFS_DOS_NAME:
+			if (ni && dir_ni) {
+				if (ntfs_remove_ntfs_dos_name(ni,dir_ni))
+					res = -errno;
+				/* ni and dir_ni have been closed */
+			} else
 				res = -errno;
-			/* ni and dir_ni have been closed */
-		} else
+			break;
+		case XATTR_NTFS_EA :
+			res = ntfs_remove_ntfs_ea(ni);
+			break;
+		default :
+			errno = EOPNOTSUPP;
 			res = -errno;
-		break;
-	case XATTR_NTFS_EA :
-		res = ntfs_remove_ntfs_ea(ni);
-		break;
-	default :
-		errno = EOPNOTSUPP;
-		res = -errno;
-		break;
+			break;
 	}
 	return (res);
 }

--- a/src/cluster.c
+++ b/src/cluster.c
@@ -74,7 +74,7 @@ int cluster_find(ntfs_volume *vol, LCN c_begin, LCN c_end, cluster_cb *cb, void 
 
 			if (!rec->non_resident) {
 				ntfs_log_verbose("0x%02x skipped - attr is resident\n",
-					(int)le32_to_cpu(a_ctx->attr->type));
+						(int)le32_to_cpu(a_ctx->attr->type));
 				continue;
 			}
 
@@ -99,7 +99,7 @@ int cluster_find(ntfs_volume *vol, LCN c_begin, LCN c_end, cluster_cb *cb, void 
 						(long long)runs[j].vcn,
 						(long long)runs[j].lcn,
 						(long long)(runs[j].lcn +
-						runs[j].length - 1),
+							runs[j].length - 1),
 						(long long)runs[j].length);
 				//dprint list
 

--- a/src/list.h
+++ b/src/list.h
@@ -188,6 +188,6 @@ static __inline__ void ntfs_list_splice(struct ntfs_list_head *list,
  */
 #define ntfs_list_for_each_safe(pos, n, head) \
 	for (pos = (head)->next, n = pos->next; pos != (head); \
-		pos = n, n = pos->next)
+			pos = n, n = pos->next)
 
 #endif /* defined _NTFS_LIST_H */

--- a/src/mkntfs.c
+++ b/src/mkntfs.c
@@ -76,8 +76,8 @@
 #ifdef HAVE_GETOPT_H
 #include <getopt.h>
 #else
-	extern char *optarg;
-	extern int optind;
+extern char *optarg;
+extern int optind;
 #endif
 
 #ifdef HAVE_LINUX_MAJOR_H
@@ -100,11 +100,11 @@
 #			define IDE9_MAJOR	91
 #		endif
 #		define IDE_DISK_MAJOR(M) \
-				((M) == IDE0_MAJOR || (M) == IDE1_MAJOR || \
-				(M) == IDE2_MAJOR || (M) == IDE3_MAJOR || \
-				(M) == IDE4_MAJOR || (M) == IDE5_MAJOR || \
-				(M) == IDE6_MAJOR || (M) == IDE7_MAJOR || \
-				(M) == IDE8_MAJOR || (M) == IDE9_MAJOR)
+			((M) == IDE0_MAJOR || (M) == IDE1_MAJOR || \
+			 (M) == IDE2_MAJOR || (M) == IDE3_MAJOR || \
+			 (M) == IDE4_MAJOR || (M) == IDE5_MAJOR || \
+			 (M) == IDE6_MAJOR || (M) == IDE7_MAJOR || \
+			 (M) == IDE8_MAJOR || (M) == IDE9_MAJOR)
 #	endif
 #	ifndef SCSI_DISK_MAJOR
 #		ifndef SCSI_DISK0_MAJOR
@@ -113,9 +113,9 @@
 #			define SCSI_DISK7_MAJOR	71
 #		endif
 #		define SCSI_DISK_MAJOR(M) \
-				((M) == SCSI_DISK0_MAJOR || \
-				((M) >= SCSI_DISK1_MAJOR && \
-				(M) <= SCSI_DISK7_MAJOR))
+			((M) == SCSI_DISK0_MAJOR || \
+			 ((M) >= SCSI_DISK1_MAJOR && \
+			  (M) <= SCSI_DISK7_MAJOR))
 #	endif
 #endif
 
@@ -149,8 +149,8 @@ typedef enum { WRITE_STANDARD, WRITE_BITMAP, WRITE_LOGFILE } WRITE_TYPE;
 
 #ifdef NO_NTFS_DEVICE_DEFAULT_IO_OPS
 #error "No default device io operations!  Cannot build mkntfs.  \
-You need to run ./configure without the --disable-default-device-io-ops \
-switch if you want to be able to build the NTFS utilities."
+	You need to run ./configure without the --disable-default-device-io-ops \
+	switch if you want to be able to build the NTFS utilities."
 #endif
 
 /* Page size on ia32. Can change to 8192 on Alpha. */
@@ -164,7 +164,7 @@ struct BITMAP_ALLOCATION {
 	s64	length;		/* count of consecutive clusters */
 } ;
 
-		/* Upcase $Info, used since Windows 8 */
+/* Upcase $Info, used since Windows 8 */
 struct UPCASEINFO {
 	le32	len;
 	le32	filler;
@@ -242,36 +242,36 @@ static void mkntfs_license(void)
 static void mkntfs_usage(void)
 {
 	ntfs_log_info("\nUsage: %s [options] device [number-of-sectors]\n"
-"\n"
-"Basic options:\n"
-"    -f, --fast                      Perform a quick format(default)\n"
-"    -Q, --quick                     Perform a quick format(default)\n"
-"    -u, --full                      Perform a full format\n"
-"    -L, --label STRING              Set the volume label\n"
-"    -C, --enable-compression        Enable compression on the volume\n"
-"    -I, --no-indexing               Disable indexing on the volume\n"
-"    -n, --no-action                 Do not write to disk\n"
-"\n"
-"Advanced options:\n"
-"    -c, --cluster-size BYTES        Specify the cluster size for the volume\n"
-"    -s, --sector-size BYTES         Specify the sector size for the device\n"
-"    -p, --partition-start SECTOR    Specify the partition start sector\n"
-"    -H, --heads NUM                 Specify the number of heads\n"
-"    -S, --sectors-per-track NUM     Specify the number of sectors per track\n"
-"    -z, --mft-zone-multiplier NUM   Set the MFT zone multiplier\n"
-"    -T, --zero-time                 Fake the time to be 00:00 UTC, Jan 1, 1970\n"
-"    -F, --force                     Force execution despite errors\n"
-"\n"
-"Output options:\n"
-"    -q, --quiet                     Quiet execution\n"
-"    -v, --verbose                   Verbose execution\n"
-"        --debug                     Very verbose execution\n"
-"\n"
-"Help options:\n"
-"    -V, --version                   Display version\n"
-"    -l, --license                   Display licensing information\n"
-"    -h, --help                      Display this help\n"
-"\n", basename(EXEC_NAME));
+		"\n"
+		"Basic options:\n"
+		"    -f, --fast                      Perform a quick format(default)\n"
+		"    -Q, --quick                     Perform a quick format(default)\n"
+		"    -u, --full                      Perform a full format\n"
+		"    -L, --label STRING              Set the volume label\n"
+		"    -C, --enable-compression        Enable compression on the volume\n"
+		"    -I, --no-indexing               Disable indexing on the volume\n"
+		"    -n, --no-action                 Do not write to disk\n"
+		"\n"
+		"Advanced options:\n"
+		"    -c, --cluster-size BYTES        Specify the cluster size for the volume\n"
+		"    -s, --sector-size BYTES         Specify the sector size for the device\n"
+		"    -p, --partition-start SECTOR    Specify the partition start sector\n"
+		"    -H, --heads NUM                 Specify the number of heads\n"
+		"    -S, --sectors-per-track NUM     Specify the number of sectors per track\n"
+		"    -z, --mft-zone-multiplier NUM   Set the MFT zone multiplier\n"
+		"    -T, --zero-time                 Fake the time to be 00:00 UTC, Jan 1, 1970\n"
+		"    -F, --force                     Force execution despite errors\n"
+		"\n"
+		"Output options:\n"
+		"    -q, --quiet                     Quiet execution\n"
+		"    -v, --verbose                   Verbose execution\n"
+		"        --debug                     Very verbose execution\n"
+		"\n"
+		"Help options:\n"
+		"    -V, --version                   Display version\n"
+		"    -l, --license                   Display licensing information\n"
+		"    -h, --help                      Display this help\n"
+		"\n", basename(EXEC_NAME));
 }
 
 /**
@@ -295,7 +295,7 @@ static void mkntfs_version(void)
  * ECMA-182 polynomial, see
  *     http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-182.pdf
  */
-		/* make sure the needed types are defined */
+/* make sure the needed types are defined */
 #undef byte
 #undef uint32_t
 #undef uint64_t
@@ -312,7 +312,7 @@ static uint64_t crc64(uint64_t crc, const byte * data, size_t size)
 	crc ^= xorout;
 
 	if (data == NULL) {
-	/* generate the table of CRC remainders for all possible bytes */
+		/* generate the table of CRC remainders for all possible bytes */
 		uint64_t c;
 		uint32_t i, j;
 		for (i = 0;  i < 256;  i++) {
@@ -361,7 +361,7 @@ static BOOL bitmap_allocate(LCN lcn, s64 length)
 		}
 		/* make sure the requested lcns were not allocated */
 		if ((q && ((q->lcn + q->length) > lcn))
-		   || (p && ((lcn + length) > p->lcn))) {
+				|| (p && ((lcn + length) > p->lcn))) {
 			ntfs_log_error("Bitmap allocation error\n");
 			done = FALSE;
 		}
@@ -370,7 +370,7 @@ static BOOL bitmap_allocate(LCN lcn, s64 length)
 			q->length += length;
 		} else {
 			newall = (struct BITMAP_ALLOCATION*)
-				    ntfs_malloc(sizeof(struct BITMAP_ALLOCATION));
+				ntfs_malloc(sizeof(struct BITMAP_ALLOCATION));
 			if (newall) {
 				newall->lcn = lcn;
 				newall->length = length;
@@ -405,16 +405,16 @@ static BOOL bitmap_deallocate(LCN lcn, s64 length)
 	if (length) {
 		p = g_allocation;
 		q = (struct BITMAP_ALLOCATION*)NULL;
-			/* locate a run which has a common portion */
+		/* locate a run which has a common portion */
 		while (p) {
 			first = (p->lcn > lcn ? p->lcn : lcn);
 			last = ((p->lcn + p->length) < (lcn + length)
-				? p->lcn + p->length : lcn + length);
+					? p->lcn + p->length : lcn + length);
 			if (first < last) {
-					/* get the parts which must be kept */
+				/* get the parts which must be kept */
 				begin_length = first - p->lcn;
 				end_length = p->lcn + p->length - last;
-					/* delete the entry */
+				/* delete the entry */
 				if (q)
 					q->next = p->next;
 				else
@@ -422,13 +422,13 @@ static BOOL bitmap_deallocate(LCN lcn, s64 length)
 				free(p);
 				/* reallocate the beginning and the end */
 				if (begin_length
-				    && !bitmap_allocate(first - begin_length,
+						&& !bitmap_allocate(first - begin_length,
 							begin_length))
 					done = FALSE;
 				if (end_length
-				    && !bitmap_allocate(last, end_length))
+						&& !bitmap_allocate(last, end_length))
 					done = FALSE;
-					/* restart a full search */
+				/* restart a full search */
 				p = g_allocation;
 				q = (struct BITMAP_ALLOCATION*)NULL;
 			} else {
@@ -490,20 +490,20 @@ static void bitmap_build(u8 *buf, LCN lcn, s64 length)
 	for (p=g_allocation; p; p=p->next) {
 		first = (p->lcn > lcn ? p->lcn : lcn);
 		last = ((p->lcn + p->length) < (lcn + length)
-			? p->lcn + p->length : lcn + length);
+				? p->lcn + p->length : lcn + length);
 		if (first < last) {
 			bn = first - lcn;
-				/* initial partial byte, if any */
+			/* initial partial byte, if any */
 			while ((bn < (last - lcn)) && (bn & 7)) {
 				buf[bn >> 3] |= 1 << (bn & 7);
 				bn++;
 			}
-				/* full bytes */
+			/* full bytes */
 			while (bn < (last - lcn - 7)) {
 				buf[bn >> 3] = 255;
 				bn += 8;
 			}
-				/* final partial byte, if any */
+			/* final partial byte, if any */
 			while (bn < (last - lcn)) {
 				buf[bn >> 3] |= 1 << (bn & 7);
 				bn++;
@@ -641,8 +641,8 @@ static int mkntfs_parse_options(int argc, char *argv[], struct mkntfs_options *o
 			if (!opts2->dev_name)
 				opts2->dev_name = argv[optind - 1];
 			else if (!mkntfs_parse_llong(optarg,
-					"number of sectors",
-					&opts2->num_sectors))
+						"number of sectors",
+						&opts2->num_sectors))
 				err++;
 			break;
 		case 'C':
@@ -650,7 +650,7 @@ static int mkntfs_parse_options(int argc, char *argv[], struct mkntfs_options *o
 			break;
 		case 'c':
 			if (!mkntfs_parse_long(optarg, "cluster size",
-					&opts2->cluster_size))
+						&opts2->cluster_size))
 				err++;
 			break;
 		case 'F':
@@ -737,10 +737,10 @@ static int mkntfs_parse_options(int argc, char *argv[], struct mkntfs_options *o
 			if (ntfs_log_parse_option (argv[optind-1]))
 				break;
 			if (((optopt == 'c') || (optopt == 'H') ||
-			     (optopt == 'L') || (optopt == 'p') ||
-			     (optopt == 's') || (optopt == 'S') ||
-			     (optopt == 'N') || (optopt == 'z')) &&
-			     (!optarg)) {
+				(optopt == 'L') || (optopt == 'p') ||
+				(optopt == 's') || (optopt == 'S') ||
+				(optopt == 'N') || (optopt == 'z')) &&
+					(!optarg)) {
 				ntfs_log_error("Option '%s' requires an "
 						"argument.\n", argv[optind-1]);
 			} else if (optopt != '?') {
@@ -767,7 +767,7 @@ static int mkntfs_parse_options(int argc, char *argv[], struct mkntfs_options *o
 	if (err || help)
 		mkntfs_usage();
 
-		/* tri-state 0 : done, 1 : error, -1 : proceed */
+	/* tri-state 0 : done, 1 : error, -1 : proceed */
 	return (err ? 1 : (help || ver || lic ? 0 : -1));
 }
 
@@ -795,10 +795,10 @@ static BOOL append_to_bad_blocks(unsigned long long block)
 
 	if (!(g_num_bad_blocks & 15)) {
 		new_buf = realloc(g_bad_blocks, (g_num_bad_blocks + 16) *
-							sizeof(long long));
+				sizeof(long long));
 		if (!new_buf) {
 			ntfs_log_perror("Reallocating memory for bad blocks "
-				"list failed");
+					"list failed");
 			return FALSE;
 		}
 		g_bad_blocks = new_buf;
@@ -836,7 +836,7 @@ static long long mkntfs_write(struct ntfs_device *dev,
 	} while (count && retry < 3);
 	if (count)
 		ntfs_log_error("Failed to complete writing to %s after three retries."
-			"\n", dev->d_name);
+				"\n", dev->d_name);
 	return total;
 }
 
@@ -847,7 +847,7 @@ static long long mkntfs_write(struct ntfs_device *dev,
  * mkntfs_bitmap_write
  */
 static s64 mkntfs_bitmap_write(struct ntfs_device *dev,
-			s64 offset, s64 length)
+		s64 offset, s64 length)
 {
 	s64 partial_length;
 	s64 written;
@@ -855,7 +855,7 @@ static s64 mkntfs_bitmap_write(struct ntfs_device *dev,
 	partial_length = length;
 	if (partial_length > g_dynamic_buf_size)
 		partial_length = g_dynamic_buf_size;
-		/* create a partial bitmap section, and write it */
+	/* create a partial bitmap section, and write it */
 	bitmap_build(g_dynamic_buf,offset << 3,partial_length << 3);
 	written = dev->d_ops->write(dev, g_dynamic_buf, partial_length);
 	return (written);
@@ -868,7 +868,7 @@ static s64 mkntfs_bitmap_write(struct ntfs_device *dev,
  * mkntfs_logfile_write
  */
 static s64 mkntfs_logfile_write(struct ntfs_device *dev,
-			s64 offset __attribute__((unused)), s64 length)
+		s64 offset __attribute__((unused)), s64 length)
 {
 	s64 partial_length;
 	s64 written;
@@ -876,7 +876,7 @@ static s64 mkntfs_logfile_write(struct ntfs_device *dev,
 	partial_length = length;
 	if (partial_length > g_dynamic_buf_size)
 		partial_length = g_dynamic_buf_size;
-		/* create a partial bad cluster section, and write it */
+	/* create a partial bad cluster section, and write it */
 	memset(g_dynamic_buf, -1, partial_length);
 	written = dev->d_ops->write(dev, g_dynamic_buf, partial_length);
 	return (written);
@@ -930,29 +930,29 @@ static s64 ntfs_rlwrite(struct ntfs_device *dev, const runlist *rl,
 			delta -= length;
 		}
 		if (dev->d_ops->seek(dev, rl[i].lcn * g_vol->cluster_size,
-				SEEK_SET) == (off_t)-1)
+					SEEK_SET) == (off_t)-1)
 			return -1LL;
 		retry = 0;
 		do {
 			/* use specific functions if buffer is not prefilled */
 			switch (write_type) {
-			case WRITE_BITMAP :
-				bytes_written = mkntfs_bitmap_write(dev,
-					total, length);
-				break;
-			case WRITE_LOGFILE :
-				bytes_written = mkntfs_logfile_write(dev,
-					total, length);
-				break;
-			default :
-				bytes_written = dev->d_ops->write(dev,
-					val + total, length);
-				break;
+				case WRITE_BITMAP :
+					bytes_written = mkntfs_bitmap_write(dev,
+							total, length);
+					break;
+				case WRITE_LOGFILE :
+					bytes_written = mkntfs_logfile_write(dev,
+							total, length);
+					break;
+				default :
+					bytes_written = dev->d_ops->write(dev,
+							val + total, length);
+					break;
 			}
 			if (bytes_written == -1LL) {
 				retry = errno;
 				ntfs_log_perror("Error writing to %s",
-					dev->d_name);
+						dev->d_name);
 				errno = retry;
 				return bytes_written;
 			}
@@ -1240,7 +1240,7 @@ static int mkntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 			break;
 		ctx->attr = a;
 		if (((type != AT_UNUSED) && (le32_to_cpu(a->type) >
-				le32_to_cpu(type))) ||
+						le32_to_cpu(type))) ||
 				(a->type == AT_END)) {
 			errno = ENOENT;
 			return -1;
@@ -1264,13 +1264,13 @@ static int mkntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 				return -1;
 			}
 		} else if (name && !ntfs_names_are_equal(name, name_len,
-				(ntfschar*)((char*)a + le16_to_cpu(a->name_offset)),
-				a->name_length, ic, upcase, upcase_len)) {
+					(ntfschar*)((char*)a + le16_to_cpu(a->name_offset)),
+					a->name_length, ic, upcase, upcase_len)) {
 			int rc;
 
 			rc = ntfs_names_full_collate(name, name_len,
 					(ntfschar*)((char*)a +
-					le16_to_cpu(a->name_offset)),
+						le16_to_cpu(a->name_offset)),
 					a->name_length, IGNORE_CASE,
 					upcase, upcase_len);
 			/*
@@ -1286,7 +1286,7 @@ static int mkntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 				continue;
 			rc = ntfs_names_full_collate(name, name_len,
 					(ntfschar*)((char*)a +
-					le16_to_cpu(a->name_offset)),
+						le16_to_cpu(a->name_offset)),
 					a->name_length, CASE_SENSITIVE,
 					upcase, upcase_len);
 			if (rc == -1) {
@@ -1303,13 +1303,13 @@ static int mkntfs_attr_find(const ATTR_TYPES type, const ntfschar *name,
 		 */
 		if (!val) {
 			return 0;
-		/* @val is present; compare values. */
+			/* @val is present; compare values. */
 		} else {
 			int rc;
 
 			rc = memcmp(val, (char*)a +le16_to_cpu(a->value_offset),
 					min(val_len,
-					le32_to_cpu(a->value_length)));
+						le32_to_cpu(a->value_length)));
 			/*
 			 * If @val collates before the current attribute's
 			 * value, there is no matching attribute.
@@ -1557,7 +1557,7 @@ static int insert_positioned_attr_in_mft_record(MFT_RECORD *m,
 	a->flags = flags;
 	a->instance = m->next_attr_instance;
 	m->next_attr_instance = cpu_to_le16((le16_to_cpu(m->next_attr_instance)
-			+ 1) & 0xffff);
+				+ 1) & 0xffff);
 	a->lowest_vcn = const_cpu_to_sle64(0);
 	a->highest_vcn = cpu_to_sle64(highest_vcn - 1LL);
 	a->mapping_pairs_offset = cpu_to_le16(hdr_size + ((name_len + 7) & ~7));
@@ -1584,8 +1584,8 @@ static int insert_positioned_attr_in_mft_record(MFT_RECORD *m,
 	} else {
 		a->compression_unit = 0;
 		if ((type == AT_DATA)
-		    && (m->mft_record_number
-				 == const_cpu_to_le32(FILE_LogFile)))
+				&& (m->mft_record_number
+					== const_cpu_to_le32(FILE_LogFile)))
 			bw = ntfs_rlwrite(g_vol->dev, rl, val, val_len,
 					&inited_size, WRITE_LOGFILE);
 		else
@@ -1637,10 +1637,10 @@ static int insert_non_resident_attr_in_mft_record(MFT_RECORD *m,
 	ntfschar *uname = NULL;
 	int uname_len = 0;
 	/*
-	if (base record)
-		attr_lookup();
-	else
-	*/
+	   if (base record)
+	   attr_lookup();
+	   else
+	   */
 
 	uname = ntfs_str2ucs(name, &uname_len);
 	if (!uname)
@@ -1682,7 +1682,7 @@ static int insert_non_resident_attr_in_mft_record(MFT_RECORD *m,
 	}
 	if (val_len) {
 		rl = allocate_scattered_clusters((val_len +
-				g_vol->cluster_size - 1) / g_vol->cluster_size);
+					g_vol->cluster_size - 1) / g_vol->cluster_size);
 		if (!rl) {
 			err = -errno;
 			ntfs_log_perror("Failed to allocate scattered clusters");
@@ -1751,7 +1751,7 @@ static int insert_non_resident_attr_in_mft_record(MFT_RECORD *m,
 	a->flags = flags;
 	a->instance = m->next_attr_instance;
 	m->next_attr_instance = cpu_to_le16((le16_to_cpu(m->next_attr_instance)
-			+ 1) & 0xffff);
+				+ 1) & 0xffff);
 	a->lowest_vcn = const_cpu_to_sle64(0);
 	for (i = 0; rl[i].length; i++)
 		;
@@ -1781,7 +1781,7 @@ static int insert_non_resident_attr_in_mft_record(MFT_RECORD *m,
 	} else {
 		a->compression_unit = 0;
 		bw = ntfs_rlwrite(g_vol->dev, rl, val, val_len, NULL,
-					write_type);
+				write_type);
 		if (bw != val_len) {
 			ntfs_log_error("Error writing non-resident attribute "
 					"value.\n");
@@ -1798,7 +1798,7 @@ static int insert_non_resident_attr_in_mft_record(MFT_RECORD *m,
 		if (err >= 0)
 			err = -EIO;
 		ntfs_log_error("insert_non_resident_attr_in_mft_record failed with "
-			"error %lld.\n", (long long) (err < 0 ? err : bw));
+				"error %lld.\n", (long long) (err < 0 ? err : bw));
 	}
 err_out:
 	if (ctx)
@@ -1848,7 +1848,7 @@ static int insert_resident_attr_in_mft_record(MFT_RECORD *m,
 		goto err_out;
 	}
 	if (!mkntfs_attr_lookup(type, uname, uname_len, ic, 0, val, val_len,
-			ctx)) {
+				ctx)) {
 		err = -EEXIST;
 		goto err_out;
 	}
@@ -1900,7 +1900,7 @@ static int insert_resident_attr_in_mft_record(MFT_RECORD *m,
 	a->flags = flags;
 	a->instance = m->next_attr_instance;
 	m->next_attr_instance = cpu_to_le16((le16_to_cpu(m->next_attr_instance)
-			+ 1) & 0xffff);
+				+ 1) & 0xffff);
 	a->value_length = cpu_to_le32(val_len);
 	a->value_offset = cpu_to_le16(24 + ((name_len*2 + 7) & ~7));
 	a->resident_flags = res_flags;
@@ -2130,7 +2130,7 @@ static int add_attr_sd(MFT_RECORD *m, const u8 *sd, const s64 sd_len)
 
 	/* Does it fit? NO: create non-resident. YES: create resident. */
 	if (le32_to_cpu(m->bytes_in_use) + 24 + sd_len >
-						le32_to_cpu(m->bytes_allocated))
+			le32_to_cpu(m->bytes_allocated))
 		err = insert_non_resident_attr_in_mft_record(m,
 				AT_SECURITY_DESCRIPTOR, NULL, 0,
 				CASE_SENSITIVE, const_cpu_to_le16(0), sd,
@@ -2169,7 +2169,7 @@ static int add_attr_data(MFT_RECORD *m, const char *name, const u32 name_len,
 	 */
 	if (le32_to_cpu(m->bytes_in_use) + 24 + val_len >
 			min(le32_to_cpu(m->bytes_allocated),
-			le32_to_cpu(m->bytes_allocated) - 512))
+				le32_to_cpu(m->bytes_allocated) - 512))
 		err = insert_non_resident_attr_in_mft_record(m, AT_DATA, name,
 				name_len, ic, flags, val, val_len,
 				WRITE_STANDARD);
@@ -2286,12 +2286,12 @@ static int add_attr_index_root(MFT_RECORD *m, const char *name,
 	if (!r)
 		return -errno;
 	r->type = (indexed_attr_type == AT_FILE_NAME)
-				? AT_FILE_NAME : const_cpu_to_le32(0);
+		? AT_FILE_NAME : const_cpu_to_le32(0);
 	if (indexed_attr_type == AT_FILE_NAME &&
 			collation_rule != COLLATION_FILE_NAME) {
 		free(r);
 		ntfs_log_error("add_attr_index_root: indexed attribute is $FILE_NAME "
-			"but collation rule is not COLLATION_FILE_NAME.\n");
+				"but collation rule is not COLLATION_FILE_NAME.\n");
 		return -EINVAL;
 	}
 	r->collation_rule = collation_rule;
@@ -2304,7 +2304,7 @@ static int add_attr_index_root(MFT_RECORD *m, const char *name,
 			return -EINVAL;
 		}
 		r->clusters_per_index_block = index_block_size /
-				g_vol->cluster_size;
+			g_vol->cluster_size;
 	} else { /* if (g_vol->cluster_size > index_block_size) */
 		if (index_block_size & (index_block_size - 1)) {
 			ntfs_log_error("add_attr_index_root: index block size is not "
@@ -2313,13 +2313,13 @@ static int add_attr_index_root(MFT_RECORD *m, const char *name,
 			return -EINVAL;
 		}
 		if (index_block_size < (u32)opts.sector_size) {
-			 ntfs_log_error("add_attr_index_root: index block size "
-					 "is smaller than the sector size.\n");
-			 free(r);
-			 return -EINVAL;
+			ntfs_log_error("add_attr_index_root: index block size "
+					"is smaller than the sector size.\n");
+			free(r);
+			return -EINVAL;
 		}
 		r->clusters_per_index_block = index_block_size
-				>> NTFS_BLOCK_SIZE_BITS;
+			>> NTFS_BLOCK_SIZE_BITS;
 	}
 	memset(&r->reserved, 0, sizeof(r->reserved));
 	r->index.entries_offset = const_cpu_to_le32(sizeof(INDEX_HEADER));
@@ -2341,8 +2341,8 @@ static int add_attr_index_root(MFT_RECORD *m, const char *name,
 	e->flags = INDEX_ENTRY_END;
 	e->reserved = const_cpu_to_le16(0);
 	err = insert_resident_attr_in_mft_record(m, AT_INDEX_ROOT, name,
-				name_len, ic, const_cpu_to_le16(0), 0,
-				(u8*)r, val_len);
+			name_len, ic, const_cpu_to_le16(0), 0,
+			(u8*)r, val_len);
 	free(r);
 	if (err < 0)
 		ntfs_log_error("add_attr_index_root failed: %s\n", strerror(-err));
@@ -2381,7 +2381,7 @@ static int add_attr_bitmap(MFT_RECORD *m, const char *name, const u32 name_len,
 
 	/* Does it fit? NO: create non-resident. YES: create resident. */
 	if (le32_to_cpu(m->bytes_in_use) + 24 + bitmap_len >
-						le32_to_cpu(m->bytes_allocated))
+			le32_to_cpu(m->bytes_allocated))
 		err = insert_non_resident_attr_in_mft_record(m, AT_BITMAP, name,
 				name_len, ic, const_cpu_to_le16(0), bitmap,
 				bitmap_len, WRITE_STANDARD);
@@ -2505,13 +2505,13 @@ static int upgrade_to_large_index(MFT_RECORD *m, const char *name,
 	}
 	/* Set USN to 1. */
 	*(le16*)((char*)ia_val + le16_to_cpu(ia_val->usa_ofs)) =
-			const_cpu_to_le16(1);
+		const_cpu_to_le16(1);
 	ia_val->lsn = const_cpu_to_sle64(0);
 	ia_val->index_block_vcn = const_cpu_to_sle64(0);
 	ia_val->index.ih_flags = LEAF_NODE;
 	/* Align to 8-byte boundary. */
 	ia_val->index.entries_offset = cpu_to_le32((sizeof(INDEX_HEADER) +
-			le16_to_cpu(ia_val->usa_count) * 2 + 7) & ~7);
+				le16_to_cpu(ia_val->usa_count) * 2 + 7) & ~7);
 	ia_val->index.allocated_size = cpu_to_le32(index_block_size -
 			(sizeof(INDEX_ALLOCATION) - sizeof(INDEX_HEADER)));
 	/* Find the last entry in the index root and save it in re. */
@@ -2541,8 +2541,8 @@ static int upgrade_to_large_index(MFT_RECORD *m, const char *name,
 	r->index.allocated_size = r->index.index_length;
 	/* Resize index root attribute. */
 	if (ntfs_resident_attr_value_resize(m, a, sizeof(INDEX_ROOT) -
-			sizeof(INDEX_HEADER) +
-			le32_to_cpu(r->index.allocated_size))) {
+				sizeof(INDEX_HEADER) +
+				le32_to_cpu(r->index.allocated_size))) {
 		/* TODO: Remove the added bitmap! */
 		/* Revert index root from index allocation. */
 		err = -errno;
@@ -2550,7 +2550,7 @@ static int upgrade_to_large_index(MFT_RECORD *m, const char *name,
 	}
 	/* Set VCN pointer to 0LL. */
 	*(leVCN*)((char*)re + le16_to_cpu(re->length) - sizeof(VCN)) =
-			const_cpu_to_sle64(0);
+		const_cpu_to_sle64(0);
 	err = ntfs_mst_pre_write_fixup((NTFS_RECORD*)ia_val, index_block_size);
 	if (err) {
 		err = -errno;
@@ -2603,11 +2603,11 @@ static int make_room_for_index_entry_in_index_block(INDEX_BLOCK *idx,
 		return -EINVAL;
 	if ((char*)pos < (char*)idx || (char*)pos + size < (char*)idx ||
 			(char*)pos > (char*)idx + sizeof(INDEX_BLOCK) -
-				sizeof(INDEX_HEADER) +
-				le32_to_cpu(idx->index.allocated_size) ||
+			sizeof(INDEX_HEADER) +
+			le32_to_cpu(idx->index.allocated_size) ||
 			(char*)pos + size > (char*)idx + sizeof(INDEX_BLOCK) -
-				sizeof(INDEX_HEADER) +
-				le32_to_cpu(idx->index.allocated_size))
+			sizeof(INDEX_HEADER) +
+			le32_to_cpu(idx->index.allocated_size))
 		return -EINVAL;
 	/* The - sizeof(INDEX_ENTRY_HEADER) is for the index terminator. */
 	if ((char*)pos - (char*)&idx->index >
@@ -2621,7 +2621,7 @@ static int make_room_for_index_entry_in_index_block(INDEX_BLOCK *idx,
 		return -ENOSPC;
 	/* Move everything after pos to pos + size. */
 	memmove((char*)pos + size, (char*)pos, biu - ((char*)pos -
-			(char*)&idx->index));
+				(char*)&idx->index));
 	/* Update index block. */
 	idx->index.index_length = cpu_to_le32(biu + size);
 	return 0;
@@ -2731,14 +2731,14 @@ static int insert_index_entry_in_res_dir_index(INDEX_ENTRY *idx, u32 idx_size,
 		goto err_out;
 	}
 	if (mkntfs_attr_lookup(AT_INDEX_ROOT, name, name_size,
-			CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 		err = -EEXIST;
 		goto err_out;
 	}
 	/* found attribute */
 	a = (ATTR_RECORD*)ctx->attr;
 	collation_rule = ((INDEX_ROOT*)((u8*)a +
-			le16_to_cpu(a->value_offset)))->collation_rule;
+				le16_to_cpu(a->value_offset)))->collation_rule;
 	idx_header = (INDEX_HEADER*)((u8*)a + le16_to_cpu(a->value_offset)
 			+ 0x10);
 	idx_entry = (INDEX_ENTRY*)((u8*)idx_header +
@@ -2905,10 +2905,10 @@ static int initialize_secure(char *sds, u32 sds_size, MFT_RECORD *m)
 		sii_data->offset = sds_header->offset;
 		sii_data->length = sds_header->length;
 		if ((err = insert_index_entry_in_res_dir_index(idx_entry_sdh,
-				sdh_size, m, NTFS_INDEX_SDH, 4, AT_UNUSED)))
+						sdh_size, m, NTFS_INDEX_SDH, 4, AT_UNUSED)))
 			break;
 		if ((err = insert_index_entry_in_res_dir_index(idx_entry_sii,
-				sii_size, m, NTFS_INDEX_SII, 4, AT_UNUSED)))
+						sii_size, m, NTFS_INDEX_SII, 4, AT_UNUSED)))
 			break;
 		sds_header = (SECURITY_DESCRIPTOR_HEADER*)((u8*)sds_header +
 				((le32_to_cpu(sds_header->length) + 15) & ~15));
@@ -2986,9 +2986,9 @@ static int initialize_quota(MFT_RECORD *m)
 		idx_entry_q2_data->sid.identifier_authority.value[i] = 0;
 	idx_entry_q2_data->sid.identifier_authority.value[5] = 0x05;
 	idx_entry_q2_data->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	idx_entry_q2_data->sid.sub_authority[1] =
-			const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
+		const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
 	err = insert_index_entry_in_res_dir_index(idx_entry_q2, q2_size, m,
 			NTFS_INDEX_Q, 2, AT_UNUSED);
 	free(idx_entry_q2);
@@ -3011,9 +3011,9 @@ static int initialize_quota(MFT_RECORD *m)
 		idx_entry_o->key.sid.identifier_authority.value[i] = 0;
 	idx_entry_o->key.sid.identifier_authority.value[5] = 0x05;
 	idx_entry_o->key.sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	idx_entry_o->key.sid.sub_authority[1] =
-			const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
+		const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
 	idx_entry_o_data = (QUOTA_O_INDEX_DATA*)((char*)idx_entry_o
 			+ le16_to_cpu(idx_entry_o->data_offset));
 	idx_entry_o_data->owner_id  = QUOTA_FIRST_USER_ID;
@@ -3064,7 +3064,7 @@ static int insert_file_link_in_dir_index(INDEX_BLOCK *idx, leMFT_REF file_ref,
 		if (file_name->file_name_length) {
 			char *__buf = NULL;
 			i = ntfs_ucstombs((ntfschar*)&file_name->file_name,
-				file_name->file_name_length, &__buf, 0);
+					file_name->file_name_length, &__buf, 0);
 			if (i < 0)
 				ntfs_log_debug("Name contains non-displayable "
 						"Unicode characters.\n");
@@ -3077,8 +3077,8 @@ static int insert_file_link_in_dir_index(INDEX_BLOCK *idx, leMFT_REF file_ref,
 		if (ie->key.file_name.file_name_length) {
 			char *__buf = NULL;
 			i = ntfs_ucstombs(ie->key.file_name.file_name,
-				ie->key.file_name.file_name_length + 1, &__buf,
-				0);
+					ie->key.file_name.file_name_length + 1, &__buf,
+					0);
 			if (i < 0)
 				ntfs_log_debug("Name contains non-displayable "
 						"Unicode characters.\n");
@@ -3115,7 +3115,7 @@ static int insert_file_link_in_dir_index(INDEX_BLOCK *idx, leMFT_REF file_ref,
 		 * and hence this following code is luxury. (AIA)
 		 */
 		if (file_name->file_name_type != FILE_NAME_POSIX ||
-		    ie->key.file_name.file_name_type != FILE_NAME_POSIX)
+				ie->key.file_name.file_name_type != FILE_NAME_POSIX)
 			return -EEXIST;
 		/*
 		i = ntfs_file_values_compare(file_name,
@@ -3310,7 +3310,7 @@ static int create_hardlink(INDEX_BLOCK *idx, const leMFT_REF ref_parent,
 	fn->last_data_change_time = fn->creation_time;
 	fn->last_mft_change_time = fn->creation_time;
 	fn->last_access_time = fn->creation_time;
-		/* allocated size depends on unnamed data being resident */
+	/* allocated size depends on unnamed data being resident */
 	if (allocated_size && non_resident_unnamed_data(m_file))
 		fn->allocated_size = cpu_to_sle64(allocated_size);
 	else
@@ -3409,7 +3409,7 @@ static int index_obj_id_insert(MFT_RECORD *m, const GUID *guid,
 		return -errno;
 	idx_entry_new->data_offset = cpu_to_le16(data_ofs);
 	idx_entry_new->data_length =
-			const_cpu_to_le16(sizeof(OBJ_ID_INDEX_DATA));
+		const_cpu_to_le16(sizeof(OBJ_ID_INDEX_DATA));
 	idx_entry_new->length = cpu_to_le16(idx_size);
 	idx_entry_new->key_length = const_cpu_to_le16(sizeof(GUID));
 	idx_entry_new->key.object_id = *guid;
@@ -3536,9 +3536,9 @@ static BOOL mkntfs_open_partition(ntfs_volume *vol)
 		ntfs_log_warning("mkntfs forced anyway.\n");
 #ifdef HAVE_LINUX_MAJOR_H
 	} else if ((IDE_DISK_MAJOR(MAJOR(sbuf.st_rdev)) &&
-			MINOR(sbuf.st_rdev) % 64 == 0) ||
+				MINOR(sbuf.st_rdev) % 64 == 0) ||
 			(SCSI_DISK_MAJOR(MAJOR(sbuf.st_rdev)) &&
-			MINOR(sbuf.st_rdev) % 16 == 0)) {
+			 MINOR(sbuf.st_rdev) % 16 == 0)) {
 		ntfs_log_error("%s is entire device, not just one partition.\n", vol->dev->d_name);
 		if (!opts.force) {
 			ntfs_log_error("Refusing to make a filesystem here!\n");
@@ -3597,21 +3597,21 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 		opts.sector_size = ntfs_device_sector_size_get(vol->dev);
 		if (opts.sector_size < 0) {
 			ntfs_log_warning("The sector size was not specified "
-				"for %s and it could not be obtained "
-				"automatically.  It has been set to 512 "
-				"bytes.\n", vol->dev->d_name);
+					"for %s and it could not be obtained "
+					"automatically.  It has been set to 512 "
+					"bytes.\n", vol->dev->d_name);
 			opts.sector_size = 512;
 		}
 	}
 	/* Validate sector size. */
 	if ((opts.sector_size - 1) & opts.sector_size) {
 		ntfs_log_error("The sector size is invalid.  It must be a "
-			"power of two, e.g. 512, 1024.\n");
+				"power of two, e.g. 512, 1024.\n");
 		return FALSE;
 	}
 	if (opts.sector_size < 256 || opts.sector_size > 4096) {
 		ntfs_log_error("The sector size is invalid.  The minimum size "
-			"is 256 bytes and the maximum is 4096 bytes.\n");
+				"is 256 bytes and the maximum is 4096 bytes.\n");
 		return FALSE;
 	}
 	ntfs_log_debug("sector size = %ld bytes\n", opts.sector_size);
@@ -3628,8 +3628,8 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 				opts.sector_size);
 		if (opts.num_sectors <= 0) {
 			ntfs_log_error("Couldn't determine the size of %s.  "
-				"Please specify the number of sectors "
-				"manually.\n", vol->dev->d_name);
+					"Please specify the number of sectors "
+					"manually.\n", vol->dev->d_name);
 			return FALSE;
 		}
 	}
@@ -3650,24 +3650,24 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 				vol->dev);
 		if (opts.part_start_sect < 0) {
 			ntfs_log_warning("The partition start sector was not "
-				"specified for %s and it could not be obtained "
-				"automatically.  It has been set to 0.\n",
-				vol->dev->d_name);
+					"specified for %s and it could not be obtained "
+					"automatically.  It has been set to 0.\n",
+					vol->dev->d_name);
 			opts.part_start_sect = 0;
 			winboot = FALSE;
 		} else if (opts.part_start_sect >> 32) {
 			ntfs_log_warning("The partition start sector was not "
-				"specified for %s and the automatically "
-				"determined value is too large (%lld). "
-				"It has been set to 0.\n",
-				vol->dev->d_name,
-				(long long)opts.part_start_sect);
+					"specified for %s and the automatically "
+					"determined value is too large (%lld). "
+					"It has been set to 0.\n",
+					vol->dev->d_name,
+					(long long)opts.part_start_sect);
 			opts.part_start_sect = 0;
 			winboot = FALSE;
 		}
 	} else if (opts.part_start_sect >> 32) {
 		ntfs_log_error("Invalid partition start sector.  Maximum is "
-			"4294967295 (2^32-1).\n");
+				"4294967295 (2^32-1).\n");
 		return FALSE;
 	}
 	/* If user didn't specify the sectors per track, determine it now. */
@@ -3676,22 +3676,22 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 				vol->dev);
 		if (opts.sectors_per_track < 0) {
 			ntfs_log_warning("The number of sectors per track was "
-				"not specified for %s and it could not be "
-				"obtained automatically.  It has been set to "
-				"0.\n", vol->dev->d_name);
+					"not specified for %s and it could not be "
+					"obtained automatically.  It has been set to "
+					"0.\n", vol->dev->d_name);
 			opts.sectors_per_track = 0;
 			winboot = FALSE;
 		} else if (opts.sectors_per_track > 65535) {
 			ntfs_log_warning("The number of sectors per track was "
-				"not specified for %s and the automatically "
-				"determined value is too large.  It has been "
-				"set to 0.\n", vol->dev->d_name);
+					"not specified for %s and the automatically "
+					"determined value is too large.  It has been "
+					"set to 0.\n", vol->dev->d_name);
 			opts.sectors_per_track = 0;
 			winboot = FALSE;
 		}
 	} else if (opts.sectors_per_track > 65535) {
 		ntfs_log_error("Invalid number of sectors per track.  Maximum "
-			"is 65535.\n");
+				"is 65535.\n");
 		return FALSE;
 	}
 	/* If user didn't specify the number of heads, determine it now. */
@@ -3699,16 +3699,16 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 		opts.heads = ntfs_device_heads_get(vol->dev);
 		if (opts.heads < 0) {
 			ntfs_log_warning("The number of heads was not "
-				"specified for %s and it could not be obtained "
-				"automatically.  It has been set to 0.\n",
-				vol->dev->d_name);
+					"specified for %s and it could not be obtained "
+					"automatically.  It has been set to 0.\n",
+					vol->dev->d_name);
 			opts.heads = 0;
 			winboot = FALSE;
 		} else if (opts.heads > 65535) {
 			ntfs_log_warning("The number of heads was not "
-				"specified for %s and the automatically "
-				"determined value is too large.  It has been "
-				"set to 0.\n", vol->dev->d_name);
+					"specified for %s and the automatically "
+					"determined value is too large.  It has been "
+					"set to 0.\n", vol->dev->d_name);
 			opts.heads = 0;
 			winboot = FALSE;
 		}
@@ -3764,7 +3764,7 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 				"to, or larger than, the sector size.\n");
 		return FALSE;
 	}
-		/* Before Windows 10 Creators, the limit was 128 */
+	/* Before Windows 10 Creators, the limit was 128 */
 	if (vol->cluster_size > 4096 * (u32)opts.sector_size) {
 		ntfs_log_error("The cluster size is invalid.  It cannot be "
 				"more that 4096 times the size of the sector "
@@ -3773,9 +3773,9 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 	}
 	if (vol->cluster_size > NTFS_MAX_CLUSTER_SIZE) {
 		ntfs_log_error("The cluster size is invalid.  The maximum "
-			"cluster size is %lu bytes (%lukiB).\n",
-			(unsigned long)NTFS_MAX_CLUSTER_SIZE,
-			(unsigned long)(NTFS_MAX_CLUSTER_SIZE >> 10));
+				"cluster size is %lu bytes (%lukiB).\n",
+				(unsigned long)NTFS_MAX_CLUSTER_SIZE,
+				(unsigned long)(NTFS_MAX_CLUSTER_SIZE >> 10));
 		return FALSE;
 	}
 	vol->cluster_size_bits = ffs(vol->cluster_size) - 1;
@@ -3803,10 +3803,10 @@ static BOOL mkntfs_override_vol_params(ntfs_volume *vol)
 	 * with volume_size.
 	 */
 	if ((vol->nr_clusters != ((opts.num_sectors * opts.sector_size) /
-			vol->cluster_size) ||
-			(volume_size / opts.sector_size) != opts.num_sectors ||
-			(volume_size / vol->cluster_size) !=
-			vol->nr_clusters)) {
+					vol->cluster_size) ||
+				(volume_size / opts.sector_size) != opts.num_sectors ||
+				(volume_size / vol->cluster_size) !=
+				vol->nr_clusters)) {
 		/* XXX is this code reachable? */
 		ntfs_log_error("Illegal combination of volume/cluster/sector "
 				"size and/or cluster/sector number.\n");
@@ -3891,7 +3891,7 @@ static BOOL mkntfs_initialize_bitmaps(void)
 	/* Needs to be multiple of 8 bytes. */
 	g_lcn_bitmap_byte_size = (g_lcn_bitmap_byte_size + 7) & ~7;
 	i = (g_lcn_bitmap_byte_size + g_vol->cluster_size - 1) &
-			~(g_vol->cluster_size - 1);
+		~(g_vol->cluster_size - 1);
 	ntfs_log_debug("g_lcn_bitmap_byte_size = %i, allocated = %llu\n",
 			g_lcn_bitmap_byte_size, (unsigned long long)i);
 	g_dynamic_buf_size = mkntfs_get_page_size();
@@ -3903,7 +3903,7 @@ static BOOL mkntfs_initialize_bitmaps(void)
 	 * must be set. This region also encompasses the backup boot sector.
 	 */
 	if (!bitmap_allocate(g_vol->nr_clusters,
-		    ((s64)g_lcn_bitmap_byte_size << 3) - g_vol->nr_clusters))
+				((s64)g_lcn_bitmap_byte_size << 3) - g_vol->nr_clusters))
 		return (FALSE);
 	/*
 	 * Mft size is 27 (NTFS 3.0+) mft records or one cluster, whichever is
@@ -3963,25 +3963,25 @@ static BOOL mkntfs_initialize_rl_mft(void)
 		g_mft_lcn = g_rl_mft_bmp[0].lcn + g_rl_mft_bmp[0].length;
 		if (g_mft_lcn * g_vol->cluster_size < 16 * 1024)
 			g_mft_lcn = (16 * 1024 + g_vol->cluster_size - 1) /
-					g_vol->cluster_size;
+				g_vol->cluster_size;
 	}
 	ntfs_log_debug("$MFT logical cluster number = 0x%llx\n", g_mft_lcn);
 	/* Determine MFT zone size. */
 	g_mft_zone_end = g_vol->nr_clusters;
 	switch (opts.mft_zone_multiplier) {  /* % of volume size in clusters */
-	case 4:
-		g_mft_zone_end = g_mft_zone_end >> 1;	/* 50%   */
-		break;
-	case 3:
-		g_mft_zone_end = g_mft_zone_end * 3 >> 3;/* 37.5% */
-		break;
-	case 2:
-		g_mft_zone_end = g_mft_zone_end >> 2;	/* 25%   */
-		break;
-	case 1:
-	default:
-		g_mft_zone_end = g_mft_zone_end >> 3;	/* 12.5% */
-		break;
+		case 4:
+			g_mft_zone_end = g_mft_zone_end >> 1;	/* 50%   */
+			break;
+		case 3:
+			g_mft_zone_end = g_mft_zone_end * 3 >> 3;/* 37.5% */
+			break;
+		case 2:
+			g_mft_zone_end = g_mft_zone_end >> 2;	/* 25%   */
+			break;
+		case 1:
+		default:
+			g_mft_zone_end = g_mft_zone_end >> 3;	/* 12.5% */
+			break;
 	}
 	ntfs_log_debug("MFT zone size = %lldkiB\n", g_mft_zone_end <<
 			g_vol->cluster_size_bits >> 10 /* >> 10 == / 1024 */);
@@ -4007,7 +4007,7 @@ static BOOL mkntfs_initialize_rl_mft(void)
 	bitmap_allocate(g_mft_lcn,j);
 	/* Determine mftmirr_lcn (middle of volume). */
 	g_mftmirr_lcn = (opts.num_sectors * opts.sector_size >> 1)
-			/ g_vol->cluster_size;
+		/ g_vol->cluster_size;
 	ntfs_log_debug("$MFTMirr logical cluster number = 0x%llx\n",
 			g_mftmirr_lcn);
 	/* Create runlist for mft mirror. */
@@ -4081,7 +4081,7 @@ static BOOL mkntfs_initialize_rl_logfile(void)
 			g_logfile_size = 64 << 20;	/*   -> 64MiB	*/
 		else
 			g_logfile_size = (volume_size / 200) &
-					~(g_vol->cluster_size - 1);
+				~(g_vol->cluster_size - 1);
 	}
 	j = g_logfile_size / g_vol->cluster_size;
 	while (g_rl_logfile[0].lcn + j >= g_vol->nr_clusters) {
@@ -4094,7 +4094,7 @@ static BOOL mkntfs_initialize_rl_logfile(void)
 		j = g_logfile_size / g_vol->cluster_size;
 	}
 	g_logfile_size = (g_logfile_size + g_vol->cluster_size - 1) &
-			~(g_vol->cluster_size - 1);
+		~(g_vol->cluster_size - 1);
 	ntfs_log_debug("$LogFile (journal) size = %ikiB\n",
 			g_logfile_size / 1024);
 	/*
@@ -4198,17 +4198,17 @@ static BOOL mkntfs_fill_device_with_zeroes(void)
 			}
 			if (!position) {
 				ntfs_log_error("Error: Cluster zero is bad. "
-					"Cannot create NTFS file "
-					"system.\n");
+						"Cannot create NTFS file "
+						"system.\n");
 				return FALSE;
 			}
 			/* Add the baddie to our bad blocks list. */
 			if (!append_to_bad_blocks(position))
 				return FALSE;
 			ntfs_log_quiet("\nFound bad cluster (%lld). Adding to "
-				"list of bad blocks.\nInitializing "
-				"device with zeroes: %3.0f%%", position,
-				position / progress_inc);
+					"list of bad blocks.\nInitializing "
+					"device with zeroes: %3.0f%%", position,
+					position / progress_inc);
 			/* Seek to next cluster. */
 			g_vol->dev->d_ops->seek(g_vol->dev,
 					((off_t)position + 1) *
@@ -4217,7 +4217,7 @@ static BOOL mkntfs_fill_device_with_zeroes(void)
 	}
 	ntfs_log_progress("\b\b\b\b100%%");
 	position = (volume_size & (g_vol->cluster_size - 1)) /
-			opts.sector_size;
+		opts.sector_size;
 	for (i = 0; (unsigned long)i < position; i++) {
 		bw = mkntfs_write(g_vol->dev, g_buf, opts.sector_size);
 		if (bw != opts.sector_size) {
@@ -4226,8 +4226,8 @@ static BOOL mkntfs_fill_device_with_zeroes(void)
 				return FALSE;
 			} else if (i + 1ull == position) {
 				ntfs_log_error("Error: Bad cluster found in "
-					"location reserved for system "
-					"file $Boot.\n");
+						"location reserved for system "
+						"file $Boot.\n");
 				return FALSE;
 			}
 			/* Seek to next sector. */
@@ -4262,7 +4262,7 @@ static BOOL mkntfs_sync_index_record(INDEX_ALLOCATION* idx, MFT_RECORD* m,
 	}
 	/* FIXME: This should be IGNORE_CASE! */
 	if (mkntfs_attr_lookup(AT_INDEX_ALLOCATION, name, name_len,
-			CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 		ntfs_attr_put_search_ctx(ctx);
 		ntfs_log_error("BUG: $INDEX_ALLOCATION attribute not found.\n");
 		return FALSE;
@@ -4283,16 +4283,16 @@ static BOOL mkntfs_sync_index_record(INDEX_ALLOCATION* idx, MFT_RECORD* m,
 	}
 	ntfs_attr_put_search_ctx(ctx);
 	i = sizeof(INDEX_BLOCK) - sizeof(INDEX_HEADER) +
-			le32_to_cpu(idx->index.allocated_size);
+		le32_to_cpu(idx->index.allocated_size);
 	err = ntfs_mst_pre_write_fixup((NTFS_RECORD*)idx, i);
 	if (err) {
 		free(rl_index);
 		ntfs_log_error("ntfs_mst_pre_write_fixup() failed while "
-			"syncing index block.\n");
+				"syncing index block.\n");
 		return FALSE;
 	}
 	lw = ntfs_rlwrite(g_vol->dev, rl_index, (u8*)idx, i, NULL,
-				WRITE_STANDARD);
+			WRITE_STANDARD);
 	free(rl_index);
 	if (lw != i) {
 		ntfs_log_error("Error writing $INDEX_ALLOCATION.\n");
@@ -4367,7 +4367,7 @@ static int create_backup_boot_sector(u8 *buff)
 	if (size < opts.sector_size)
 		size = opts.sector_size;
 	if (g_vol->dev->d_ops->seek(g_vol->dev, (opts.num_sectors + 1) *
-			opts.sector_size - size, SEEK_SET) == (off_t)-1) {
+				opts.sector_size - size, SEEK_SET) == (off_t)-1) {
 		ntfs_log_perror("Seek failed");
 		goto bb_err;
 	}
@@ -4458,7 +4458,7 @@ static BOOL mkntfs_create_root_structures(void)
 	 */
 	for (i = 0; i < nr_sysfiles; i++) {
 		if (ntfs_mft_record_layout(g_vol, 0, m = (MFT_RECORD *)(g_buf +
-				i * g_vol->mft_record_size))) {
+						i * g_vol->mft_record_size))) {
 			ntfs_log_error("Failed to layout system mft records."
 					"\n");
 			return FALSE;
@@ -4474,7 +4474,7 @@ static BOOL mkntfs_create_root_structures(void)
 	 */
 	if (nr_sysfiles * (s32)g_vol->mft_record_size < g_mft_size) {
 		for (i = nr_sysfiles;
-		      i * (s32)g_vol->mft_record_size < g_mft_size; i++) {
+				i * (s32)g_vol->mft_record_size < g_mft_size; i++) {
 			m = (MFT_RECORD *)(g_buf + i * g_vol->mft_record_size);
 			if (ntfs_mft_record_layout(g_vol, 0, m)) {
 				ntfs_log_error("Failed to layout mft record."
@@ -4511,22 +4511,22 @@ static BOOL mkntfs_create_root_structures(void)
 		if (i == 0 || i == 1 || i == 2 || i == 6 || i == 8 ||
 				i == 10) {
 			add_attr_std_info(m, file_attrs,
-				const_cpu_to_le32(0x0100));
+					const_cpu_to_le32(0x0100));
 		} else if (i == 9) {
 			file_attrs |= FILE_ATTR_VIEW_INDEX_PRESENT;
 			add_attr_std_info(m, file_attrs,
-				const_cpu_to_le32(0x0101));
+					const_cpu_to_le32(0x0101));
 		} else if (i == 11) {
 			add_attr_std_info(m, file_attrs,
-				const_cpu_to_le32(0x0101));
+					const_cpu_to_le32(0x0101));
 		} else if (i == 24 || i == 25 || i == 26) {
 			file_attrs |= FILE_ATTR_ARCHIVE;
 			file_attrs |= FILE_ATTR_VIEW_INDEX_PRESENT;
 			add_attr_std_info(m, file_attrs,
-				const_cpu_to_le32(0x0101));
+					const_cpu_to_le32(0x0101));
 		} else {
 			add_attr_std_info(m, file_attrs,
-				const_cpu_to_le32(0x00));
+					const_cpu_to_le32(0x00));
 		}
 	}
 	/* The root directory mft reference. */
@@ -4564,7 +4564,7 @@ static BOOL mkntfs_create_root_structures(void)
 		}
 		/* There is exactly one file name so this is ok. */
 		if (mkntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
-				CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			ntfs_attr_put_search_ctx(ctx);
 			ntfs_log_error("BUG: $FILE_NAME attribute not found."
 					"\n");
@@ -4573,13 +4573,13 @@ static BOOL mkntfs_create_root_structures(void)
 		a = ctx->attr;
 		err = insert_file_link_in_dir_index(g_index_block, root_ref,
 				(FILE_NAME_ATTR*)((char*)a +
-				le16_to_cpu(a->value_offset)),
+					le16_to_cpu(a->value_offset)),
 				le32_to_cpu(a->value_length));
 		ntfs_attr_put_search_ctx(ctx);
 	}
 	if (err) {
 		ntfs_log_error("Couldn't create root directory: %s\n",
-			strerror(-err));
+				strerror(-err));
 		return FALSE;
 	}
 	/* Add all other attributes, on a per-file basis for clarity. */
@@ -4591,7 +4591,7 @@ static BOOL mkntfs_create_root_structures(void)
 		err = create_hardlink(g_index_block, root_ref, m,
 				MK_LE_MREF(FILE_MFT, 1),
 				((g_mft_size - 1)
-					| (g_vol->cluster_size - 1)) + 1,
+				 | (g_vol->cluster_size - 1)) + 1,
 				g_mft_size, FILE_ATTR_HIDDEN |
 				FILE_ATTR_SYSTEM, 0, 0, "$MFT",
 				FILE_NAME_WIN32_AND_DOS);
@@ -4663,16 +4663,16 @@ static BOOL mkntfs_create_root_structures(void)
 	/* windows 2003 will regard the volume as corrupt (ERSO) */
 	if (!err)
 		err = insert_non_resident_attr_in_mft_record(m,
-			AT_DATA,  NULL, 0, CASE_SENSITIVE,
-			const_cpu_to_le16(0), (const u8*)NULL,
-			g_lcn_bitmap_byte_size, WRITE_BITMAP);
+				AT_DATA,  NULL, 0, CASE_SENSITIVE,
+				const_cpu_to_le16(0), (const u8*)NULL,
+				g_lcn_bitmap_byte_size, WRITE_BITMAP);
 
 
 	if (!err)
 		err = create_hardlink(g_index_block, root_ref, m,
 				MK_LE_MREF(FILE_Bitmap, FILE_Bitmap),
 				(g_lcn_bitmap_byte_size + g_vol->cluster_size -
-				1) & ~(g_vol->cluster_size - 1),
+				 1) & ~(g_vol->cluster_size - 1),
 				g_lcn_bitmap_byte_size,
 				FILE_ATTR_HIDDEN | FILE_ATTR_SYSTEM, 0, 0,
 				"$Bitmap", FILE_NAME_WIN32_AND_DOS);
@@ -4863,19 +4863,19 @@ static BOOL mkntfs_create_root_structures(void)
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$SDH", 4, CASE_SENSITIVE,
-			AT_UNUSED, COLLATION_NTOFS_SECURITY_HASH,
-			g_vol->indx_record_size);
+				AT_UNUSED, COLLATION_NTOFS_SECURITY_HASH,
+				g_vol->indx_record_size);
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$SII", 4, CASE_SENSITIVE,
-			AT_UNUSED, COLLATION_NTOFS_ULONG,
-			g_vol->indx_record_size);
+				AT_UNUSED, COLLATION_NTOFS_ULONG,
+				g_vol->indx_record_size);
 	if (!err)
 		err = initialize_secure(buf_sds, buf_sds_first_size, m);
 	free(buf_sds);
 	if (err < 0) {
 		ntfs_log_error("Couldn't create $Secure: %s\n",
-			strerror(-err));
+				strerror(-err));
 		return FALSE;
 	}
 	ntfs_log_verbose("Creating $UpCase (mft record 0xa)\n");
@@ -4888,13 +4888,13 @@ static BOOL mkntfs_create_root_structures(void)
 	 */
 	if (!err)
 		err = add_attr_data(m, "$Info", 5, CASE_SENSITIVE,
-			const_cpu_to_le16(0),
-			(u8*)g_upcaseinfo, sizeof(struct UPCASEINFO));
+				const_cpu_to_le16(0),
+				(u8*)g_upcaseinfo, sizeof(struct UPCASEINFO));
 	if (!err)
 		err = create_hardlink(g_index_block, root_ref, m,
 				MK_LE_MREF(FILE_UpCase, FILE_UpCase),
 				((g_vol->upcase_len << 1) +
-				g_vol->cluster_size - 1) &
+				 g_vol->cluster_size - 1) &
 				~(g_vol->cluster_size - 1),
 				g_vol->upcase_len << 1,
 				FILE_ATTR_HIDDEN | FILE_ATTR_SYSTEM, 0, 0,
@@ -4919,11 +4919,11 @@ static BOOL mkntfs_create_root_structures(void)
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$I30", 4, CASE_SENSITIVE,
-			AT_FILE_NAME, COLLATION_FILE_NAME,
-			g_vol->indx_record_size);
+				AT_FILE_NAME, COLLATION_FILE_NAME,
+				g_vol->indx_record_size);
 	if (err < 0) {
 		ntfs_log_error("Couldn't create $Extend: %s\n",
-			strerror(-err));
+				strerror(-err));
 		return FALSE;
 	}
 	/* NTFS reserved system files (mft records 0xc-0xf) */
@@ -4952,17 +4952,17 @@ static BOOL mkntfs_create_root_structures(void)
 	m->flags |= MFT_RECORD_IS_VIEW_INDEX;
 	if (!err)
 		err = create_hardlink_res((MFT_RECORD*)(g_buf +
-			11 * g_vol->mft_record_size), extend_ref, m,
-			MK_LE_MREF(24, 1), 0LL, 0LL, extend_flags,
-			0, 0, "$Quota", FILE_NAME_WIN32_AND_DOS);
+					11 * g_vol->mft_record_size), extend_ref, m,
+				MK_LE_MREF(24, 1), 0LL, 0LL, extend_flags,
+				0, 0, "$Quota", FILE_NAME_WIN32_AND_DOS);
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$Q", 2, CASE_SENSITIVE, AT_UNUSED,
-			COLLATION_NTOFS_ULONG, g_vol->indx_record_size);
+				COLLATION_NTOFS_ULONG, g_vol->indx_record_size);
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$O", 2, CASE_SENSITIVE, AT_UNUSED,
-			COLLATION_NTOFS_SID, g_vol->indx_record_size);
+				COLLATION_NTOFS_SID, g_vol->indx_record_size);
 	if (!err)
 		err = initialize_quota(m);
 	if (err < 0) {
@@ -4975,7 +4975,7 @@ static BOOL mkntfs_create_root_structures(void)
 	m->flags |= MFT_RECORD_IS_VIEW_INDEX;
 	if (!err)
 		err = create_hardlink_res((MFT_RECORD*)(g_buf +
-				11 * g_vol->mft_record_size), extend_ref,
+					11 * g_vol->mft_record_size), extend_ref,
 				m, MK_LE_MREF(25, 1), 0LL, 0LL,
 				extend_flags, 0, 0, "$ObjId",
 				FILE_NAME_WIN32_AND_DOS);
@@ -4983,8 +4983,8 @@ static BOOL mkntfs_create_root_structures(void)
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$O", 2, CASE_SENSITIVE, AT_UNUSED,
-			COLLATION_NTOFS_ULONGS,
-			g_vol->indx_record_size);
+				COLLATION_NTOFS_ULONGS,
+				g_vol->indx_record_size);
 	if (!err && opts.with_uuid)
 		err = index_obj_id_insert(m, &vol_guid,
 				MK_LE_MREF(FILE_Volume, FILE_Volume));
@@ -4999,17 +4999,17 @@ static BOOL mkntfs_create_root_structures(void)
 	m->flags |= MFT_RECORD_IS_VIEW_INDEX;
 	if (!err)
 		err = create_hardlink_res((MFT_RECORD*)(g_buf +
-				11 * g_vol->mft_record_size),
+					11 * g_vol->mft_record_size),
 				extend_ref, m, MK_LE_MREF(26, 1),
 				0LL, 0LL, extend_flags, 0, 0,
 				"$Reparse", FILE_NAME_WIN32_AND_DOS);
 	/* FIXME: This should be IGNORE_CASE */
 	if (!err)
 		err = add_attr_index_root(m, "$R", 2, CASE_SENSITIVE, AT_UNUSED,
-			COLLATION_NTOFS_ULONGS, g_vol->indx_record_size);
+				COLLATION_NTOFS_ULONGS, g_vol->indx_record_size);
 	if (err < 0) {
 		ntfs_log_error("Couldn't create $Reparse: %s\n",
-			strerror(-err));
+				strerror(-err));
 		return FALSE;
 	}
 	return TRUE;
@@ -5127,7 +5127,7 @@ static int mkntfs_redirect(struct mkntfs_options *opts2)
 	 */
 	ntfs_log_verbose("Syncing root directory index record.\n");
 	if (!mkntfs_sync_index_record(g_index_block, (MFT_RECORD*)(g_buf + 5 *
-			g_vol->mft_record_size), NTFS_INDEX_I30, 4))
+					g_vol->mft_record_size), NTFS_INDEX_I30, 4))
 		goto done;
 
 	ntfs_log_verbose("Syncing $Bitmap.\n");
@@ -5153,12 +5153,12 @@ static int mkntfs_redirect(struct mkntfs_options *opts2)
 			goto done;
 		}
 		lw = ntfs_rlwrite(g_vol->dev, rl, (const u8*)NULL,
-			 g_lcn_bitmap_byte_size, NULL, WRITE_BITMAP);
+				g_lcn_bitmap_byte_size, NULL, WRITE_BITMAP);
 		err = errno;
 		free(rl);
 		if (lw != g_lcn_bitmap_byte_size) {
 			ntfs_log_error("ntfs_rlwrite: %s\n", lw == -1 ?
-				       strerror(err) : "unknown error");
+					strerror(err) : "unknown error");
 			goto done;
 		}
 	} else {
@@ -5179,7 +5179,7 @@ static int mkntfs_redirect(struct mkntfs_options *opts2)
 			lw = ntfs_mst_pwrite(g_vol->dev, pos, 1, g_vol->mft_record_size, g_buf + i * g_vol->mft_record_size);
 		if (lw != 1) {
 			ntfs_log_error("ntfs_mst_pwrite: %s\n", lw == -1 ?
-				       strerror(errno) : "unknown error");
+					strerror(errno) : "unknown error");
 			goto done;
 		}
 		pos += g_vol->mft_record_size;
@@ -5203,7 +5203,7 @@ static int mkntfs_redirect(struct mkntfs_options *opts2)
 			lw = ntfs_mst_pwrite(g_vol->dev, pos, 1, g_vol->mft_record_size, g_buf + i * g_vol->mft_record_size);
 		if (lw != 1) {
 			ntfs_log_error("ntfs_mst_pwrite: %s\n", lw == -1 ?
-				       strerror(errno) : "unknown error");
+					strerror(errno) : "unknown error");
 			goto done;
 		}
 		pos += g_vol->mft_record_size;
@@ -5239,7 +5239,7 @@ int main(int argc, char *argv[])
 
 	mkntfs_init_options(&opts);			/* Set up the options */
 
-			/* Read the command line options */
+	/* Read the command line options */
 	result = mkntfs_parse_options(argc, argv, &opts);
 
 	if (result < 0)

--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -154,25 +154,25 @@ u64 orphan_cnt;
 /**
  * usage
  */
-__attribute__((noreturn))
+	__attribute__((noreturn))
 static void usage(int error)
 {
 	ntfs_log_info("%s v%s\n\n"
-		      "Usage: %s [options] device\n"
-		      "-a, --repair-auto	auto-repair. no questions\n"
-		      "-p,			auto-repair. no questions\n"
-		      "-C,			just check volume dirty\n"
-		      "-n, --repair-no		just check the consistency and no fix\n"
-		      "-q, --quiet		No progress bar\n"
-		      "-r, --repair		Repair interactively\n"
-		      "-y, --repair-yes		all yes about all question\n"
-		      "-v, --verbose		verbose\n"
-		      "-V, --version		version\n\n"
-		      "NOTE: -a/-p, -C, -n, -r, -y options are mutually exclusive with each other options\n\n"
-		      "For example: %s /dev/sda1\n"
-		      "For example: %s -C /dev/sda1\n"
-		      "For example: %s -a /dev/sda1\n\n",
-		      NTFS_PROGS, VERSION, NTFS_PROGS, NTFS_PROGS, NTFS_PROGS, NTFS_PROGS);
+		"Usage: %s [options] device\n"
+		"-a, --repair-auto	auto-repair. no questions\n"
+		"-p,			auto-repair. no questions\n"
+		"-C,			just check volume dirty\n"
+		"-n, --repair-no		just check the consistency and no fix\n"
+		"-q, --quiet		No progress bar\n"
+		"-r, --repair		Repair interactively\n"
+		"-y, --repair-yes		all yes about all question\n"
+		"-v, --verbose		verbose\n"
+		"-V, --version		version\n\n"
+		"NOTE: -a/-p, -C, -n, -r, -y options are mutually exclusive with each other options\n\n"
+		"For example: %s /dev/sda1\n"
+		"For example: %s -C /dev/sda1\n"
+		"For example: %s -a /dev/sda1\n\n",
+		NTFS_PROGS, VERSION, NTFS_PROGS, NTFS_PROGS, NTFS_PROGS, NTFS_PROGS);
 	exit(error ? RETURN_USAGE_OR_SYNTAX_ERROR : 0);
 }
 
@@ -1057,7 +1057,7 @@ stack_of:
 		}
 
 		while (!ntfs_attr_lookup(AT_FILE_NAME, AT_UNNAMED, 0,
-						CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			fn = (FILE_NAME_ATTR *)((u8 *)ctx->attr +
 					le16_to_cpu(ctx->attr->value_offset));
 
@@ -1229,15 +1229,15 @@ static void ntfsck_check_mft_record_unused(ntfs_volume *vol, s64 mft_num)
 	}
 
 	if (!ntfs_is_file_record(mrec_temp_buf->magic) ||
-	    !(mrec_temp_buf->flags & MFT_RECORD_IN_USE)) {
+			!(mrec_temp_buf->flags & MFT_RECORD_IN_USE)) {
 		ntfs_log_verbose("Record(%"PRId64") unused. Skipping.\n",
 				mft_num);
 		return;
 	}
 
 	ntfs_log_error("Record(%"PRId64") used. "
-		       "Mark the mft record as not in use.\n",
-		       mft_num);
+			"Mark the mft record as not in use.\n",
+			mft_num);
 	mrec_temp_buf->flags &= ~MFT_RECORD_IN_USE;
 	seq_no = le16_to_cpu(mrec_temp_buf->sequence_number);
 	if (seq_no == 0xffff)
@@ -1264,7 +1264,7 @@ static void ntfsck_verify_mft_record(ntfs_volume *vol, s64 mft_num)
 	is_used = check_mftrec_in_use(vol, mft_num, 0);
 	if (is_used < 0) {
 		ntfs_log_error("Error getting bit value for record %"PRId64".\n",
-			mft_num);
+				mft_num);
 		return;
 	} else if (!is_used) {
 		if (mft_num < FILE_Extend) {
@@ -1490,7 +1490,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 	if (!fn) {
 		/* NOT FOUND MFT/$FN */
 		filename = ntfs_attr_name_get(ie_fn->file_name,
-					      ie_fn->file_name_length);
+				ie_fn->file_name_length);
 		ntfs_log_error("Filename(%s) in index entry of parent(%"PRIu64") "
 				"was not found in inode(%"PRIu64")\n",
 				filename, ictx->ni->mft_no, ni->mft_no);
@@ -1511,17 +1511,17 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 
 	/* check parent MFT reference */
 	if (idx_pdir != mft_pdir ||
-		idx_pdir_seq != mft_pdir_seq ||
-		mft_pdir != ictx->ni->mft_no) {
-			filename = ntfs_attr_name_get(ie_fn->file_name,
-						      ie_fn->file_name_length);
-			ntfs_log_error("Parent MFT reference is different "
-					"(IDX/$FN:%"PRIu64"-%u MFT/$FN:%"PRIu64"-%u) "
-					"on inode(%"PRIu64", %s), parent(%"PRIu64")\n",
-					idx_pdir, idx_pdir_seq, mft_pdir, mft_pdir_seq,
-					ni->mft_no, filename, ictx->ni->mft_no);
-			ret = STATUS_ERROR;
-			goto out;
+			idx_pdir_seq != mft_pdir_seq ||
+			mft_pdir != ictx->ni->mft_no) {
+		filename = ntfs_attr_name_get(ie_fn->file_name,
+				ie_fn->file_name_length);
+		ntfs_log_error("Parent MFT reference is different "
+				"(IDX/$FN:%"PRIu64"-%u MFT/$FN:%"PRIu64"-%u) "
+				"on inode(%"PRIu64", %s), parent(%"PRIu64")\n",
+				idx_pdir, idx_pdir_seq, mft_pdir, mft_pdir_seq,
+				ni->mft_no, filename, ictx->ni->mft_no);
+		ret = STATUS_ERROR;
+		goto out;
 	}
 
 	/*
@@ -1539,7 +1539,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 		if (ntfs_attr_lookup(AT_REPARSE_POINT, AT_UNNAMED, 0,
 					CASE_SENSITIVE, 0, NULL, 0, _ctx)) {
 			filename = ntfs_attr_name_get(ie_fn->file_name,
-						      ie_fn->file_name_length);
+					ie_fn->file_name_length);
 			ntfs_log_error("MFT flag set as reparse file, but there's no "
 					"MFT/$REPARSE_POINT attribute on inode(%"PRIu64":%s)",
 					ni->mft_no, filename);
@@ -1557,7 +1557,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 
 		if (ie_fn->reparse_point_tag != rpp->reparse_tag) {
 			filename = ntfs_attr_name_get(ie_fn->file_name,
-						      ie_fn->file_name_length);
+					ie_fn->file_name_length);
 			pctx->filename = filename;
 			fsck_err_found();
 			ntfs_print_problem(vol, PR_MFT_REPARSE_TAG_MISMATCH, &pctx);
@@ -1580,7 +1580,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 	if (ni->mrec->flags & MFT_RECORD_IS_DIRECTORY) {
 		if (!(ie_fn->file_attributes & FILE_ATTR_I30_INDEX_PRESENT)) {
 			filename = ntfs_attr_name_get(ie_fn->file_name,
-						      ie_fn->file_name_length);
+					ie_fn->file_name_length);
 			pctx.filename = filename;
 			fsck_err_found();
 			if (ntfs_fix_problem(vol, PR_MFT_FLAG_MISMATCH, &pctx)) {
@@ -1597,7 +1597,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 				ni->allocated_size != 0 || ni->data_size != 0) {
 			if (!filename)
 				filename = ntfs_attr_name_get(ie_fn->file_name,
-							      ie_fn->file_name_length);
+						ie_fn->file_name_length);
 			pctx.filename = filename;
 			fsck_err_found();
 			if (ntfs_fix_problem(vol, PR_DIR_NONZERO_SIZE, &pctx)) {
@@ -1626,7 +1626,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 	/* check $FN size fields */
 	if (ni->allocated_size != sle64_to_cpu(ie_fn->allocated_size)) {
 		filename = ntfs_attr_name_get(ie_fn->file_name,
-					      ie_fn->file_name_length);
+				ie_fn->file_name_length);
 		pctx.filename = filename;
 		fsck_err_found();
 		ntfs_print_problem(vol, PR_MFT_ALLOCATED_SIZE_MISMATCH, &pctx);
@@ -1640,7 +1640,7 @@ static int ntfsck_check_file_name_attr(ntfs_inode *ni, FILE_NAME_ATTR *ie_fn,
 	 */
 	if (ni->data_size != sle64_to_cpu(ie_fn->data_size)) {
 		filename = ntfs_attr_name_get(ie_fn->file_name,
-					      ie_fn->file_name_length);
+				ie_fn->file_name_length);
 		pctx.filename = filename;
 		fsck_err_found();
 		ntfs_print_problem(vol, PR_MFT_DATA_SIZE_MISMATCH, &pctx);
@@ -1989,7 +1989,7 @@ static runlist *ntfsck_decompose_runlist(ntfs_attr *na, BOOL *need_fix)
 			/* TODO: last_vcn value should be recalculated */
 			/* Get the last vcn in the attribute. */
 			last_vcn = sle64_to_cpu(attr->allocated_size) >>
-					vol->cluster_size_bits;
+				vol->cluster_size_bits;
 		}
 
 		highest_vcn = sle64_to_cpu(attr->highest_vcn);
@@ -3031,7 +3031,7 @@ static inline int ntfsck_is_directory(FILE_NAME_ATTR *ie_fn)
  * next entry.
  */
 static int ntfsck_check_index(ntfs_volume *vol, INDEX_ENTRY *ie,
-			       ntfs_index_context *ictx)
+		ntfs_index_context *ictx)
 {
 	ntfs_inode *ni;
 	struct dir *dir;
@@ -3283,7 +3283,7 @@ out:
 }
 
 static void ntfsck_validate_index_blocks(ntfs_volume *vol,
-					 ntfs_index_context *ictx)
+		ntfs_index_context *ictx)
 {
 	ntfs_attr *bmp_na = NULL;
 	INDEX_ALLOCATION *ia;
@@ -3329,7 +3329,7 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 	}
 
 	memcpy(ir_buf, (u8 *)&ir->index + le32_to_cpu(ir->index.entries_offset),
-		       ir_size);
+			ir_size);
 
 	/* check entries in INDEX_ROOT */
 	ie = (INDEX_ENTRY *)ir_buf;
@@ -3339,7 +3339,7 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 			ie = (INDEX_ENTRY *)((u8 *)ie + le16_to_cpu(ie->length))) {
 		/* check length bound */
 		if ((u8 *)ie + sizeof(INDEX_ENTRY_HEADER) > index_end ||
-		    (u8 *)ie + le16_to_cpu(ie->length) > index_end) {
+				(u8 *)ie + le16_to_cpu(ie->length) > index_end) {
 			ntfs_log_error("Index root entry out of bounds in"
 					" inode %"PRId64"\n", ni->mft_no);
 			goto initialize_index;
@@ -3361,7 +3361,7 @@ static void ntfsck_validate_index_blocks(ntfs_volume *vol,
 
 		/* The file name must not overflow from the entry */
 		if (ntfs_index_entry_inconsistent(vol, ie, COLLATION_FILE_NAME,
-				ni->mft_no, NULL) < 0) {
+					ni->mft_no, NULL) < 0) {
 			ntfs_log_error("Index entry(%p) of inode(%"PRIu64
 					") is inconsistent\n", ie, ni->mft_no);
 			goto initialize_index;
@@ -3780,7 +3780,7 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 		ntfs_attr_reinit_search_ctx(ctx);
 		/* Find the index root attribute in the mft record. */
 		if (ntfs_attr_lookup(AT_INDEX_ROOT, NTFS_INDEX_I30, 4,
-				     CASE_SENSITIVE, 0, NULL, 0, ctx)) {
+					CASE_SENSITIVE, 0, NULL, 0, ctx)) {
 			ntfs_log_perror("Index root attribute missing in directory inode "
 					"%"PRId64"", dir_ni->mft_no);
 			goto err_continue;
@@ -3796,7 +3796,7 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 		if (next->ie_flags & INDEX_ENTRY_NODE) {
 			/* read $IA */
 			ictx->ia_na = ntfs_attr_open(dir_ni, AT_INDEX_ALLOCATION,
-							ictx->name, ictx->name_len);
+					ictx->name, ictx->name_len);
 			if (!ictx->ia_na) {
 				ntfs_log_perror("Failed to open index allocation of inode "
 						"%"PRIu64"", dir_ni->mft_no);
@@ -3855,7 +3855,7 @@ static int ntfsck_scan_index_entries_btree(ntfs_volume *vol)
 		while ((next = ntfs_index_next(next, ictx)) != NULL) {
 check_index:
 			if (!ntfs_fsck_mftbmp_get(vol,
-					MREF(le64_to_cpu(next->indexed_file))))
+						MREF(le64_to_cpu(next->indexed_file))))
 				progress_update(&prog, ++checked_cnt);
 
 			ret = ntfsck_check_index(vol, next, ictx);
@@ -3931,7 +3931,7 @@ static void ntfsck_check_mft_records(ntfs_volume *vol)
 
 	// For each mft record, verify that it contains a valid file record.
 	nr_mft_records = vol->mft_na->initialized_size >>
-			vol->mft_record_size_bits;
+		vol->mft_record_size_bits;
 	ntfs_log_verbose("Checking %"PRId64" MFT records.\n", nr_mft_records);
 
 	progress_init(&prog, 0, nr_mft_records, 1000, pb_flags);
@@ -3999,12 +3999,12 @@ static inline BOOL ntfsck_opened_ni_vol(s64 mft_num)
 	BOOL is_opened = FALSE;
 
 	switch (mft_num) {
-	case FILE_MFT:
-	case FILE_MFTMirr:
-	case FILE_Volume:
-	case FILE_Bitmap:
-	case FILE_Secure:
-		is_opened = TRUE;
+		case FILE_MFT:
+		case FILE_MFTMirr:
+		case FILE_Volume:
+		case FILE_Bitmap:
+		case FILE_Secure:
+			is_opened = TRUE;
 	}
 
 	return is_opened;
@@ -4015,20 +4015,20 @@ static ntfs_inode *ntfsck_get_opened_ni_vol(ntfs_volume *vol, s64 mft_num)
 	ntfs_inode *ni = NULL;
 
 	switch (mft_num) {
-	case FILE_MFT:
-		ni = vol->mft_ni;
-		break;
-	case FILE_MFTMirr:
-		ni = vol->mftmirr_ni;
-		break;
-	case FILE_Volume:
-		ni = vol->vol_ni;
-		break;
-	case FILE_Bitmap:
-		ni = vol->lcnbmp_ni;
-		break;
-	case FILE_Secure:
-		ni = vol->secure_ni;
+		case FILE_MFT:
+			ni = vol->mft_ni;
+			break;
+		case FILE_MFTMirr:
+			ni = vol->mftmirr_ni;
+			break;
+		case FILE_Volume:
+			ni = vol->vol_ni;
+			break;
+		case FILE_Bitmap:
+			ni = vol->lcnbmp_ni;
+			break;
+		case FILE_Secure:
+			ni = vol->secure_ni;
 	}
 
 	return ni;
@@ -4054,7 +4054,7 @@ static int ntfsck_validate_system_file(ntfs_inode *ni)
 		/* TODO: check sub-directory */
 		ntfsck_check_inode_non_resident(ni, 1);
 		break;
-	case FILE_Bitmap: {
+	case FILE_Bitmap:
 		s64 max_lcnbmp_size;
 
 		if (ntfs_attr_map_whole_runlist(vol->lcnbmp_na)) {
@@ -4107,7 +4107,6 @@ static int ntfsck_validate_system_file(ntfs_inode *ni)
 			}
 		}
 		break;
-	}
 	}
 
 	return 0;
@@ -4500,7 +4499,7 @@ static int ntfsck_scan_mft_record(ntfs_volume *vol, s64 mft_num)
 	is_used = check_mftrec_in_use(vol, mft_num, 0);
 	if (is_used < 0) {
 		ntfs_log_error("Error getting bit value for record %"PRId64".\n",
-			mft_num);
+				mft_num);
 		return STATUS_ERROR;
 	} else if (!is_used) {
 		if (mft_num < FILE_Extend) {
@@ -4553,7 +4552,7 @@ static void ntfsck_scan_mft_records(ntfs_volume *vol)
 
 	// For each mft record, verify that it contains a valid file record.
 	nr_mft_records = vol->mft_na->initialized_size >>
-			vol->mft_record_size_bits;
+		vol->mft_record_size_bits;
 	ntfs_log_verbose("Scanning maximum %"PRId64" MFT records.\n", nr_mft_records);
 
 	ntfs_print_message(vol, PR_PRE_SCAN_MFT, &pctx);
@@ -4605,8 +4604,8 @@ int main(int argc, char **argv)
 					check_dirty_only == TRUE) {
 conflict_option:
 				ntfs_log_error("\n%s: "
-				"Only one of the optinos -a/-p, -C, -n, -r or -y may be specified.\n",
-				NTFS_PROGS);
+						"Only one of the optinos -a/-p, -C, -n, -r or -y may be specified.\n",
+						NTFS_PROGS);
 
 				exit(RETURN_USAGE_OR_SYNTAX_ERROR);
 			}
@@ -4615,8 +4614,8 @@ conflict_option:
 			break;
 		case 'C':	/* exclusive with others */
 			if (option.flags & (NTFS_MNT_FS_AUTO_REPAIR |
-							NTFS_MNT_FS_ASK_REPAIR |
-							NTFS_MNT_FS_YES_REPAIR)) {
+						NTFS_MNT_FS_ASK_REPAIR |
+						NTFS_MNT_FS_YES_REPAIR)) {
 				goto conflict_option;
 			}
 
@@ -4664,8 +4663,8 @@ conflict_option:
 			break;
 		case 'v':
 			option.verbose = 1;
-                        ntfs_log_set_levels(NTFS_LOG_LEVEL_VERBOSE);
-                        break;
+			ntfs_log_set_levels(NTFS_LOG_LEVEL_VERBOSE);
+			break;
 		case 'V':
 			version();
 			break;
@@ -4677,9 +4676,9 @@ conflict_option:
 
 	/* If not set fsck repair option, set default fsck flags to ASK mode. */
 	if (!(option.flags & (NTFS_MNT_FS_AUTO_REPAIR |
-				NTFS_MNT_FS_NO_REPAIR |
-				NTFS_MNT_FS_ASK_REPAIR |
-				NTFS_MNT_FS_YES_REPAIR))) {
+					NTFS_MNT_FS_NO_REPAIR |
+					NTFS_MNT_FS_ASK_REPAIR |
+					NTFS_MNT_FS_YES_REPAIR))) {
 		option.flags |= NTFS_MNT_FS_ASK_REPAIR;
 	}
 

--- a/src/ntfsclone.c
+++ b/src/ntfsclone.c
@@ -100,8 +100,8 @@
 #endif
 
 #if defined(linux) || defined(__uClinux__) || defined(__sun) \
-		|| defined(__APPLE__) || defined(__DARWIN__)
-  /* Make sure the presence of <windows.h> means compiling for Windows */
+	|| defined(__APPLE__) || defined(__DARWIN__)
+/* Make sure the presence of <windows.h> means compiling for Windows */
 #undef HAVE_WINDOWS_H
 #endif
 
@@ -254,7 +254,7 @@ static struct image_hdr {
 static int compare_bitmaps(struct bitmap *a, BOOL copy);
 
 #define NTFSCLONE_IMG_HEADER_SIZE_OLD	\
-		(offsetof(struct image_hdr, offset_to_image_data))
+	(offsetof(struct image_hdr, offset_to_image_data))
 
 #define NTFS_MBYTE (1000 * 1000)
 
@@ -382,10 +382,10 @@ __attribute__((noreturn))
 static void version(void)
 {
 	fprintf(stderr,
-		   "Efficiently clone, image, restore or rescue an NTFS Volume.\n\n"
-		   "Copyright (c) 2003-2006 Szabolcs Szakacsits\n"
-		   "Copyright (c) 2004-2006 Anton Altaparmakov\n"
-		   "Copyright (c) 2010-2018 Jean-Pierre Andre\n\n");
+		"Efficiently clone, image, restore or rescue an NTFS Volume.\n\n"
+		"Copyright (c) 2003-2006 Szabolcs Szakacsits\n"
+		"Copyright (c) 2004-2006 Anton Altaparmakov\n"
+		"Copyright (c) 2010-2018 Jean-Pierre Andre\n\n");
 	exit(0);
 }
 
@@ -511,18 +511,18 @@ static void parse_options(int argc, char **argv)
 
 	if (opt.metadata && opt.restore_image)
 		err_exit("Restoring only metadata from an image is not "
-			 "supported!\n");
+				"supported!\n");
 
 	if (opt.metadata && !opt.metadata_image && opt.std_out)
 		err_exit("Cloning only metadata to stdout isn't supported!\n");
 
 	if (opt.ignore_fs_check && !opt.metadata && !opt.rescue)
 		err_exit("Filesystem check can be ignored only for metadata "
-			 "cloning or rescue situations!\n");
+				"cloning or rescue situations!\n");
 
 	if (opt.save_image && opt.restore_image)
 		err_exit("Saving and restoring an image at the same time "
-			 "is not supported!\n");
+				"is not supported!\n");
 
 	if (opt.no_action && !opt.restore_image)
 		err_exit("A restoring test requires the restore option!\n");
@@ -534,7 +534,7 @@ static void parse_options(int argc, char **argv)
 		struct stat st;
 #ifdef HAVE_WINDOWS_H
 		BOOL blkdev = opt.output[0] && (opt.output[1] == ':')
-					&& !opt.output[2];
+			&& !opt.output[2];
 
 		if (!blkdev && (stat(opt.output, &st) == -1)) {
 #else
@@ -545,8 +545,8 @@ static void parse_options(int argc, char **argv)
 		} else {
 			if (!opt.overwrite)
 				err_exit("Output file '%s' already exists.\n"
-					 "Use option --overwrite if you want to"
-					 " replace its content.\n", opt.output);
+						"Use option --overwrite if you want to"
+						" replace its content.\n", opt.output);
 
 #ifdef HAVE_WINDOWS_H
 			if (blkdev) {
@@ -556,15 +556,15 @@ static void parse_options(int argc, char **argv)
 				opt.blkdev_out = 1;
 				if (opt.metadata && !opt.force)
 					err_exit("Cloning only metadata to a "
-					     "block device does not usually "
-					     "make sense, aborting...\n"
-					     "If you were instructed to do "
-					     "this by a developer and/or are "
-					     "sure that this is what you want "
-					     "to do, run this utility again "
-					     "but this time add the force "
-					     "option, i.e. add '--force' to "
-					     "the command line arguments.");
+						"block device does not usually "
+						"make sense, aborting...\n"
+						"If you were instructed to do "
+						"this by a developer and/or are "
+						"sure that this is what you want "
+						"to do, run this utility again "
+						"but this time add the force "
+						"option, i.e. add '--force' to "
+						"the command line arguments.");
 			}
 		}
 	}
@@ -590,7 +590,7 @@ static void parse_options(int argc, char **argv)
 static void generate_serial_number(void) {
 	u64 sn;
 
-		/* different values for parallel processes */
+	/* different values for parallel processes */
 	srandom(time((time_t*)NULL) ^ (getpid() << 16));
 	sn = ((u64)random() << 32) | ((u64)random() & 0xffffffff);
 	volume_serial_number = cpu_to_le64(sn);
@@ -649,7 +649,7 @@ static int io_all(void *fd, void *buf, int count, int do_write)
 #ifdef HAVE_WINDOWS_H
 				else if (dev_out)
 					i = dev_out->d_ops->write(dev_out,
-								buf, count);
+							buf, count);
 #endif
 				else
 					i = write(*(int *)fd, buf, count);
@@ -679,7 +679,7 @@ static void rescue_sector(void *fd, u32 bytes_per_sector, off_t pos, void *buff)
 
 	if (opt.restore_image) {
 		if (!opt.no_action
-		    && (lseek(*(int *)fd, pos, SEEK_SET) == (off_t)-1))
+				&& (lseek(*(int *)fd, pos, SEEK_SET) == (off_t)-1))
 			perr_exit("lseek");
 	} else {
 		if (vol->dev->d_ops->seek(dev, pos, SEEK_SET) == (off_t)-1)
@@ -688,7 +688,7 @@ static void rescue_sector(void *fd, u32 bytes_per_sector, off_t pos, void *buff)
 
 	if (read_all(fd, buff, bytes_per_sector) == -1) {
 		Printf("WARNING: Can't read sector at %llu, lost data.\n",
-			(unsigned long long)pos);
+				(unsigned long long)pos);
 		memset(buff, '?', bytes_per_sector);
 		memmove(buff, badsector_magic, sizeof(badsector_magic));
 	}
@@ -699,7 +699,7 @@ static void rescue_sector(void *fd, u32 bytes_per_sector, off_t pos, void *buff)
  */
 
 static void read_rescue(void *fd, char *buff, u32 csize, u32 bytes_per_sector,
-				u64 rescue_lcn)
+		u64 rescue_lcn)
 {
 	off_t rescue_pos;
 
@@ -744,7 +744,7 @@ static void copy_cluster(int rescue, u64 rescue_lcn, u64 lcn)
 	if (!buff)
 		err_exit("Not enough memory");
 
-		/* possible partial cluster holding the backup boot sector */
+	/* possible partial cluster holding the backup boot sector */
 	backup_bootsector = (lcn + 1)*csize >= full_device_size;
 	if (backup_bootsector) {
 		csize = full_device_size - lcn*csize;
@@ -753,7 +753,7 @@ static void copy_cluster(int rescue, u64 rescue_lcn, u64 lcn)
 		}
 	}
 
-// need reading when not about to write ?
+	// need reading when not about to write ?
 	if (read_all(fd, buff, csize) == -1) {
 
 		if (errno != EIO) {
@@ -773,37 +773,37 @@ static void copy_cluster(int rescue, u64 rescue_lcn, u64 lcn)
 		}
 	}
 
-		/* Set the new serial number if requested */
+	/* Set the new serial number if requested */
 	if (opt.new_serial
-	    && !opt.save_image
-	    && (!lcn || backup_bootsector)) {
-			/*
-			 * For updating the backup boot sector, we need to
-			 * know the sector size, but this is not recorded
-			 * in the image header, so we collect it on the fly
-			 * while reading the first boot sector.
-			 */
+			&& !opt.save_image
+			&& (!lcn || backup_bootsector)) {
+		/*
+		 * For updating the backup boot sector, we need to
+		 * know the sector size, but this is not recorded
+		 * in the image header, so we collect it on the fly
+		 * while reading the first boot sector.
+		 */
 		if (!lcn) {
 			bs = (NTFS_BOOT_SECTOR*)buff;
 			bytes_per_sector = le16_to_cpu(bs->bpb.bytes_per_sector);
 			if ((bytes_per_sector > csize)
-			    || (bytes_per_sector < NTFS_SECTOR_SIZE))
+					|| (bytes_per_sector < NTFS_SECTOR_SIZE))
 				bytes_per_sector = NTFS_SECTOR_SIZE;
 		} else
 			bs = (NTFS_BOOT_SECTOR*)(buff
-						+ csize - bytes_per_sector);
+					+ csize - bytes_per_sector);
 		if (opt.new_serial & 2)
 			bs->volume_serial_number = volume_serial_number;
 		else {
 			mask = const_cpu_to_le64(~0x0ffffffffULL);
 			bs->volume_serial_number
-			    = (volume_serial_number & mask)
+				= (volume_serial_number & mask)
 				| (bs->volume_serial_number & ~mask);
 		}
-			/* Show the new full serial after merging */
+		/* Show the new full serial after merging */
 		if (!lcn)
 			Printf("New serial number      : 0x%llx\n",
-				(long long)le64_to_cpu(
+					(long long)le64_to_cpu(
 						bs->volume_serial_number));
 	}
 
@@ -814,15 +814,15 @@ static void copy_cluster(int rescue, u64 rescue_lcn, u64 lcn)
 	}
 
 	if ((!opt.metadata_image || wipe)
-	    && (write_all(&fd_out, buff, csize) == -1)) {
+			&& (write_all(&fd_out, buff, csize) == -1)) {
 #ifndef NO_STATFS
 		int err = errno;
 		perr_printf("Write failed");
 		if (err == EIO && opt.stfs.f_type == 0x517b)
 			Printf("Apparently you tried to clone to a remote "
-			       "Windows computer but they don't\nhave "
-			       "efficient sparse file handling by default. "
-			       "Please try a different method.\n");
+				"Windows computer but they don't\nhave "
+				"efficient sparse file handling by default. "
+				"Please try a different method.\n");
 		exit(1);
 #else
 		perr_printf("Write failed");
@@ -855,7 +855,7 @@ static void lseek_to_cluster(s64 lcn)
 		return;
 
 	if (lseek_out(fd_out, pos, SEEK_SET) == (off_t)-1)
-			perr_exit("lseek output");
+		perr_exit("lseek output");
 }
 
 static void gap_to_cluster(s64 gap)
@@ -893,11 +893,11 @@ static void write_image_hdr(void)
 
 	if (opt.save_image || opt.metadata_image) {
 		int alignsize = le32_to_cpu(image_hdr.offset_to_image_data)
-				- sizeof(image_hdr);
+			- sizeof(image_hdr);
 		memset(alignment,0,IMAGE_HDR_ALIGN);
 		if ((alignsize < 0)
-			|| write_all(&fd_out, &image_hdr, sizeof(image_hdr))
-			|| write_all(&fd_out, alignment, alignsize))
+				|| write_all(&fd_out, &image_hdr, sizeof(image_hdr))
+				|| write_all(&fd_out, alignment, alignsize))
 			perr_exit("write_all");
 	}
 }
@@ -931,19 +931,19 @@ static void clone_ntfs(u64 nr_clusters, int more_use)
 
 	if (opt.save_image) {
 		int alignsize = le32_to_cpu(image_hdr.offset_to_image_data)
-				- sizeof(image_hdr);
+			- sizeof(image_hdr);
 		memset(alignment,0,IMAGE_HDR_ALIGN);
 		if ((alignsize < 0)
-			|| write_all(&fd_out, &image_hdr, sizeof(image_hdr))
-			|| write_all(&fd_out, alignment, alignsize))
+				|| write_all(&fd_out, &image_hdr, sizeof(image_hdr))
+				|| write_all(&fd_out, alignment, alignsize))
 			perr_exit("write_all");
 	}
 
-		/* save suspicious clusters if required */
+	/* save suspicious clusters if required */
 	if (more_use && opt.ignore_fs_check) {
 		compare_bitmaps(&lcn_bitmap, TRUE);
 	}
-		/* Examine up to the alternate boot sector */
+	/* Examine up to the alternate boot sector */
 	for (last_cl = cl = 0; cl <= (u64)vol->nr_clusters; cl++) {
 
 		if (ntfs_bit_get(lcn_bitmap.bm, cl)) {
@@ -967,7 +967,7 @@ static void clone_ntfs(u64 nr_clusters, int more_use)
 }
 
 static void write_empty_clusters(s32 csize, s64 count,
-				 struct progress_bar *progress, u64 *p_counter)
+		struct progress_bar *progress, u64 *p_counter)
 {
 	s64 i;
 	char *buff;
@@ -1001,14 +1001,14 @@ static void restore_image(void)
 		pb_flags |= NTFS_PROGBAR;
 
 	progress_init(&progress, p_counter, opt.std_out ?
-		      (u64)sle64_to_cpu(image_hdr.nr_clusters) + 1 :
-		      le64_to_cpu(image_hdr.inuse) + 1,
-		      100, pb_flags);
+			(u64)sle64_to_cpu(image_hdr.nr_clusters) + 1 :
+			le64_to_cpu(image_hdr.inuse) + 1,
+			100, pb_flags);
 
 	if (opt.new_serial)
 		generate_serial_number();
 
-		/* Restore up to the alternate boot sector */
+	/* Restore up to the alternate boot sector */
 	while (pos <= sle64_to_cpu(image_hdr.nr_clusters)) {
 		if (read_all(&fd_in, &cmd, sizeof(cmd)) == -1) {
 			if (pos == sle64_to_cpu(image_hdr.nr_clusters)) {
@@ -1026,36 +1026,36 @@ static void restore_image(void)
 
 				/* little endian image, on any computer */
 				if (read_all(&fd_in, &lecount,
-						sizeof(lecount)) == -1)
+							sizeof(lecount)) == -1)
 					perr_exit("read_all");
 				count = sle64_to_cpu(lecount);
 			} else {
 				/* big endian image on big endian computer */
 				if (read_all(&fd_in, &count,
-						sizeof(count)) == -1)
+							sizeof(count)) == -1)
 					perr_exit("read_all");
 			}
 			if (!count)
 				err_exit("Bad offset at input location 0x%llx\n",
-					(long long)tellin(fd_in) - 9);
+						(long long)tellin(fd_in) - 9);
 			if (opt.std_out) {
 				if ((!p_counter && count) || (count < 0))
 					err_exit("Cannot restore a metadata"
-						" image to stdout\n");
+							" image to stdout\n");
 				else
 					write_empty_clusters(csize, count,
-						     &progress, &p_counter);
+							&progress, &p_counter);
 			} else {
 				if (((pos + count) < 0)
-				   || ((pos + count)
-					> sle64_to_cpu(image_hdr.nr_clusters)))
+						|| ((pos + count)
+							> sle64_to_cpu(image_hdr.nr_clusters)))
 					err_exit("restore_image: corrupt image "
-						"at input offset %lld\n",
-						(long long)tellin(fd_in) - 9);
+							"at input offset %lld\n",
+							(long long)tellin(fd_in) - 9);
 				else {
 					if (!opt.no_action
-					    && (lseek_out(fd_out, count * csize,
-							SEEK_CUR) == (off_t)-1))
+							&& (lseek_out(fd_out, count * csize,
+									SEEK_CUR) == (off_t)-1))
 						perr_exit("restore_image: lseek");
 				}
 			}
@@ -1103,7 +1103,7 @@ static void wipe_index_allocation_timestamps(ntfs_inode *ni, ATTR_RECORD *attr)
 	indexr = ntfs_index_root_get(ni, attr);
 	if (!indexr) {
 		perr_printf("Failed to read $INDEX_ROOT attribute of inode "
-			    "%lld", (long long)ni->mft_no);
+				"%lld", (long long)ni->mft_no);
 		return;
 	}
 
@@ -1114,7 +1114,7 @@ static void wipe_index_allocation_timestamps(ntfs_inode *ni, ATTR_RECORD *attr)
 	name_len = attr->name_length;
 
 	byte = bitmap = ntfs_attr_readall(ni, AT_BITMAP, name, name_len,
-						NULL);
+			NULL);
 	if (!byte) {
 		perr_printf("Failed to read $BITMAP attribute");
 		goto out_indexr;
@@ -1142,13 +1142,13 @@ static void wipe_index_allocation_timestamps(ntfs_inode *ni, ATTR_RECORD *attr)
 	while ((u8 *)tmp_indexa < (u8 *)indexa + na->data_size) {
 		if (*byte & (1 << bit)) {
 			if (ntfs_mst_post_read_fixup((NTFS_RECORD *)tmp_indexa,
-					le32_to_cpu(
-					indexr->index_block_size))) {
+						le32_to_cpu(
+							indexr->index_block_size))) {
 				perr_printf("Damaged INDX record");
 				goto out_indexa;
 			}
 			entry = (INDEX_ENTRY *)((u8 *)tmp_indexa + le32_to_cpu(
-				tmp_indexa->index.entries_offset) + 0x18);
+						tmp_indexa->index.entries_offset) + 0x18);
 
 			wipe_index_entry_timestams(entry);
 
@@ -1156,8 +1156,8 @@ static void wipe_index_allocation_timestamps(ntfs_inode *ni, ATTR_RECORD *attr)
 				perr_exit("ntfs_mft_usn_dec");
 
 			if (ntfs_mst_pre_write_fixup((NTFS_RECORD *)tmp_indexa,
-					le32_to_cpu(
-					indexr->index_block_size))) {
+						le32_to_cpu(
+							indexr->index_block_size))) {
 				perr_printf("INDX write fixup failed");
 				goto out_indexa;
 			}
@@ -1204,10 +1204,10 @@ static void wipe_index_root_timestamps(ATTR_RECORD *attr, sle64 timestamp)
 			wiped_timestamp_data += 32;
 
 		} else if (ntfs_names_are_equal(NTFS_INDEX_Q,
-				sizeof(NTFS_INDEX_Q) / 2 - 1,
-				(ntfschar *)((char *)attr +
-					    le16_to_cpu(attr->name_offset)),
-				attr->name_length, CASE_SENSITIVE, NULL, 0)) {
+					sizeof(NTFS_INDEX_Q) / 2 - 1,
+					(ntfschar *)((char *)attr +
+						le16_to_cpu(attr->name_offset)),
+					attr->name_length, CASE_SENSITIVE, NULL, 0)) {
 
 			QUOTA_CONTROL_ENTRY *quota_q;
 
@@ -1233,7 +1233,7 @@ do {								\
 	atype *ats;						\
 	ats = (atype *)((char *)(attr) + le16_to_cpu((attr)->value_offset)); \
 								\
-	ats->creation_time = (timestamp);	       		\
+	ats->creation_time = (timestamp);			\
 	ats->last_data_change_time = (timestamp);		\
 	ats->last_mft_change_time= (timestamp);			\
 	ats->last_access_time = (timestamp);			\
@@ -1378,18 +1378,18 @@ static void wipe_mft(char *mrec, u32 mrecsz, u64 mft_no)
 	if (!(((MFT_RECORD*)mrec)->flags & MFT_RECORD_IN_USE)) {
 		wipe_unused_mft(&ni);
 	} else {
-			/* ctx with no ntfs_inode prevents from searching external attrs */
+		/* ctx with no ntfs_inode prevents from searching external attrs */
 		if (!(ctx = ntfs_attr_get_search_ctx((ntfs_inode*)NULL, (MFT_RECORD*)mrec)))
 			perr_exit("ntfs_get_attr_search_ctx");
 
 		while (!ntfs_attr_lookup(AT_UNUSED, NULL, 0, CASE_SENSITIVE, 0,
-						NULL, 0, ctx)) {
+					NULL, 0, ctx)) {
 			if (ctx->attr->type == AT_END)
 				break;
 
 			image.ctx = ctx;
 			if (!ctx->attr->non_resident
-			    && (mft_no > LAST_METADATA_INODE))
+					&& (mft_no > LAST_METADATA_INODE))
 				wipe_resident_data(&image);
 			if (!opt.preserve_timestamps)
 				wipe_timestamps(&image);
@@ -1417,15 +1417,15 @@ static void wipe_indx(char *mrec, u32 mrecsz)
 		goto out_indexa;
 	}
 	indexa = (INDEX_ALLOCATION*)mrec;
-		/*
-		 * The index bitmap is not checked, obsoleted records are
-		 * wiped if they pass the safety checks
-		 */
+	/*
+	 * The index bitmap is not checked, obsoleted records are
+	 * wiped if they pass the safety checks
+	 */
 	if ((indexa->magic == magic_INDX)
-	    && (le32_to_cpu(indexa->index.entries_offset) >= sizeof(INDEX_HEADER))
-	    && (le32_to_cpu(indexa->index.allocated_size) <= mrecsz)) {
+			&& (le32_to_cpu(indexa->index.entries_offset) >= sizeof(INDEX_HEADER))
+			&& (le32_to_cpu(indexa->index.allocated_size) <= mrecsz)) {
 		entry = (INDEX_ENTRY *)((u8 *)mrec + le32_to_cpu(
-				indexa->index.entries_offset) + 0x18);
+					indexa->index.entries_offset) + 0x18);
 		wipe_index_entry_timestams(entry);
 	}
 
@@ -1444,7 +1444,7 @@ out_indexa : ;
  */
 
 static void write_set(char *buff, u32 csize, s64 *current_lcn,
-			runlist_element *rl, u32 wi, u32 wj, u32 cnt)
+		runlist_element *rl, u32 wi, u32 wj, u32 cnt)
 {
 	u32 k;
 	s64 target_lcn;
@@ -1455,7 +1455,7 @@ static void write_set(char *buff, u32 csize, s64 *current_lcn,
 		if (target_lcn != *current_lcn)
 			gap_to_cluster(target_lcn - *current_lcn);
 		if ((write_all(&fd_out, &cmd, sizeof(cmd)) == -1)
-		    || (write_all(&fd_out, &buff[k*csize], csize) == -1))
+				|| (write_all(&fd_out, &buff[k*csize], csize) == -1))
 			perr_exit("Failed to write_all");
 		*current_lcn = target_lcn + 1;
 
@@ -1496,11 +1496,11 @@ static void copy_wipe_mft(ntfs_walk_clusters_ctx *image, runlist *rl)
 	csize = image->ni->vol->cluster_size;
 	bytes_per_sector = image->ni->vol->sector_size;
 	fd = image->ni->vol->dev;
-		/*
-		 * Depending on the sizes, there may be several records
-		 * per cluster, or several clusters per record.
-		 * Anyway, records are read and rescued by full clusters.
-		 */
+	/*
+	 * Depending on the sizes, there may be several records
+	 * per cluster, or several clusters per record.
+	 * Anyway, records are read and rescued by full clusters.
+	 */
 	if (csize >= mft_record_size) {
 		records_per_set = csize/mft_record_size;
 		clusters_per_set = 1;
@@ -1522,7 +1522,7 @@ static void copy_wipe_mft(ntfs_walk_clusters_ctx *image, runlist *rl)
 	while (rl[ri].length) {
 		for (k=0; (k<clusters_per_set) && rl[ri].length; k++) {
 			read_rescue(fd, &buff[k*csize], csize, bytes_per_sector,
-							rl[ri].lcn + rj);
+					rl[ri].lcn + rj);
 			if (++rj >= rl[ri].length) {
 				rj = 0;
 				if (rl[++ri].length)
@@ -1533,7 +1533,7 @@ static void copy_wipe_mft(ntfs_walk_clusters_ctx *image, runlist *rl)
 			for (r=0; r<records_per_set; r++) {
 				if (!strncmp(&buff[r*mft_record_size],"FILE",4))
 					wipe_mft(&buff[r*mft_record_size],
-						mft_record_size, mft_no);
+							mft_record_size, mft_no);
 				mft_no++;
 			}
 			write_set(buff, csize, &current_lcn,
@@ -1577,11 +1577,11 @@ static void copy_wipe_i30(ntfs_walk_clusters_ctx *image, runlist *rl)
 	csize = image->ni->vol->cluster_size;
 	bytes_per_sector = image->ni->vol->sector_size;
 	fd = image->ni->vol->dev;
-		/*
-		 * Depending on the sizes, there may be several records
-		 * per cluster, or several clusters per record.
-		 * Anyway, records are read and rescued by full clusters.
-		 */
+	/*
+	 * Depending on the sizes, there may be several records
+	 * per cluster, or several clusters per record.
+	 * Anyway, records are read and rescued by full clusters.
+	 */
 	indx_record_size = image->ni->vol->indx_record_size;
 	if (csize >= indx_record_size) {
 		records_per_set = csize/indx_record_size;
@@ -1603,7 +1603,7 @@ static void copy_wipe_i30(ntfs_walk_clusters_ctx *image, runlist *rl)
 	while (rl[ri].length) {
 		for (k=0; (k<clusters_per_set) && rl[ri].length; k++) {
 			read_rescue(fd, &buff[k*csize], csize, bytes_per_sector,
-							rl[ri].lcn + rj);
+					rl[ri].lcn + rj);
 			if (++rj >= rl[ri].length) {
 				rj = 0;
 				if (rl[++ri].length)
@@ -1616,7 +1616,7 @@ static void copy_wipe_i30(ntfs_walk_clusters_ctx *image, runlist *rl)
 				for (r=0; r<records_per_set; r++) {
 					if (!strncmp(&buff[r*indx_record_size],"INDX",4))
 						wipe_indx(&buff[r*indx_record_size],
-							indx_record_size);
+								indx_record_size);
 				}
 			write_set(buff, csize, &current_lcn,
 					rl, wi, wj, clusters_per_set);
@@ -1677,21 +1677,21 @@ static void walk_runs(struct ntfs_walk_cluster *walk)
 	}
 
 	if (wipe
-	    && !opt.preserve_timestamps
-	    && walk->image->ctx->attr->type == AT_INDEX_ALLOCATION)
+			&& !opt.preserve_timestamps
+			&& walk->image->ctx->attr->type == AT_INDEX_ALLOCATION)
 		wipe_index_allocation_timestamps(walk->image->ni, a);
 
 	if (!(rl = ntfs_mapping_pairs_decompress(vol, a, NULL)))
 		perr_exit("ntfs_decompress_mapping_pairs");
 
-		/* special wipings for MFT records and directory indexes */
+	/* special wipings for MFT records and directory indexes */
 	mft_data = ((walk->image->ni->mft_no == FILE_MFT)
 			|| (walk->image->ni->mft_no == FILE_MFTMirr))
-		    && (a->type == AT_DATA);
+		&& (a->type == AT_DATA);
 	index_i30 = (walk->image->ctx->attr->type == AT_INDEX_ALLOCATION)
-		    && (a->name_length == 4)
-		    && !memcmp((char*)a + le16_to_cpu(a->name_offset),
-					NTFS_INDEX_I30,8);
+		&& (a->name_length == 4)
+		&& !memcmp((char*)a + le16_to_cpu(a->name_offset),
+				NTFS_INDEX_I30,8);
 
 	for (i = 0; rl[i].length; i++) {
 		s64 lcn = rl[i].lcn;
@@ -1703,10 +1703,10 @@ static void walk_runs(struct ntfs_walk_cluster *walk)
 		/* FIXME: ntfs_mapping_pairs_decompress should return error */
 		if (lcn < 0 || lcn_length < 0)
 			err_exit("Corrupt runlist in inode %lld attr %x LCN "
-				 "%llx length %llx\n",
-				(long long)ctx->ntfs_ino->mft_no,
-				(unsigned int)le32_to_cpu(a->type),
-				(long long)lcn, (long long)lcn_length);
+					"%llx length %llx\n",
+					(long long)ctx->ntfs_ino->mft_no,
+					(unsigned int)le32_to_cpu(a->type),
+					(long long)lcn, (long long)lcn_length);
 
 		if (opt.metadata_image ? wipe && !mft_data && !index_i30 : !wipe)
 			dump_clusters(walk->image, rl + i);
@@ -1716,33 +1716,33 @@ static void walk_runs(struct ntfs_walk_cluster *walk)
 			if (ntfs_bit_get_and_set(lcn_bitmap.bm, k, 1)) {
 				if (opt.ignore_fs_check)
 					Printf("Cluster %llu is referenced"
-						" twice!\n",
-						(unsigned long long)k);
+							" twice!\n",
+							(unsigned long long)k);
 				else
 					err_exit("Cluster %llu referenced"
-						" twice!\nYou didn't shutdown"
-						" your Windows properly?\n",
-						(unsigned long long)k);
+							" twice!\nYou didn't shutdown"
+							" your Windows properly?\n",
+							(unsigned long long)k);
 			}
 		}
 
 		if (!opt.metadata_image)
 			walk->image->inuse += lcn_length;
-			/*
-			 * For a metadata image, we have to compute the
-			 * number of metadata clusters for the percentages
-			 * to be displayed correctly while restoring.
-			 */
+		/*
+		 * For a metadata image, we have to compute the
+		 * number of metadata clusters for the percentages
+		 * to be displayed correctly while restoring.
+		 */
 		if (!wipe && opt.metadata_image) {
 			if ((walk->image->ni->mft_no == FILE_LogFile)
-			    && (walk->image->ctx->attr->type == AT_DATA)) {
-					/* 16 KiB of FILE_LogFile */
+					&& (walk->image->ctx->attr->type == AT_DATA)) {
+				/* 16 KiB of FILE_LogFile */
 				walk->image->inuse
-				   += is_critical_metadata(walk->image,rl);
+					+= is_critical_metadata(walk->image,rl);
 			} else {
 				if ((walk->image->ni->mft_no
-						<= LAST_METADATA_INODE)
-				   || (walk->image->ctx->attr->type != AT_DATA))
+							<= LAST_METADATA_INODE)
+						|| (walk->image->ctx->attr->type != AT_DATA))
 					walk->image->inuse += lcn_length;
 			}
 		}
@@ -1764,11 +1764,11 @@ static void walk_runs(struct ntfs_walk_cluster *walk)
 					copy_wipe_mft(walk->image,na->rl);
 				} else
 					perr_exit("Failed to map data of inode %lld",
-						(long long)walk->image->ni->mft_no);
+							(long long)walk->image->ni->mft_no);
 				ntfs_attr_close(na);
 			} else
 				perr_exit("Failed to open data of inode %lld",
-					(long long)walk->image->ni->mft_no);
+						(long long)walk->image->ni->mft_no);
 		}
 		if (index_i30 && !a->lowest_vcn) {
 			na = ntfs_attr_open(walk->image->ni,
@@ -1780,17 +1780,17 @@ static void walk_runs(struct ntfs_walk_cluster *walk)
 					copy_wipe_i30(walk->image,na->rl);
 				} else
 					perr_exit("Failed to map index of inode %lld",
-						(long long)walk->image->ni->mft_no);
+							(long long)walk->image->ni->mft_no);
 				ntfs_attr_close(na);
 			} else
 				perr_exit("Failed to open index of inode %lld",
-					(long long)walk->image->ni->mft_no);
+						(long long)walk->image->ni->mft_no);
 		}
 	}
 	if (opt.metadata
-	    && (opt.metadata_image || !wipe)
-	    && (walk->image->ni->mft_no == FILE_LogFile)
-	    && (walk->image->ctx->attr->type == AT_DATA))
+			&& (opt.metadata_image || !wipe)
+			&& (walk->image->ni->mft_no == FILE_LogFile)
+			&& (walk->image->ctx->attr->type == AT_DATA))
 		clone_logfile_parts(walk->image, rl);
 
 	free(rl);
@@ -1844,8 +1844,8 @@ static int compare_bitmaps(struct bitmap *a, BOOL copy)
 			/* the backup bootsector need not be accounted for */
 			if (((vol->nr_clusters + 7) >> 3) > pos)
 				err_exit("$Bitmap size is smaller than expected"
-					 " (%lld < %lld)\n",
-					(long long)pos, (long long)a->size);
+						" (%lld < %lld)\n",
+						(long long)pos, (long long)a->size);
 			break;
 		}
 
@@ -1870,8 +1870,8 @@ static int compare_bitmaps(struct bitmap *a, BOOL copy)
 				if (opt.ignore_fs_check && !bit && copy) {
 					lseek_to_cluster(cl);
 					if (opt.save_image
-					   || (opt.metadata
-						&& opt.metadata_image)) {
+							|| (opt.metadata
+								&& opt.metadata_image)) {
 						gap_to_cluster(cl - new_cl);
 						new_cl = cl + 1;
 					}
@@ -1882,9 +1882,9 @@ static int compare_bitmaps(struct bitmap *a, BOOL copy)
 					continue;
 
 				Printf("Cluster accounting failed at %lld "
-				       "(0x%llx): %s cluster in $Bitmap\n",
-				       (long long)cl, (unsigned long long)cl,
-				       bit ? "missing" : "extra");
+						"(0x%llx): %s cluster in $Bitmap\n",
+						(long long)cl, (unsigned long long)cl,
+						bit ? "missing" : "extra");
 			}
 		}
 	}
@@ -1893,15 +1893,15 @@ done:
 		Printf("Totally %d cluster accounting mismatches.\n", mismatch);
 		if (opt.ignore_fs_check) {
 			Printf("WARNING: The NTFS inconsistency was overruled "
-			       "by the --ignore-fs-check option.\n");
+					"by the --ignore-fs-check option.\n");
 			if (new_cl) {
 				gap_to_cluster(-new_cl);
 			}
 			return (more_use);
 		}
 		err_exit("Filesystem check failed! Windows wasn't shutdown "
-			 "properly or inconsistent\nfilesystem. Please run "
-			 "chkdsk /f on Windows then reboot it TWICE.\n");
+				"properly or inconsistent\nfilesystem. Please run "
+				"chkdsk /f on Windows then reboot it TWICE.\n");
 	}
 	return (more_use);
 }
@@ -1998,7 +1998,7 @@ static int walk_clusters(ntfs_volume *volume, struct ntfs_walk_cluster *walk)
 			if (errno == EIO || errno == ENOENT)
 				continue;
 			perr_exit("Reading inode %lld failed",
-				(long long)inode);
+					(long long)inode);
 		}
 
 		if (wipe)
@@ -2022,7 +2022,7 @@ out:
 
 		if (ntfs_inode_close(ni))
 			perr_exit("ntfs_inode_close for inode %lld",
-				(long long)inode);
+					(long long)inode);
 	}
 	if (opt.metadata) {
 		if (opt.metadata_image && wipe && opt.ignore_fs_check) {
@@ -2031,16 +2031,16 @@ out:
 			walk->image->current_lcn = 0;
 		}
 		if (opt.metadata_image ? wipe : !wipe) {
-				/* also get the backup bootsector */
+			/* also get the backup bootsector */
 			nr_clusters = vol->nr_clusters;
 			lseek_to_cluster(nr_clusters);
 			if (opt.metadata_image && wipe)
 				gap_to_cluster(nr_clusters
-					- walk->image->current_lcn);
+						- walk->image->current_lcn);
 			copy_cluster(opt.rescue, nr_clusters, nr_clusters);
 			walk->image->current_lcn = nr_clusters;
 		}
-			/* Not counted, for compatibility with older versions */
+		/* Not counted, for compatibility with older versions */
 		if (!opt.metadata_image)
 			walk->image->inuse++;
 	}
@@ -2140,10 +2140,10 @@ static void check_if_mounted(const char *device, unsigned long new_mntflag)
 	if (mntflag & NTFS_MF_MOUNTED) {
 		if (!(mntflag & NTFS_MF_READONLY))
 			err_exit("Device '%s' is mounted read-write. "
-				 "You must 'umount' it first.\n", device);
+					"You must 'umount' it first.\n", device);
 		if (!new_mntflag)
 			err_exit("Device '%s' is mounted. "
-				 "You must 'umount' it first.\n", device);
+					"You must 'umount' it first.\n", device);
 	}
 }
 
@@ -2165,9 +2165,9 @@ static void mount_volume(unsigned long new_mntflag)
 		perr_printf("Opening '%s' as NTFS failed", opt.volume);
 		if (err == EINVAL) {
 			Printf("Apparently device '%s' doesn't have a "
-			       "valid NTFS. Maybe you selected\nthe whole "
-			       "disk instead of a partition (e.g. /dev/hda, "
-			       "not /dev/hda1)?\n", opt.volume);
+					"valid NTFS. Maybe you selected\nthe whole "
+					"disk instead of a partition (e.g. /dev/hda, "
+					"not /dev/hda1)?\n", opt.volume);
 		}
 		/*
 		 * Retry with recovering the log file enabled.
@@ -2180,13 +2180,13 @@ static void mount_volume(unsigned long new_mntflag)
 		if (!(new_mntflag & (NTFS_MNT_RDONLY | NTFS_MNT_RECOVER))) {
 			if (opt.full_logfile) {
 				Printf("Retrying read-only to ignore"
-							" the log file...\n");
+						" the log file...\n");
 				vol = ntfs_mount(opt.volume,
-					 new_mntflag | NTFS_MNT_RDONLY);
+						new_mntflag | NTFS_MNT_RDONLY);
 			} else {
 				Printf("Trying to recover...\n");
 				vol = ntfs_mount(opt.volume,
-					new_mntflag | NTFS_MNT_RECOVER);
+						new_mntflag | NTFS_MNT_RECOVER);
 			}
 			Printf("... %s\n",(vol ? "Successful" : "Failed"));
 		}
@@ -2209,7 +2209,7 @@ static void mount_volume(unsigned long new_mntflag)
 	Printf("Cluster size       : %u bytes\n",
 			(unsigned int)vol->cluster_size);
 	print_volume_size("Current volume size",
-			  volume_size(vol, vol->nr_clusters));
+			volume_size(vol, vol->nr_clusters));
 }
 
 static struct ntfs_walk_cluster backup_clusters = { NULL, NULL };
@@ -2231,8 +2231,8 @@ static s64 device_size_get(int fd)
 
 		if (ioctl(fd, BLKGETSIZE64, &size) >= 0) {
 			ntfs_log_debug("BLKGETSIZE64 nr bytes = %llu "
-				"(0x%llx).\n", (unsigned long long)size,
-				(unsigned long long)size);
+					"(0x%llx).\n", (unsigned long long)size,
+					(unsigned long long)size);
 			return (s64)size;
 		}
 	}
@@ -2242,7 +2242,7 @@ static s64 device_size_get(int fd)
 
 		if (ioctl(fd, BLKGETSIZE, &size) >= 0) {
 			ntfs_log_debug("BLKGETSIZE nr 512 byte blocks = %lu "
-				"(0x%lx).\n", size, size);
+					"(0x%lx).\n", size, size);
 			return (s64)size * 512;
 		}
 	}
@@ -2252,8 +2252,8 @@ static s64 device_size_get(int fd)
 
 		if (ioctl(fd, FDGETPRM, &this_floppy) >= 0) {
 			ntfs_log_debug("FDGETPRM nr 512 byte blocks = %lu "
-				"(0x%lx).\n", this_floppy.size,
-				this_floppy.size);
+					"(0x%lx).\n", this_floppy.size,
+					this_floppy.size);
 			return (s64)this_floppy.size * 512;
 		}
 	}
@@ -2293,19 +2293,19 @@ static void set_filesize(s64 filesize)
 
 	if (fstatfs(fd_out, &opt.stfs) == -1)
 		Printf("WARNING: Couldn't get filesystem type: "
-		       "%s\n", strerror(errno));
+				"%s\n", strerror(errno));
 	else
 		fs_type = opt.stfs.f_type;
 
 	if (fs_type == 0x52654973)
 		Printf("WARNING: You're using ReiserFS, it has very poor "
-		       "performance creating\nlarge sparse files. The next "
-		       "operation might take a very long time!\n"
-		       "Creating sparse output file ...\n");
+				"performance creating\nlarge sparse files. The next "
+				"operation might take a very long time!\n"
+				"Creating sparse output file ...\n");
 	else if (fs_type == 0x517b)
 		Printf("WARNING: You're using SMBFS and if the remote share "
-		       "isn't Samba but a Windows\ncomputer then the clone "
-		       "operation will be very inefficient and may fail!\n");
+				"isn't Samba but a Windows\ncomputer then the clone "
+				"operation will be very inefficient and may fail!\n");
 #endif
 
 	if (!opt.no_action && (ftruncate(fd_out, filesize) == -1)) {
@@ -2314,35 +2314,35 @@ static void set_filesize(s64 filesize)
 #ifndef NO_STATFS
 		if (fs_type)
 			Printf("Destination filesystem type is 0x%lx.\n",
-			       (unsigned long)fs_type);
+					(unsigned long)fs_type);
 #endif
 		if (err == E2BIG) {
 			Printf("Your system or the destination filesystem "
-			       "doesn't support large files.\n");
+					"doesn't support large files.\n");
 #ifndef NO_STATFS
 			if (fs_type == 0x517b) {
 				Printf("SMBFS needs minimum Linux kernel "
-				       "version 2.4.25 and\n the 'lfs' option"
-				       "\nfor smbmount to have large "
-				       "file support.\n");
+						"version 2.4.25 and\n the 'lfs' option"
+						"\nfor smbmount to have large "
+						"file support.\n");
 			}
 #endif
 		} else if (err == EPERM) {
 			Printf("Apparently the destination filesystem doesn't "
-			       "support sparse files.\nYou can overcome this "
-			       "by using the more efficient --save-image "
-			       "option\nof ntfsclone. Use the --restore-image "
-			       "option to restore the image.\n");
+					"support sparse files.\nYou can overcome this "
+					"by using the more efficient --save-image "
+					"option\nof ntfsclone. Use the --restore-image "
+					"option to restore the image.\n");
 		}
 		exit(1);
 	}
-		/*
-		 * If truncate just created a sparse file, the ability
-		 * to generically store big files has been checked, but no
-		 * space has been reserved and available space has probably
-		 * not been checked. Better reset the file so that we write
-		 * sequentially to the end.
-		 */
+	/*
+	 * If truncate just created a sparse file, the ability
+	 * to generically store big files has been checked, but no
+	 * space has been reserved and available space has probably
+	 * not been checked. Better reset the file so that we write
+	 * sequentially to the end.
+	 */
 	if (!opt.no_action) {
 #ifdef HAVE_WINDOWS_H
 		if (ftruncate(fd_out, 0))
@@ -2355,7 +2355,7 @@ static void set_filesize(s64 filesize)
 		if (s || (!st.st_blocks && ftruncate(fd_out, 0)))
 			Printf("Failed to reset the output file.\n");
 #endif
-			/* Proceed even if ftruncate failed */
+		/* Proceed even if ftruncate failed */
 	}
 }
 
@@ -2395,11 +2395,11 @@ static s64 open_image(void)
 		image_hdr.inuse = cpu_to_sle64(image_hdr.inuse);
 #endif
 		image_hdr.offset_to_image_data =
-				const_cpu_to_le32((sizeof(image_hdr)
-				    + IMAGE_HDR_ALIGN - 1) & -IMAGE_HDR_ALIGN);
+			const_cpu_to_le32((sizeof(image_hdr)
+						+ IMAGE_HDR_ALIGN - 1) & -IMAGE_HDR_ALIGN);
 		image_is_host_endian = TRUE;
 	} else {
-			/* safe image : little endian data */
+		/* safe image : little endian data */
 		le32 offset_to_image_data;
 		int delta;
 
@@ -2411,9 +2411,9 @@ static s64 open_image(void)
 					image_hdr.minor_ver);
 		/* Read the image header data offset. */
 		if (read_all(&fd_in, &offset_to_image_data,
-				sizeof(offset_to_image_data)) == -1)
+					sizeof(offset_to_image_data)) == -1)
 			perr_exit("read_all");
-			/* do not translate little endian data */
+		/* do not translate little endian data */
 		image_hdr.offset_to_image_data = offset_to_image_data;
 		/*
 		 * Read any fields from the header that we have not read yet so
@@ -2422,8 +2422,8 @@ static s64 open_image(void)
 		 * header in a backwards compatible way.
 		 */
 		delta = le32_to_cpu(offset_to_image_data)
-				- (NTFSCLONE_IMG_HEADER_SIZE_OLD +
-				sizeof(image_hdr.offset_to_image_data));
+			- (NTFSCLONE_IMG_HEADER_SIZE_OLD +
+					sizeof(image_hdr.offset_to_image_data));
 		if (delta > 0) {
 			char *dummy_buf;
 
@@ -2447,14 +2447,14 @@ static s64 open_volume(void)
 	device_size = ntfs_device_size_get(vol->dev, 1);
 	if (device_size <= 0)
 		err_exit("Couldn't get device size (%lld)!\n",
-			(long long)device_size);
+				(long long)device_size);
 
 	print_volume_size("Current device size", device_size);
 
 	if (device_size < vol->nr_clusters * vol->cluster_size)
 		err_exit("Current NTFS volume size is bigger than the device "
-			 "size (%lld)!\nCorrupt partition table or incorrect "
-			 "device partitioning?\n", (long long)device_size);
+				"size (%lld)!\nCorrupt partition table or incorrect "
+				"device partitioning?\n", (long long)device_size);
 
 	return device_size;
 }
@@ -2469,7 +2469,7 @@ static void initialise_image_hdr(s64 device_size, s64 inuse)
 	image_hdr.nr_clusters = cpu_to_sle64(vol->nr_clusters);
 	image_hdr.inuse = cpu_to_le64(inuse);
 	image_hdr.offset_to_image_data = cpu_to_le32((sizeof(image_hdr)
-			 + IMAGE_HDR_ALIGN - 1) & -IMAGE_HDR_ALIGN);
+				+ IMAGE_HDR_ALIGN - 1) & -IMAGE_HDR_ALIGN);
 }
 
 static void check_output_device(s64 input_size)
@@ -2483,8 +2483,8 @@ static void check_output_device(s64 input_size)
 			dest_size = device_size_get(fd_out);
 		if (dest_size < input_size)
 			err_exit("Output device is too small (%lld) to fit the "
-				 "NTFS image (%lld).\n",
-				(long long)dest_size, (long long)input_size);
+					"NTFS image (%lld).\n",
+					(long long)dest_size, (long long)input_size);
 
 		check_if_mounted(opt.output, 0);
 	} else
@@ -2524,7 +2524,7 @@ static void ignore_bad_clusters(ntfs_walk_clusters_ctx *image)
 	}
 	if (nr_bad_clusters)
 		Printf("WARNING: The disk has %lld or more bad sectors"
-		       " (hardware faults).\n", (long long)nr_bad_clusters);
+				" (hardware faults).\n", (long long)nr_bad_clusters);
 	ntfs_attr_close(na);
 	if (ntfs_inode_close(ni))
 		perr_exit("ntfs_inode_close failed for $BadClus");
@@ -2545,7 +2545,7 @@ static void check_dest_free_space(u64 src_bytes)
 	 */
 	if (fstatvfs(fd_out, &stvfs) == -1) {
 		Printf("WARNING: Unknown free space on the destination: %s\n",
-		       strerror(errno));
+				strerror(errno));
 		return;
 	}
 
@@ -2562,9 +2562,9 @@ static void check_dest_free_space(u64 src_bytes)
 
 	if (dest_bytes < src_bytes)
 		err_exit("Destination doesn't have enough free space: "
-			 "%llu MB < %llu MB\n",
-			 (unsigned long long)rounded_up_division(dest_bytes, NTFS_MBYTE),
-			 (unsigned long long)rounded_up_division(src_bytes,  NTFS_MBYTE));
+				"%llu MB < %llu MB\n",
+				(unsigned long long)rounded_up_division(dest_bytes, NTFS_MBYTE),
+				(unsigned long long)rounded_up_division(src_bytes,  NTFS_MBYTE));
 #endif
 }
 
@@ -2593,7 +2593,7 @@ int main(int argc, char **argv)
 	if (opt.restore_image) {
 		device_size = open_image();
 		ntfs_size = sle64_to_cpu(image_hdr.nr_clusters) *
-				le32_to_cpu(image_hdr.cluster_size);
+			le32_to_cpu(image_hdr.cluster_size);
 	} else {
 		device_size = open_volume();
 		ntfs_size = vol->nr_clusters * vol->cluster_size;
@@ -2631,16 +2631,16 @@ int main(int argc, char **argv)
 #ifdef HAVE_WINDOWS_H
 			if (!opt.no_action) {
 				dev_out = ntfs_device_alloc(opt.output, 0,
-					&ntfs_device_default_io_ops, NULL);
+						&ntfs_device_default_io_ops, NULL);
 				if (!dev_out
-				    || (dev_out->d_ops->open)(dev_out, flags))
+						|| (dev_out->d_ops->open)(dev_out, flags))
 					perr_exit("Opening volume '%s' failed",
 							opt.output);
 			}
 #else
 			if (!opt.no_action
-			    && ((fd_out = open(opt.output, flags,
-						S_IRUSR | S_IWUSR)) == -1))
+					&& ((fd_out = open(opt.output, flags,
+								S_IRUSR | S_IWUSR)) == -1))
 				perr_exit("Opening file '%s' failed",
 						opt.output);
 #endif
@@ -2664,7 +2664,7 @@ int main(int argc, char **argv)
 
 	walk_clusters(vol, &backup_clusters);
 	image.more_use = compare_bitmaps(&lcn_bitmap,
-				opt.metadata && !opt.metadata_image);
+			opt.metadata && !opt.metadata_image);
 	print_disk_usage("", vol->cluster_size, vol->nr_clusters, image.inuse);
 
 	check_dest_free_space(vol->cluster_size * image.inuse);
@@ -2700,8 +2700,8 @@ int main(int argc, char **argv)
 		} else
 			fsync_clone(fd_out); /* sync copy before mounting */
 		opt.volume = opt.output;
-	/* 'force' again mount for dirty volumes (e.g. after resize).
-	   FIXME: use mount flags to avoid potential side-effects in future */
+		/* 'force' again mount for dirty volumes (e.g. after resize).
+FIXME: use mount flags to avoid potential side-effects in future */
 		opt.force++;
 		ntfs_umount(vol,FALSE);
 		mount_volume(0 /*NTFS_MNT_NOATIME*/);

--- a/src/ntfscluster.c
+++ b/src/ntfscluster.c
@@ -150,7 +150,7 @@ static int parse_options(int argc, char **argv)
 
 		case 'c':
 			if ((opts.action == act_none) &&
-			    (utils_parse_range(optarg, &opts.range_begin, &opts.range_end, FALSE)))
+					(utils_parse_range(optarg, &opts.range_begin, &opts.range_end, FALSE)))
 				opts.action = act_cluster;
 			else
 				opts.action = act_error;
@@ -197,7 +197,7 @@ static int parse_options(int argc, char **argv)
 			break;
 		case 's':
 			if ((opts.action == act_none) &&
-			    (utils_parse_range(optarg, &opts.range_begin, &opts.range_end, FALSE)))
+					(utils_parse_range(optarg, &opts.range_begin, &opts.range_end, FALSE)))
 				opts.action = act_sector;
 			else
 				opts.action = act_error;
@@ -266,7 +266,7 @@ static int parse_options(int argc, char **argv)
 	if (help || err)
 		usage();
 
-		/* tri-state 0 : done, 1 : error, -1 : proceed */
+	/* tri-state 0 : done, 1 : error, -1 : proceed */
 	return (err ? 1 : (help || ver ? 0 : -1));
 }
 
@@ -425,7 +425,7 @@ static int dump_file(ntfs_volume *vol, ntfs_inode *ino)
  * print_match
  */
 static int print_match(ntfs_inode *ino, ATTR_RECORD *attr,
-	runlist_element *run, void *data __attribute__((unused)))
+		runlist_element *run, void *data __attribute__((unused)))
 {
 	char *buffer;
 
@@ -452,7 +452,7 @@ static int print_match(ntfs_inode *ino, ATTR_RECORD *attr,
  * find_last
  */
 static int find_last(ntfs_inode *ino, ATTR_RECORD *attr, runlist_element *run,
-	void *data)
+		void *data)
 {
 	struct match *m;
 
@@ -527,7 +527,7 @@ int main(int argc, char *argv[])
 			ino = 0;
 			if (unix_name) {
 				ino = ntfs_pathname_to_inode(vol, NULL,
-								unix_name);
+						unix_name);
 				free(unix_name);
 			}
 #else

--- a/src/ntfsinfo.c
+++ b/src/ntfsinfo.c
@@ -143,7 +143,7 @@ static void usage(void)
 		"    -v, --verbose    More output\n"
 		"    -V, --version    Display version information\n"
 		"    -h, --help       Display this help\n"
-	        "\n",
+		"\n",
 		EXEC_NAME);
 }
 
@@ -195,14 +195,14 @@ static int parse_options(int argc, char *argv[])
 			break;
 		case 'i':
 			if ((opts.inode != -1) ||
-			    (!utils_parse_size(optarg, &opts.inode, FALSE))) {
+					(!utils_parse_size(optarg, &opts.inode, FALSE))) {
 				err++;
 			}
 			break;
 		case 'e':
 			if ((opts.extent_inode != -1) ||
-			    (!utils_parse_size(optarg,
-					       &opts.extent_inode, FALSE))) {
+					(!utils_parse_size(optarg,
+							   &opts.extent_inode, FALSE))) {
 				err++;
 			}
 			break;
@@ -232,7 +232,7 @@ static int parse_options(int argc, char *argv[])
 		case 'T':
 			/* 'T' is deprecated, notify */
 			ntfs_log_error("Option 'T' is deprecated, it was "
-				"replaced by 't'.\n");
+					"replaced by 't'.\n");
 			err++;
 			break;
 		case 'v':
@@ -281,27 +281,27 @@ static int parse_options(int argc, char *argv[])
 		if (opts.device == NULL) {
 			if (argc > 1)
 				ntfs_log_error("You must specify exactly one "
-					"device.\n");
+						"device.\n");
 			err++;
 		}
 
 		if (opts.inode == -1 && !opts.filename && !opts.mft) {
 			if (argc > 1)
 				ntfs_log_error("You must specify an inode to "
-					"learn about.\n");
+						"learn about.\n");
 			err++;
 		}
 
 		if (opts.quiet && opts.verbose) {
 			ntfs_log_error("You may not use --quiet and --verbose "
-				"at the same time.\n");
+					"at the same time.\n");
 			err++;
 		}
 
 		if ((opts.inode != -1) && (opts.filename != NULL)) {
 			if (argc > 1)
 				ntfs_log_error("You may not specify --inode "
-					"and --file together.\n");
+						"and --file together.\n");
 			err++;
 		}
 
@@ -312,7 +312,7 @@ static int parse_options(int argc, char *argv[])
 	if (help || err)
 		usage();
 
-		/* tri-state 0 : done, 1 : error, -1 : proceed */
+	/* tri-state 0 : done, 1 : error, -1 : proceed */
 	return (err ? 1 : (help || ver ? 0 : -1));
 }
 
@@ -333,10 +333,10 @@ static int parse_options(int argc, char *argv[])
  */
 static char *ntfsinfo_time_to_str(const sle64 sle_ntfs_clock)
 {
-		/* JPA display timestamps in UTC */
+	/* JPA display timestamps in UTC */
 	static const char *months[]
 		= { "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-		    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" } ;
+			"Jul", "Aug", "Sep", "Oct", "Nov", "Dec" } ;
 	static const char *wdays[]
 		= { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" } ;
 	static char str[50];
@@ -353,25 +353,25 @@ static char *ntfsinfo_time_to_str(const sle64 sle_ntfs_clock)
 	seconds = ((stamp/10000000LL)%86400) & 0x1ffff;
 	wday = (days + 1)%7;
 	year = 1601;
-				/* periods of 400 years */
+	/* periods of 400 years */
 	cnt = days/146097;
 	days -= 146097*cnt;
 	year += 400*cnt;
-				/* periods of 100 years */
+	/* periods of 100 years */
 	cnt = (3*days + 3)/109573;
 	days -= 36524*cnt;
 	year += 100*cnt;
-				/* periods of 4 years */
+	/* periods of 4 years */
 	cnt = days/1461;
 	days -= 1461*cnt;
 	year += 4*cnt;
-				/* periods of a single year */
+	/* periods of a single year */
 	cnt = (3*days + 3)/1096;
 	days -= 365*cnt;
 	year += cnt;
 
 	if ((!(year % 100) ? (year % 400) : (year % 4))
-		&& (days > 58)) days++;
+			&& (days > 58)) days++;
 	if (days > 59) {
 		mon = (5*days + 161)/153;
 		days -= (153*mon - 162)/5;
@@ -380,12 +380,12 @@ static char *ntfsinfo_time_to_str(const sle64 sle_ntfs_clock)
 		days -= 31*(mon - 1) - 1;
 	}
 	snprintf(str, sizeof(str), "%3s %3s %2u %02u:%02u:%02u %4u UTC\n",
-		wdays[wday],
-		months[mon-1],(unsigned int)days,
-		(unsigned int)(seconds/3600),
-		(unsigned int)(seconds/60%60),
-		(unsigned int)(seconds%60),
-		(unsigned int)year);
+			wdays[wday],
+			months[mon-1],(unsigned int)days,
+			(unsigned int)(seconds/3600),
+			(unsigned int)(seconds/60%60),
+			(unsigned int)(seconds%60),
+			(unsigned int)year);
 	return (str);
 }
 
@@ -423,48 +423,48 @@ static const char *reparse_type_name(le32 tag)
 
 	seltag = tag & IO_REPARSE_PLUGIN_SELECT;
 	switch (seltag) {
-	case IO_REPARSE_TAG_MOUNT_POINT :
-		name = " (mount point)";
-		break;
-	case IO_REPARSE_TAG_SYMLINK :
-		name = " (symlink)";
-		break;
-	case IO_REPARSE_TAG_WOF :
-		name = " (Wof compressed)";
-		break;
-	case IO_REPARSE_TAG_DEDUP :
-		name = " (deduplicated)";
-		break;
-	case IO_REPARSE_TAG_WCI :
-		name = " (Windows container)";
-		break;
-	case IO_REPARSE_TAG_CLOUD :
-		name = " (Cloud)";
-		break;
-	case IO_REPARSE_TAG_NFS :
-		name = " (NFS symlink)";
-		break;
-	case IO_REPARSE_TAG_LX_SYMLINK :
-		name = " (Linux symlink)";
-		break;
-	case IO_REPARSE_TAG_LX_FIFO :
-		name = " (Linux fifo)";
-		break;
-	case IO_REPARSE_TAG_LX_CHR :
-		name = " (Linux character device)";
-		break;
-	case IO_REPARSE_TAG_LX_BLK :
-		name = " (Linux block device)";
-		break;
-	case IO_REPARSE_TAG_AF_UNIX :
-		name = " (Unix socket)";
-		break;
-	case IO_REPARSE_TAG_APPEXECLINK :
-		name = " (Exec link)";
-		break;
-	default :
-		name = "";
-		break;
+		case IO_REPARSE_TAG_MOUNT_POINT :
+			name = " (mount point)";
+			break;
+		case IO_REPARSE_TAG_SYMLINK :
+			name = " (symlink)";
+			break;
+		case IO_REPARSE_TAG_WOF :
+			name = " (Wof compressed)";
+			break;
+		case IO_REPARSE_TAG_DEDUP :
+			name = " (deduplicated)";
+			break;
+		case IO_REPARSE_TAG_WCI :
+			name = " (Windows container)";
+			break;
+		case IO_REPARSE_TAG_CLOUD :
+			name = " (Cloud)";
+			break;
+		case IO_REPARSE_TAG_NFS :
+			name = " (NFS symlink)";
+			break;
+		case IO_REPARSE_TAG_LX_SYMLINK :
+			name = " (Linux symlink)";
+			break;
+		case IO_REPARSE_TAG_LX_FIFO :
+			name = " (Linux fifo)";
+			break;
+		case IO_REPARSE_TAG_LX_CHR :
+			name = " (Linux character device)";
+			break;
+		case IO_REPARSE_TAG_LX_BLK :
+			name = " (Linux block device)";
+			break;
+		case IO_REPARSE_TAG_AF_UNIX :
+			name = " (Unix socket)";
+			break;
+		case IO_REPARSE_TAG_APPEXECLINK :
+			name = " (Exec link)";
+			break;
+		default :
+			name = "";
+			break;
 	}
 	return (name);
 }
@@ -506,10 +506,10 @@ static void ntfs_dump_volume(ntfs_volume *vol)
 			(long long)vol->data2_zone_pos);
 	printf("\tAllocated clusters %lld (%2.1lf%%)\n",
 			(long long)vol->mft_na->allocated_size
-				>> vol->cluster_size_bits,
+			>> vol->cluster_size_bits,
 			100.0*(vol->mft_na->allocated_size
 				>> vol->cluster_size_bits)
-				/ vol->nr_clusters);
+			/ vol->nr_clusters);
 	printf("\tLCN of Data Attribute for FILE_MFT: %lld\n",
 			(long long)vol->mft_lcn);
 	printf("\tFILE_MFTMirr Size: %d\n", vol->mftmirr_size);
@@ -559,7 +559,7 @@ static void ntfs_dump_volume(ntfs_volume *vol)
 		printf("\tFree Clusters: %lld (%2.1lf%%)\n",
 				(long long)vol->free_clusters,
 				100.0*vol->free_clusters
-					/(double)vol->nr_clusters);
+				/(double)vol->nr_clusters);
 
 	//TODO: Still need to add a few more attributes
 }
@@ -661,20 +661,20 @@ static void ntfs_dump_namespace(const char *indent, u8 file_name_type)
 
 	/* name space */
 	switch (file_name_type) {
-	case FILE_NAME_POSIX:
-		mbs_file_type = "POSIX";
-		break;
-	case FILE_NAME_WIN32:
-		mbs_file_type = "Win32";
-		break;
-	case FILE_NAME_DOS:
-		mbs_file_type = "DOS";
-		break;
-	case FILE_NAME_WIN32_AND_DOS:
-		mbs_file_type = "Win32 & DOS";
-		break;
-	default:
-		mbs_file_type = "(unknown)";
+		case FILE_NAME_POSIX:
+			mbs_file_type = "POSIX";
+			break;
+		case FILE_NAME_WIN32:
+			mbs_file_type = "Win32";
+			break;
+		case FILE_NAME_DOS:
+			mbs_file_type = "DOS";
+			break;
+		case FILE_NAME_WIN32_AND_DOS:
+			mbs_file_type = "Win32 & DOS";
+			break;
+		default:
+			mbs_file_type = "(unknown)";
 	}
 	printf("%sNamespace:\t\t %s\n", indent, mbs_file_type);
 }
@@ -689,7 +689,7 @@ static void ntfs_dump_attr_standard_information(ATTR_RECORD *attr)
 	u32 value_length;
 
 	standard_attr = (STANDARD_INFORMATION*)((char *)attr +
-		le16_to_cpu(attr->value_offset));
+			le16_to_cpu(attr->value_offset));
 
 	/* time conversion stuff */
 	if (!opts.notime) {
@@ -699,11 +699,11 @@ static void ntfs_dump_attr_standard_information(ATTR_RECORD *attr)
 		printf("\tFile Creation Time:\t %s",ntfs_time_str);
 
 		ntfs_time_str = ntfsinfo_time_to_str(
-			standard_attr->last_data_change_time);
+				standard_attr->last_data_change_time);
 		printf("\tFile Altered Time:\t %s",ntfs_time_str);
 
 		ntfs_time_str = ntfsinfo_time_to_str(
-			standard_attr->last_mft_change_time);
+				standard_attr->last_mft_change_time);
 		printf("\tMFT Changed Time:\t %s",ntfs_time_str);
 
 		ntfs_time_str = ntfsinfo_time_to_str(standard_attr->last_access_time);
@@ -720,13 +720,13 @@ static void ntfs_dump_attr_standard_information(ATTR_RECORD *attr)
 		printf("\tVersion number:\t\t %u \n", (unsigned int)
 				le32_to_cpu(standard_attr->version_number));
 		printf("\tClass ID:\t\t %u \n",
-			(unsigned int)le32_to_cpu(standard_attr->class_id));
+				(unsigned int)le32_to_cpu(standard_attr->class_id));
 		printf("\tUser ID:\t\t %u (0x%x)\n",
-			(unsigned int)le32_to_cpu(standard_attr->owner_id),
-			(unsigned int)le32_to_cpu(standard_attr->owner_id));
+				(unsigned int)le32_to_cpu(standard_attr->owner_id),
+				(unsigned int)le32_to_cpu(standard_attr->owner_id));
 		printf("\tSecurity ID:\t\t %u (0x%x)\n",
-			(unsigned int)le32_to_cpu(standard_attr->security_id),
-			(unsigned int)le32_to_cpu(standard_attr->security_id));
+				(unsigned int)le32_to_cpu(standard_attr->security_id),
+				(unsigned int)le32_to_cpu(standard_attr->security_id));
 		printf("\tQuota charged:\t\t %llu (0x%llx)\n",
 				(unsigned long long)
 				le64_to_cpu(standard_attr->quota_charged),
@@ -784,7 +784,7 @@ static void ntfs_dump_attr_list(ATTR_RECORD *attr, ntfs_volume *vol)
 	printf("\tDumping attribute list:");
 	entry = (ATTR_LIST_ENTRY *) value;
 	for (;(u8 *)entry < (u8 *) value + l; entry = (ATTR_LIST_ENTRY *)
-				((u8 *) entry + le16_to_cpu(entry->length))) {
+			((u8 *) entry + le16_to_cpu(entry->length))) {
 		printf("\n");
 		printf("\t\tAttribute type:\t0x%x\n",
 				(unsigned int)le32_to_cpu(entry->type));
@@ -913,7 +913,7 @@ static void ntfs_dump_filename(const char *indent,
 		int mbs_file_name_size;
 
 		mbs_file_name_size = ntfs_ucstombs(file_name_attr->file_name,
-			file_name_attr->file_name_length,&mbs_file_name,0);
+				file_name_attr->file_name_length,&mbs_file_name,0);
 
 		if (mbs_file_name_size>0) {
 			printf("%sFilename:\t\t '%s'\n", indent, mbs_file_name);
@@ -933,7 +933,7 @@ static void ntfs_dump_filename(const char *indent,
 static void ntfs_dump_attr_file_name(ATTR_RECORD *attr)
 {
 	ntfs_dump_filename("\t", (FILE_NAME_ATTR*)((u8*)attr +
-			le16_to_cpu(attr->value_offset)));
+				le16_to_cpu(attr->value_offset)));
 }
 
 /**
@@ -960,7 +960,7 @@ static void ntfs_dump_attr_object_id(ATTR_RECORD *attr,ntfs_volume *vol)
 
 		/* Dump Birth Volume ID. */
 		if ((value_length > sizeof(GUID)) && !ntfs_guid_is_zero(
-				&obj_id_attr->birth_volume_id)) {
+					&obj_id_attr->birth_volume_id)) {
 			ntfs_guid_to_mbs(&obj_id_attr->birth_volume_id,
 					printable_GUID);
 			printf("\tBirth Volume ID:\t\t %s\n", printable_GUID);
@@ -969,7 +969,7 @@ static void ntfs_dump_attr_object_id(ATTR_RECORD *attr,ntfs_volume *vol)
 
 		/* Dumping Birth Object ID */
 		if ((value_length > sizeof(GUID)) && !ntfs_guid_is_zero(
-				&obj_id_attr->birth_object_id)) {
+					&obj_id_attr->birth_object_id)) {
 			ntfs_guid_to_mbs(&obj_id_attr->birth_object_id,
 					printable_GUID);
 			printf("\tBirth Object ID:\t\t %s\n", printable_GUID);
@@ -978,7 +978,7 @@ static void ntfs_dump_attr_object_id(ATTR_RECORD *attr,ntfs_volume *vol)
 
 		/* Dumping Domain_id - reserved for now */
 		if ((value_length > sizeof(GUID)) && !ntfs_guid_is_zero(
-				&obj_id_attr->domain_id)) {
+					&obj_id_attr->domain_id)) {
 			ntfs_guid_to_mbs(&obj_id_attr->domain_id,
 					printable_GUID);
 			printf("\tDomain ID:\t\t\t %s\n", printable_GUID);
@@ -986,7 +986,7 @@ static void ntfs_dump_attr_object_id(ATTR_RECORD *attr,ntfs_volume *vol)
 			printf("\tDomain ID:\t\t missing\n");
 	} else
 		printf("\t$OBJECT_ID not present. Only NTFS versions > 3.0\n"
-			"\thave $OBJECT_ID. Your version of NTFS is %d.\n",
+				"\thave $OBJECT_ID. Your version of NTFS is %d.\n",
 				vol->major_ver);
 }
 
@@ -1019,23 +1019,23 @@ static void ntfs_dump_acl(const char *prefix, ACL *acl)
 
 		/* set ace_type. */
 		switch (ace->type) {
-		case ACCESS_ALLOWED_ACE_TYPE:
-			ace_type = "allow";
-			break;
-		case ACCESS_DENIED_ACE_TYPE:
-			ace_type = "deny";
-			break;
-		case SYSTEM_AUDIT_ACE_TYPE:
-			ace_type = "audit";
-			break;
-		default:
-			ace_type = "unknown";
-			break;
+			case ACCESS_ALLOWED_ACE_TYPE:
+				ace_type = "allow";
+				break;
+			case ACCESS_DENIED_ACE_TYPE:
+				ace_type = "deny";
+				break;
+			case SYSTEM_AUDIT_ACE_TYPE:
+				ace_type = "audit";
+				break;
+			default:
+				ace_type = "unknown";
+				break;
 		}
 
 		printf("%sACE:\t\t type:%s  flags:0x%x  access:0x%x\n", prefix,
-			ace_type, (unsigned int)ace->flags,
-			(unsigned int)le32_to_cpu(ace->mask));
+				ace_type, (unsigned int)ace->flags,
+				(unsigned int)le32_to_cpu(ace->mask));
 		/* get a SID string */
 		sid = ntfs_sid_to_mbs(&ace->sid, NULL, 0);
 		printf("%s\t\t SID: %s\n", prefix, sid);
@@ -1049,7 +1049,7 @@ static void ntfs_dump_acl(const char *prefix, ACL *acl)
 
 
 static void ntfs_dump_security_descriptor(SECURITY_DESCRIPTOR_ATTR *sec_desc,
-					  const char *indent)
+		const char *indent)
 {
 	char *sid;
 
@@ -1072,7 +1072,7 @@ static void ntfs_dump_security_descriptor(SECURITY_DESCRIPTOR_ATTR *sec_desc,
 
 	if (sec_desc->owner) {
 		sid = ntfs_sid_to_mbs((SID *)((char *)sec_desc +
-			le32_to_cpu(sec_desc->owner)), NULL, 0);
+					le32_to_cpu(sec_desc->owner)), NULL, 0);
 		printf("%s\tOwner SID:\t\t %s\n", indent, sid);
 		free(sid);
 	} else
@@ -1080,7 +1080,7 @@ static void ntfs_dump_security_descriptor(SECURITY_DESCRIPTOR_ATTR *sec_desc,
 
 	if (sec_desc->group) {
 		sid = ntfs_sid_to_mbs((SID *)((char *)sec_desc +
-			le32_to_cpu(sec_desc->group)), NULL, 0);
+					le32_to_cpu(sec_desc->group)), NULL, 0);
 		printf("%s\tGroup SID:\t\t %s\n", indent, sid);
 		free(sid);
 	} else
@@ -1093,8 +1093,8 @@ static void ntfs_dump_security_descriptor(SECURITY_DESCRIPTOR_ATTR *sec_desc,
 		}
 		printf("\n");
 		ntfs_dump_acl(indent ? "\t\t\t" : "\t\t",
-			      (ACL *)((char *)sec_desc +
-				      le32_to_cpu(sec_desc->sacl)));
+				(ACL *)((char *)sec_desc +
+					le32_to_cpu(sec_desc->sacl)));
 	} else {
 		printf("missing\n");
 	}
@@ -1106,8 +1106,8 @@ static void ntfs_dump_security_descriptor(SECURITY_DESCRIPTOR_ATTR *sec_desc,
 		}
 		printf("\n");
 		ntfs_dump_acl(indent ? "\t\t\t" : "\t\t",
-			      (ACL *)((char *)sec_desc +
-				      le32_to_cpu(sec_desc->dacl)));
+				(ACL *)((char *)sec_desc +
+					le32_to_cpu(sec_desc->dacl)));
 	} else {
 		printf("missing\n");
 	}
@@ -1135,7 +1135,7 @@ static void ntfs_dump_attr_security_descriptor(ATTR_RECORD *attr, ntfs_volume *v
 				return;
 			}
 			bytes_read = ntfs_rl_pread(vol, rl, 0,
-						data_size, sec_desc_attr);
+					data_size, sec_desc_attr);
 			if (bytes_read != data_size) {
 				ntfs_log_error("ntfsinfo error: could not "
 						"read security descriptor\n");
@@ -1146,7 +1146,7 @@ static void ntfs_dump_attr_security_descriptor(ATTR_RECORD *attr, ntfs_volume *v
 			free(rl);
 		} else {
 			ntfs_log_error("ntfsinfo error: could not "
-						"decompress runlist\n");
+					"decompress runlist\n");
 			return;
 		}
 	} else {
@@ -1202,10 +1202,10 @@ static void ntfs_dump_attr_volume_information(ATTR_RECORD *attr)
 	VOLUME_INFORMATION *vol_information = NULL;
 
 	vol_information = (VOLUME_INFORMATION*)((char *)attr+
-		le16_to_cpu(attr->value_offset));
+			le16_to_cpu(attr->value_offset));
 
 	printf("\tVolume Version:\t\t %d.%d\n", vol_information->major_ver,
-		vol_information->minor_ver);
+			vol_information->minor_ver);
 	printf("\tVolume Flags:\t\t ");
 	if (vol_information->flags & VOLUME_IS_DIRTY)
 		printf("DIRTY ");
@@ -1256,7 +1256,7 @@ static void ntfs_dump_sds_entry(SECURITY_DESCRIPTOR_HEADER *sds)
 			(unsigned)le32_to_cpu(sds->length));
 
 	sd = (SECURITY_DESCRIPTOR_RELATIVE *)((char *)sds +
-		sizeof(SECURITY_DESCRIPTOR_HEADER));
+			sizeof(SECURITY_DESCRIPTOR_HEADER));
 
 	ntfs_dump_security_descriptor(sd, "\t");
 }
@@ -1281,7 +1281,7 @@ static void ntfs_dump_sds(ATTR_RECORD *attr, ntfs_inode *ni)
 
 	name = (ntfschar *)((u8 *)attr + le16_to_cpu(attr->name_offset));
 	if (!ntfs_names_are_equal(NTFS_DATA_SDS, sizeof(NTFS_DATA_SDS) / 2 - 1,
-				  name, name_len, CASE_SENSITIVE, NULL, 0))
+				name, name_len, CASE_SENSITIVE, NULL, 0))
 		return;
 
 	sd = sds = ntfs_attr_readall(ni, AT_DATA, name, name_len, &data_size);
@@ -1294,9 +1294,9 @@ static void ntfs_dump_sds(ATTR_RECORD *attr, ntfs_inode *ni)
 	 * miss real entries. For now, dump until it makes sense.
 	 */
 	while (sd->length && sd->hash &&
-	       le64_to_cpu(sd->offset) < (u64)data_size &&
-	       le32_to_cpu(sd->length) < (u64)data_size &&
-	       le64_to_cpu(sd->offset) +
+			le64_to_cpu(sd->offset) < (u64)data_size &&
+			le32_to_cpu(sd->length) < (u64)data_size &&
+			le64_to_cpu(sd->offset) +
 			le32_to_cpu(sd->length) < (u64)data_size) {
 		ntfs_dump_sds_entry(sd);
 		sd = (SECURITY_DESCRIPTOR_HEADER *)((char*)sd +
@@ -1308,24 +1308,24 @@ static void ntfs_dump_sds(ATTR_RECORD *attr, ntfs_inode *ni)
 static const char *get_attribute_type_name(le32 type)
 {
 	switch (type) {
-	case AT_UNUSED:			return "$UNUSED";
-	case AT_STANDARD_INFORMATION:   return "$STANDARD_INFORMATION";
-	case AT_ATTRIBUTE_LIST:         return "$ATTRIBUTE_LIST";
-	case AT_FILE_NAME:              return "$FILE_NAME";
-	case AT_OBJECT_ID:              return "$OBJECT_ID";
-	case AT_SECURITY_DESCRIPTOR:    return "$SECURITY_DESCRIPTOR";
-	case AT_VOLUME_NAME:            return "$VOLUME_NAME";
-	case AT_VOLUME_INFORMATION:     return "$VOLUME_INFORMATION";
-	case AT_DATA:                   return "$DATA";
-	case AT_INDEX_ROOT:             return "$INDEX_ROOT";
-	case AT_INDEX_ALLOCATION:       return "$INDEX_ALLOCATION";
-	case AT_BITMAP:                 return "$BITMAP";
-	case AT_REPARSE_POINT:          return "$REPARSE_POINT";
-	case AT_EA_INFORMATION:         return "$EA_INFORMATION";
-	case AT_EA:                     return "$EA";
-	case AT_PROPERTY_SET:           return "$PROPERTY_SET";
-	case AT_LOGGED_UTILITY_STREAM:  return "$LOGGED_UTILITY_STREAM";
-	case AT_END:                    return "$END";
+		case AT_UNUSED:			return "$UNUSED";
+		case AT_STANDARD_INFORMATION:   return "$STANDARD_INFORMATION";
+		case AT_ATTRIBUTE_LIST:         return "$ATTRIBUTE_LIST";
+		case AT_FILE_NAME:              return "$FILE_NAME";
+		case AT_OBJECT_ID:              return "$OBJECT_ID";
+		case AT_SECURITY_DESCRIPTOR:    return "$SECURITY_DESCRIPTOR";
+		case AT_VOLUME_NAME:            return "$VOLUME_NAME";
+		case AT_VOLUME_INFORMATION:     return "$VOLUME_INFORMATION";
+		case AT_DATA:                   return "$DATA";
+		case AT_INDEX_ROOT:             return "$INDEX_ROOT";
+		case AT_INDEX_ALLOCATION:       return "$INDEX_ALLOCATION";
+		case AT_BITMAP:                 return "$BITMAP";
+		case AT_REPARSE_POINT:          return "$REPARSE_POINT";
+		case AT_EA_INFORMATION:         return "$EA_INFORMATION";
+		case AT_EA:                     return "$EA";
+		case AT_PROPERTY_SET:           return "$PROPERTY_SET";
+		case AT_LOGGED_UTILITY_STREAM:  return "$LOGGED_UTILITY_STREAM";
+		case AT_END:                    return "$END";
 	}
 
 	return "$UNKNOWN";
@@ -1466,7 +1466,7 @@ static void ntfs_dump_attribute_header(ntfs_attr_search_ctx *ctx,
 							(long long)rlc->lcn,
 							(long long)rlc->length);
 					if ((next_lcn >= 0)
-					    && (rlc->lcn != next_lcn))
+							&& (rlc->lcn != next_lcn))
 						runcount->fragments++;
 					next_lcn = rlc->lcn + rlc->length;
 				} else
@@ -1607,7 +1607,8 @@ static void ntfs_dump_index_data(INDEX_ENTRY *entry, INDEX_ATTR_TYPE type)
 		ntfs_log_verbose("\t\tUnknown (padding):\t 0x%08x\n",
 				(unsigned)le32_to_cpu(data->sdh.reserved_II));
 		break;
-	case INDEX_ATTR_OBJID_O: {
+	case INDEX_ATTR_OBJID_O:
+		{
 		OBJ_ID_INDEX_DATA *object_id_data;
 		char printable_GUID[37];
 
@@ -1655,7 +1656,7 @@ static void ntfs_dump_index_data(INDEX_ENTRY *entry, INDEX_ATTR_TYPE type)
 				le64_to_cpu(data->quota_q.bytes_used));
 		ntfs_log_verbose("\t\tLast changed:\t\t %s",
 				ntfsinfo_time_to_str(
-				data->quota_q.change_time));
+					data->quota_q.change_time));
 		ntfs_log_verbose("\t\tThreshold:\t\t %lld (0x%llx)\n",
 				(unsigned long long)
 				sle64_to_cpu(data->quota_q.threshold),
@@ -1698,7 +1699,7 @@ static int ntfs_dump_index_entries(INDEX_ENTRY *entry, INDEX_ATTR_TYPE type)
 			if (entry->ie_flags & INDEX_ENTRY_END)
 				break;
 			entry = (INDEX_ENTRY *)((u8 *)entry +
-						le16_to_cpu(entry->length));
+					le16_to_cpu(entry->length));
 			numb_entries++;
 			continue;
 		}
@@ -1713,35 +1714,35 @@ static int ntfs_dump_index_entries(INDEX_ENTRY *entry, INDEX_ATTR_TYPE type)
 
 		if (entry->ie_flags & INDEX_ENTRY_NODE)
 			ntfs_log_verbose("\t\tSubnode VCN:\t\t %lld (0x%llx)\n",
-					 (long long)ntfs_ie_get_vcn(entry),
-					 (long long)ntfs_ie_get_vcn(entry));
+					(long long)ntfs_ie_get_vcn(entry),
+					(long long)ntfs_ie_get_vcn(entry));
 		if (entry->ie_flags & INDEX_ENTRY_END)
 			break;
 
 		switch (type) {
-		case INDEX_ATTR_DIRECTORY_I30:
-			ntfs_log_verbose("\t\tFILE record number:\t %llu "
-					"(0x%llx)\n", (unsigned long long)
-					MREF_LE(entry->indexed_file),
-					(unsigned long long)
-					MREF_LE(entry->indexed_file));
-			ntfs_dump_filename("\t\t", &entry->key.file_name);
-			break;
-		default:
-			ntfs_log_verbose("\t\tData offset:\t\t %u (0x%x)\n",
-					(unsigned)
-					le16_to_cpu(entry->data_offset),
-					(unsigned)
-					le16_to_cpu(entry->data_offset));
-			ntfs_log_verbose("\t\tData length:\t\t %u (0x%x)\n",
-					(unsigned)
-					le16_to_cpu(entry->data_length),
-					(unsigned)
-					le16_to_cpu(entry->data_length));
-			ntfs_dump_index_key(entry, type);
-			ntfs_log_verbose("\t\tKey Data:\n");
-			ntfs_dump_index_data(entry, type);
-			break;
+			case INDEX_ATTR_DIRECTORY_I30:
+				ntfs_log_verbose("\t\tFILE record number:\t %llu "
+						"(0x%llx)\n", (unsigned long long)
+						MREF_LE(entry->indexed_file),
+						(unsigned long long)
+						MREF_LE(entry->indexed_file));
+				ntfs_dump_filename("\t\t", &entry->key.file_name);
+				break;
+			default:
+				ntfs_log_verbose("\t\tData offset:\t\t %u (0x%x)\n",
+						(unsigned)
+						le16_to_cpu(entry->data_offset),
+						(unsigned)
+						le16_to_cpu(entry->data_offset));
+				ntfs_log_verbose("\t\tData length:\t\t %u (0x%x)\n",
+						(unsigned)
+						le16_to_cpu(entry->data_length),
+						(unsigned)
+						le16_to_cpu(entry->data_length));
+				ntfs_dump_index_key(entry, type);
+				ntfs_log_verbose("\t\tKey Data:\n");
+				ntfs_dump_index_data(entry, type);
+				break;
 		}
 		if (!entry->length) {
 			ntfs_log_verbose("\tWARNING: Corrupt index entry, "
@@ -1759,11 +1760,11 @@ static int ntfs_dump_index_entries(INDEX_ENTRY *entry, INDEX_ATTR_TYPE type)
 
 #define	COMPARE_INDEX_NAMES(attr, name)					       \
 	ntfs_names_are_equal((name), sizeof(name) / 2 - 1,		       \
-		(ntfschar*)((char*)(attr) + le16_to_cpu((attr)->name_offset)), \
-		(attr)->name_length, CASE_SENSITIVE, NULL, 0)
+			(ntfschar*)((char*)(attr) + le16_to_cpu((attr)->name_offset)), \
+			(attr)->name_length, CASE_SENSITIVE, NULL, 0)
 
 static INDEX_ATTR_TYPE get_index_attr_type(ntfs_inode *ni, ATTR_RECORD *attr,
-					   INDEX_ROOT *index_root)
+		INDEX_ROOT *index_root)
 {
 	char file_name[64];
 
@@ -1776,7 +1777,7 @@ static INDEX_ATTR_TYPE get_index_attr_type(ntfs_inode *ni, ATTR_RECORD *attr,
 		else
 			/* weird, this should be illegal */
 			ntfs_log_error("Unknown index attribute type: 0x%0X\n",
-				       le32_to_cpu(index_root->type));
+					le32_to_cpu(index_root->type));
 		return INDEX_ATTR_UNKNOWN;
 	}
 
@@ -1873,12 +1874,12 @@ static void ntfs_dump_attr_index_root(ATTR_RECORD *attr, ntfs_inode *ni)
 			(unsigned)le32_to_cpu(index_root->index_block_size));
 	if (le32_to_cpu(index_root->index_block_size) < ni->vol->cluster_size)
 		printf("\t512-byte Units Per Block:\t %u (0x%x)\n",
-			(unsigned)index_root->clusters_per_index_block,
-			(unsigned)index_root->clusters_per_index_block);
+				(unsigned)index_root->clusters_per_index_block,
+				(unsigned)index_root->clusters_per_index_block);
 	else
 		printf("\tClusters Per Block:\t %u (0x%x)\n",
-			(unsigned)index_root->clusters_per_index_block,
-			(unsigned)index_root->clusters_per_index_block);
+				(unsigned)index_root->clusters_per_index_block,
+				(unsigned)index_root->clusters_per_index_block);
 
 	ntfs_dump_index_header("\t", &index_root->index);
 
@@ -1899,9 +1900,9 @@ static void ntfs_dump_usa_lsn(const char *indent, MFT_RECORD *mrec)
 			(unsigned)le16_to_cpu(mrec->usa_count));
 	printf("%sUpd. Seq. Number:\t %u (0x%x)\n", indent,
 			(unsigned)le16_to_cpup((le16*)((u8*)mrec +
-				le16_to_cpu(mrec->usa_ofs))),
+					le16_to_cpu(mrec->usa_ofs))),
 			(unsigned)le16_to_cpup((le16*)((u8*)mrec +
-				le16_to_cpu(mrec->usa_ofs))));
+					le16_to_cpu(mrec->usa_ofs))));
 	printf("%sLogFile Seq. Number:\t 0x%llx\n", indent,
 			(unsigned long long)sle64_to_cpu(mrec->lsn));
 }
@@ -1925,7 +1926,7 @@ static s32 ntfs_dump_index_block(INDEX_BLOCK *ib, INDEX_ATTR_TYPE type,
 			(unsigned long long)sle64_to_cpu(ib->index_block_vcn));
 
 	entry = (INDEX_ENTRY*)((u8*)ib +
-				le32_to_cpu(ib->index.entries_offset) + 0x18);
+			le32_to_cpu(ib->index.entries_offset) + 0x18);
 
 	if (opts.verbose) {
 		ntfs_dump_index_header("\t\t", &ib->index);
@@ -1971,7 +1972,7 @@ static void ntfs_dump_attr_index_allocation(ATTR_RECORD *attr, ntfs_inode *ni)
 	}
 
 	tmp_alloc = allocation = ntfs_attr_readall(ni, AT_INDEX_ALLOCATION,
-						   name, name_len, &data_size);
+			name, name_len, &data_size);
 	if (!tmp_alloc) {
 		ntfs_log_perror("Failed to read $INDEX_ALLOCATION attribute");
 		goto out_bitmap;
@@ -1983,9 +1984,9 @@ static void ntfs_dump_attr_index_allocation(ATTR_RECORD *attr, ntfs_inode *ni)
 			int entries;
 
 			entries = ntfs_dump_index_block(tmp_alloc, type,
-							le32_to_cpu(
-							ir->index_block_size));
-	       		if (entries != -1) {
+					le32_to_cpu(
+						ir->index_block_size));
+			if (entries != -1) {
 				total_entries += entries;
 				total_indx_blocks++;
 				ntfs_log_verbose("\tIndex entries:\t\t %d\n",
@@ -1993,8 +1994,8 @@ static void ntfs_dump_attr_index_allocation(ATTR_RECORD *attr, ntfs_inode *ni)
 			}
 		}
 		tmp_alloc = (INDEX_ALLOCATION *)((u8 *)tmp_alloc +
-						le32_to_cpu(
-						ir->index_block_size));
+				le32_to_cpu(
+					ir->index_block_size));
 		bit++;
 		if (bit > 7) {
 			bit = 0;
@@ -2028,7 +2029,7 @@ static void ntfs_dump_attr_bitmap(ATTR_RECORD *attr __attribute__((unused)))
  * of ntfs 3.x dumps the reparse_point attribute
  */
 static void ntfs_dump_attr_reparse_point(ATTR_RECORD *attr
-			__attribute__((unused)), ntfs_inode *inode)
+		__attribute__((unused)), ntfs_inode *inode)
 {
 	REPARSE_POINT *reparse;
 	le32 tag;
@@ -2040,7 +2041,7 @@ static void ntfs_dump_attr_reparse_point(ATTR_RECORD *attr
 
 	if (attr->non_resident) {
 		reparse = ntfs_attr_readall(inode, AT_REPARSE_POINT,
-						(ntfschar*)NULL, 0, &size);
+				(ntfschar*)NULL, 0, &size);
 	} else {
 		reparse = (REPARSE_POINT*)((u8*)attr +
 				le16_to_cpu(attr->value_offset));
@@ -2049,10 +2050,10 @@ static void ntfs_dump_attr_reparse_point(ATTR_RECORD *attr
 		tag = reparse->reparse_tag;
 		name = reparse_type_name(tag);
 		printf("\tReparse tag:\t\t 0x%08lx%s\n",
-			(long)le32_to_cpu(tag),name);
+				(long)le32_to_cpu(tag),name);
 		length = le16_to_cpu(reparse->reparse_data_length);
 		printf("\tData length:\t\t %u (0x%x)\n",
-			(unsigned int)length,(unsigned int)length);
+				(unsigned int)length,(unsigned int)length);
 		cnt = length;
 		pvalue = reparse->reparse_data;
 		printf("\tData:\t\t\t");
@@ -2161,12 +2162,12 @@ static void ntfs_dump_attr_ea(ATTR_RECORD *attr, ntfs_volume *vol)
 		printf("\tValue length:\t %d (0x%x)\n",
 				(unsigned)le16_to_cpu(ea->value_length),
 				(unsigned)le16_to_cpu(ea->value_length));
-			/* Name expected to be null terminated ? */
+		/* Name expected to be null terminated ? */
 		printf("\tName:\t\t '%s'\n", ea->name);
 		printf("\tValue:\t\t ");
 		if (ea->name_length == 11 &&
 				!strncmp((const char*)"SETFILEBITS",
-				(const char*)ea->name, 11)) {
+					(const char*)ea->name, 11)) {
 			pval = (const le32*)(ea->value + ea->name_length + 1);
 			printf("0%lo\n", (unsigned long)le32_to_cpu(*pval));
 		} else {
@@ -2274,7 +2275,7 @@ static void ntfs_hex_dump(void *buf,unsigned int length)
 static void ntfs_dump_attr_unknown(ATTR_RECORD *attr)
 {
 	printf("=====  Please report this unknown attribute type to %s =====\n",
-	       NTFS_DEV_LIST);
+			NTFS_DEV_LIST);
 
 	if (!attr->non_resident) {
 		/* hex dump */
@@ -2374,69 +2375,69 @@ static void ntfs_dump_file_attributes(ntfs_inode *inode)
 	   see ntfs_attr_lookup documentation for detailed explanation */
 	ctx = ntfs_attr_get_search_ctx(inode, NULL);
 	while (!ntfs_attr_lookup(AT_UNUSED, NULL, 0, CASE_SENSITIVE,
-			0, NULL, 0, ctx)) {
+				0, NULL, 0, ctx)) {
 		if (ctx->attr->type == AT_END || ctx->attr->type == AT_UNUSED) {
 			printf("Weird: %s attribute type was found, please "
 					"report this.\n",
 					get_attribute_type_name(
-					ctx->attr->type));
+						ctx->attr->type));
 			continue;
 		}
 
 		ntfs_dump_attribute_header(ctx, inode->vol, &runcount);
 
 		switch (ctx->attr->type) {
-		case AT_STANDARD_INFORMATION:
-			ntfs_dump_attr_standard_information(ctx->attr);
-			break;
-		case AT_ATTRIBUTE_LIST:
-			ntfs_dump_attr_list(ctx->attr, inode->vol);
-			break;
-		case AT_FILE_NAME:
-			ntfs_dump_attr_file_name(ctx->attr);
-			break;
-		case AT_OBJECT_ID:
-			ntfs_dump_attr_object_id(ctx->attr, inode->vol);
-			break;
-		case AT_SECURITY_DESCRIPTOR:
-			ntfs_dump_attr_security_descriptor(ctx->attr,
-					inode->vol);
-			break;
-		case AT_VOLUME_NAME:
-			ntfs_dump_attr_volume_name(ctx->attr);
-			break;
-		case AT_VOLUME_INFORMATION:
-			ntfs_dump_attr_volume_information(ctx->attr);
-			break;
-		case AT_DATA:
-			ntfs_dump_attr_data(ctx->attr, inode);
-			break;
-		case AT_INDEX_ROOT:
-			ntfs_dump_attr_index_root(ctx->attr, inode);
-			break;
-		case AT_INDEX_ALLOCATION:
-			ntfs_dump_attr_index_allocation(ctx->attr, inode);
-			break;
-		case AT_BITMAP:
-			ntfs_dump_attr_bitmap(ctx->attr);
-			break;
-		case AT_REPARSE_POINT:
-			ntfs_dump_attr_reparse_point(ctx->attr, inode);
-			break;
-		case AT_EA_INFORMATION:
-			ntfs_dump_attr_ea_information(ctx->attr);
-			break;
-		case AT_EA:
-			ntfs_dump_attr_ea(ctx->attr, inode->vol);
-			break;
-		case AT_PROPERTY_SET:
-			ntfs_dump_attr_property_set(ctx->attr);
-			break;
-		case AT_LOGGED_UTILITY_STREAM:
-			ntfs_dump_attr_logged_utility_stream(ctx->attr, inode);
-			break;
-		default:
-			ntfs_dump_attr_unknown(ctx->attr);
+			case AT_STANDARD_INFORMATION:
+				ntfs_dump_attr_standard_information(ctx->attr);
+				break;
+			case AT_ATTRIBUTE_LIST:
+				ntfs_dump_attr_list(ctx->attr, inode->vol);
+				break;
+			case AT_FILE_NAME:
+				ntfs_dump_attr_file_name(ctx->attr);
+				break;
+			case AT_OBJECT_ID:
+				ntfs_dump_attr_object_id(ctx->attr, inode->vol);
+				break;
+			case AT_SECURITY_DESCRIPTOR:
+				ntfs_dump_attr_security_descriptor(ctx->attr,
+						inode->vol);
+				break;
+			case AT_VOLUME_NAME:
+				ntfs_dump_attr_volume_name(ctx->attr);
+				break;
+			case AT_VOLUME_INFORMATION:
+				ntfs_dump_attr_volume_information(ctx->attr);
+				break;
+			case AT_DATA:
+				ntfs_dump_attr_data(ctx->attr, inode);
+				break;
+			case AT_INDEX_ROOT:
+				ntfs_dump_attr_index_root(ctx->attr, inode);
+				break;
+			case AT_INDEX_ALLOCATION:
+				ntfs_dump_attr_index_allocation(ctx->attr, inode);
+				break;
+			case AT_BITMAP:
+				ntfs_dump_attr_bitmap(ctx->attr);
+				break;
+			case AT_REPARSE_POINT:
+				ntfs_dump_attr_reparse_point(ctx->attr, inode);
+				break;
+			case AT_EA_INFORMATION:
+				ntfs_dump_attr_ea_information(ctx->attr);
+				break;
+			case AT_EA:
+				ntfs_dump_attr_ea(ctx->attr, inode->vol);
+				break;
+			case AT_PROPERTY_SET:
+				ntfs_dump_attr_property_set(ctx->attr);
+				break;
+			case AT_LOGGED_UTILITY_STREAM:
+				ntfs_dump_attr_logged_utility_stream(ctx->attr, inode);
+				break;
+			default:
+				ntfs_dump_attr_unknown(ctx->attr);
 		}
 	}
 
@@ -2528,7 +2529,7 @@ int main(int argc, char **argv)
 
 			for (i = 0; i < inode->nr_extents; i++) {
 				if (inode->extent_nis[i]->mft_no ==
-				    opts.extent_inode) {
+						opts.extent_inode) {
 					inode = inode->extent_nis[i];
 					goto found;
 				}

--- a/src/ntfslabel.c
+++ b/src/ntfslabel.c
@@ -96,15 +96,15 @@ static void version(void)
 static void usage(void)
 {
 	ntfs_log_info("\nUsage: %s [options] device [label]\n"
-	       "    -n, --no-action    Do not write to disk\n"
-	       "    -f, --force        Use less caution\n"
-	       "        --new-serial   Set a new serial number\n"
-	       "        --new-half-serial Set a partial new serial number\n"
-	       "    -q, --quiet        Less output\n"
-	       "    -v, --verbose      More output\n"
-	       "    -V, --version      Display version information\n"
-	       "    -h, --help         Display this help\n\n",
-	       EXEC_NAME);
+		"    -n, --no-action    Do not write to disk\n"
+		"    -f, --force        Use less caution\n"
+		"        --new-serial   Set a new serial number\n"
+		"        --new-half-serial Set a partial new serial number\n"
+		"    -q, --quiet        Less output\n"
+		"    -v, --verbose      More output\n"
+		"    -V, --version      Display version information\n"
+		"    -h, --help         Display this help\n\n",
+		EXEC_NAME);
 }
 
 /**
@@ -142,62 +142,62 @@ static int parse_options(int argc, char *argv[])
 
 	while ((c = getopt_long(argc, argv, sopt, lopt, NULL)) != -1) {
 		switch (c) {
-		case 1:	/* A non-option argument */
-			if (!err && !opts.device)
-				opts.device = argv[optind-1];
-			else if (!err && !opts.label)
-				opts.label = argv[optind-1];
-			else
-				err++;
-			break;
-		case 'f':
-			opts.force++;
-			break;
-		case 'h':
-			help++;
-			break;
-		case 'I' :	/* not proposed as a short option letter */
-			if (optarg) {
-				opts.serial = strtoull(optarg, &endserial, 16);
-				if (*endserial)
-					ntfs_log_error("Bad hexadecimal serial number.\n");
-			}
-			opts.new_serial |= 2;
-			break;
-		case 'i' :	/* not proposed as a short option letter */
-			if (optarg) {
-				opts.serial = strtoull(optarg, &endserial, 16)
-							<< 32;
-				if (*endserial)
-					ntfs_log_error("Bad hexadecimal serial number.\n");
-			}
-			opts.new_serial |= 1;
-			break;
-		case 'n':
-			opts.noaction++;
-			break;
-		case 'q':
-			opts.quiet++;
-			ntfs_log_clear_levels(NTFS_LOG_LEVEL_QUIET);
-			break;
-		case 'v':
-			opts.verbose++;
-			ntfs_log_set_levels(NTFS_LOG_LEVEL_VERBOSE);
-			break;
-		case 'V':
-			ver++;
-			break;
-		case '?':
-			if (strncmp (argv[optind-1], "--log-", 6) == 0) {
-				if (!ntfs_log_parse_option (argv[optind-1]))
+			case 1:	/* A non-option argument */
+				if (!err && !opts.device)
+					opts.device = argv[optind-1];
+				else if (!err && !opts.label)
+					opts.label = argv[optind-1];
+				else
 					err++;
 				break;
-			}
-			/* fall through */
-		default:
-			ntfs_log_error("Unknown option '%s'.\n", argv[optind-1]);
-			err++;
-			break;
+			case 'f':
+				opts.force++;
+				break;
+			case 'h':
+				help++;
+				break;
+			case 'I' :	/* not proposed as a short option letter */
+				if (optarg) {
+					opts.serial = strtoull(optarg, &endserial, 16);
+					if (*endserial)
+						ntfs_log_error("Bad hexadecimal serial number.\n");
+				}
+				opts.new_serial |= 2;
+				break;
+			case 'i' :	/* not proposed as a short option letter */
+				if (optarg) {
+					opts.serial = strtoull(optarg, &endserial, 16)
+						<< 32;
+					if (*endserial)
+						ntfs_log_error("Bad hexadecimal serial number.\n");
+				}
+				opts.new_serial |= 1;
+				break;
+			case 'n':
+				opts.noaction++;
+				break;
+			case 'q':
+				opts.quiet++;
+				ntfs_log_clear_levels(NTFS_LOG_LEVEL_QUIET);
+				break;
+			case 'v':
+				opts.verbose++;
+				ntfs_log_set_levels(NTFS_LOG_LEVEL_VERBOSE);
+				break;
+			case 'V':
+				ver++;
+				break;
+			case '?':
+				if (strncmp (argv[optind-1], "--log-", 6) == 0) {
+					if (!ntfs_log_parse_option (argv[optind-1]))
+						err++;
+					break;
+				}
+				/* fall through */
+			default:
+				ntfs_log_error("Unknown option '%s'.\n", argv[optind-1]);
+				err++;
+				break;
 		}
 	}
 
@@ -229,26 +229,26 @@ static int parse_options(int argc, char *argv[])
 	if (help || err)
 		usage();
 
-		/* tri-state 0 : done, 1 : error, -1 : proceed */
+	/* tri-state 0 : done, 1 : error, -1 : proceed */
 	return (err ? 1 : (help || ver ? 0 : -1));
 }
 
 static int change_serial(ntfs_volume *vol, u64 sector, le64 serial_number,
-			NTFS_BOOT_SECTOR *bs, NTFS_BOOT_SECTOR *oldbs)
+		NTFS_BOOT_SECTOR *bs, NTFS_BOOT_SECTOR *oldbs)
 {
 	int res;
 	le64 mask;
 	BOOL same;
 
 	res = -1;
-        if ((ntfs_pread(vol->dev, sector << vol->sector_size_bits,
-			vol->sector_size, bs) == vol->sector_size)) {
+	if ((ntfs_pread(vol->dev, sector << vol->sector_size_bits,
+					vol->sector_size, bs) == vol->sector_size)) {
 		same = TRUE;
 		if (!sector)
-				/* save the real bootsector */
+			/* save the real bootsector */
 			memcpy(oldbs, bs, vol->sector_size);
 		else
-				/* backup bootsector must be similar */
+			/* backup bootsector must be similar */
 			same = !memcmp(oldbs, bs, vol->sector_size);
 		if (same) {
 			if (opts.new_serial & 2)
@@ -256,18 +256,18 @@ static int change_serial(ntfs_volume *vol, u64 sector, le64 serial_number,
 			else {
 				mask = const_cpu_to_le64(~0x0ffffffffULL);
 				bs->volume_serial_number
-				    = (serial_number & mask)
+					= (serial_number & mask)
 					| (bs->volume_serial_number & ~mask);
 			}
 			if (opts.noaction
-			    || (ntfs_pwrite(vol->dev,
-				sector << vol->sector_size_bits,
-				vol->sector_size, bs) == vol->sector_size)) {
+					|| (ntfs_pwrite(vol->dev,
+							sector << vol->sector_size_bits,
+							vol->sector_size, bs) == vol->sector_size)) {
 				res = 0;
 			}
 		} else {
 			ntfs_log_info("* Warning : the backup boot sector"
-				" does not match (leaving unchanged)\n");
+					" does not match (leaving unchanged)\n");
 			res = 0;
 		}
 	}
@@ -293,19 +293,19 @@ static int set_new_serial(ntfs_volume *vol)
 			/* different values for parallel processes */
 			srandom(time((time_t*)NULL) ^ (getpid() << 16));
 			sn = ((u64)random() << 32)
-					| ((u64)random() & 0xffffffff);
+				| ((u64)random() & 0xffffffff);
 			serial_number = cpu_to_le64(sn);
 		}
 		if (!change_serial(vol, 0, serial_number, bs, oldbs)) {
 			number_of_sectors = ntfs_device_size_get(vol->dev,
-						vol->sector_size);
+					vol->sector_size);
 			if (!change_serial(vol, number_of_sectors - 1,
 						serial_number, bs, oldbs)) {
 				ntfs_log_info("New serial number : %016llx\n",
-					(long long)le64_to_cpu(
-						bs->volume_serial_number));
+						(long long)le64_to_cpu(
+							bs->volume_serial_number));
 				res = 0;
-				}
+			}
 		}
 	}
 	if (res)
@@ -327,10 +327,10 @@ static int print_serial(ntfs_volume *vol)
 	res = -1;
 	bs = (NTFS_BOOT_SECTOR*)ntfs_malloc(vol->sector_size);
 	if (bs
-	    && (ntfs_pread(vol->dev, 0,
-			vol->sector_size, bs) == vol->sector_size)) {
+			&& (ntfs_pread(vol->dev, 0,
+					vol->sector_size, bs) == vol->sector_size)) {
 		ntfs_log_info("Serial number : %016llx\n",
-			(long long)le64_to_cpu(bs->volume_serial_number));
+				(long long)le64_to_cpu(bs->volume_serial_number));
 		res = 0;
 		free(bs);
 	}
@@ -354,7 +354,7 @@ static int print_label(ntfs_volume *vol, unsigned long mnt_flags)
 	if ((mnt_flags & (NTFS_MF_MOUNTED | NTFS_MF_READONLY)) ==
 			NTFS_MF_MOUNTED) {
 		ntfs_log_error("%s is mounted read-write, results may be "
-			"unreliable.\n", opts.device);
+				"unreliable.\n", opts.device);
 		result = 1;
 	}
 
@@ -392,7 +392,7 @@ static int change_label(ntfs_volume *vol, char *label)
 				"allowed. Truncating %u excess characters.\n",
 				(unsigned)(0x100 / sizeof(ntfschar)),
 				(unsigned)(label_len -
-				(0x100 / sizeof(ntfschar))));
+					(0x100 / sizeof(ntfschar))));
 		label_len = 0x100 / sizeof(ntfschar);
 		new_label[label_len] = const_cpu_to_le16(0);
 	}
@@ -428,10 +428,10 @@ int main(int argc, char **argv)
 	utils_set_locale();
 
 	if ((opts.label || opts.new_serial)
-	    && !opts.noaction
-	    && !opts.force
-	    && !ntfs_check_if_mounted(opts.device, &mnt_flags)
-	    && (mnt_flags & NTFS_MF_MOUNTED)) {
+			&& !opts.noaction
+			&& !opts.force
+			&& !ntfs_check_if_mounted(opts.device, &mnt_flags)
+			&& (mnt_flags & NTFS_MF_MOUNTED)) {
 		ntfs_log_error("Cannot make changes to a mounted device\n");
 		result = 1;
 		goto abort;
@@ -462,6 +462,6 @@ int main(int argc, char **argv)
 unmount :
 	ntfs_umount(vol, FALSE);
 abort :
-		/* "result" may be a negative reply of a library function */
+	/* "result" may be a negative reply of a library function */
 	return (result ? 1 : 0);
 }

--- a/src/ntfsresize.c
+++ b/src/ntfsresize.c
@@ -168,7 +168,7 @@ struct llcn_t {
 
 #define NTFSCK_PROGBAR		0x0001
 
-			/* runlists which have to be processed later */
+/* runlists which have to be processed later */
 struct DELAYED {
 	struct DELAYED *next;
 	ATTR_TYPES type;
@@ -372,7 +372,7 @@ static void proceed_question(void)
 	printf("Are you sure you want to proceed (y/[n])? ");
 	buf[0] = 0;
 	if (fgets(buf, sizeof(buf), stdin)
-	    && !strchr(short_yes, buf[0])) {
+			&& !strchr(short_yes, buf[0])) {
 		printf("OK quitting. NO CHANGES have been made to your "
 				"NTFS volume.\n");
 		exit(1);
@@ -438,17 +438,17 @@ static s64 get_new_volume_size(char *s)
 	*/
 	/* FIXME: check for overflow */
 	switch (*suffix) {
-	case 'G':
-		size *= prefix_kind;
-		/* FALLTHRU */
-	case 'M':
-		size *= prefix_kind;
-		/* FALLTHRU */
-	case 'k':
-		size *= prefix_kind;
-		break;
-	default:
-		usage(1);
+		case 'G':
+			size *= prefix_kind;
+			/* FALLTHRU */
+		case 'M':
+			size *= prefix_kind;
+			/* FALLTHRU */
+		case 'k':
+			size *= prefix_kind;
+			break;
+		default:
+			usage(1);
 	}
 
 	return size;
@@ -493,64 +493,64 @@ static int parse_options(int argc, char **argv)
 
 	while ((c = getopt_long(argc, argv, sopt, lopt, NULL)) != -1) {
 		switch (c) {
-		case 1:	/* A non-option argument */
-			if (!err && !opt.volume)
-				opt.volume = argv[optind-1];
-			else
+			case 1:	/* A non-option argument */
+				if (!err && !opt.volume)
+					opt.volume = argv[optind-1];
+				else
+					err++;
+				break;
+			case 'b':
+				opt.badsectors++;
+				break;
+			case 'c':
+				opt.check++;
+				break;
+			case 'd':
+				opt.debug++;
+				break;
+			case 'f':
+				opt.force++;
+				break;
+			case 'h':
+				help++;
+				break;
+			case 'i':
+				opt.info++;
+				break;
+			case 'm':
+				opt.infombonly++;
+				break;
+			case 'n':
+				opt.ro_flag = NTFS_MNT_RDONLY;
+				break;
+			case 'P':
+				opt.show_progress = 0;
+				break;
+			case 's':
+				if (!err && (opt.bytes == 0))
+					opt.bytes = get_new_volume_size(optarg);
+				else
+					err++;
+				break;
+			case 'v':
+				opt.verbose++;
+				ntfs_log_set_levels(NTFS_LOG_LEVEL_VERBOSE);
+				break;
+			case 'V':
+				ver++;
+				break;
+			case 'x':
+				opt.expand++;
+				break;
+			case '?':
+			default:
+				if (optopt == 's') {
+					printf("Option '%s' requires an argument.\n", argv[optind-1]);
+				} else {
+					printf("Unknown option '%s'.\n", argv[optind-1]);
+				}
 				err++;
-			break;
-		case 'b':
-			opt.badsectors++;
-			break;
-		case 'c':
-			opt.check++;
-			break;
-		case 'd':
-			opt.debug++;
-			break;
-		case 'f':
-			opt.force++;
-			break;
-		case 'h':
-			help++;
-			break;
-		case 'i':
-			opt.info++;
-			break;
-		case 'm':
-			opt.infombonly++;
-			break;
-		case 'n':
-			opt.ro_flag = NTFS_MNT_RDONLY;
-			break;
-		case 'P':
-			opt.show_progress = 0;
-			break;
-		case 's':
-			if (!err && (opt.bytes == 0))
-				opt.bytes = get_new_volume_size(optarg);
-			else
-				err++;
-			break;
-		case 'v':
-			opt.verbose++;
-			ntfs_log_set_levels(NTFS_LOG_LEVEL_VERBOSE);
-			break;
-		case 'V':
-			ver++;
-			break;
-		case 'x':
-			opt.expand++;
-			break;
-		case '?':
-		default:
-			if (optopt == 's') {
-				printf("Option '%s' requires an argument.\n", argv[optind-1]);
-			} else {
-				printf("Unknown option '%s'.\n", argv[optind-1]);
-			}
-			err++;
-			break;
+				break;
 		}
 	}
 
@@ -564,7 +564,7 @@ static int parse_options(int argc, char **argv)
 			opt.ro_flag = NTFS_MNT_RDONLY;
 		}
 		if (opt.bytes
-		    && (opt.expand || opt.info || opt.infombonly)) {
+				&& (opt.expand || opt.info || opt.infombonly)) {
 			printf(NERR_PREFIX "Options --info(-mb-only) and --expand "
 					"cannot be used with --size.\n");
 			usage(1);
@@ -593,7 +593,7 @@ static int parse_options(int argc, char **argv)
 	if (help || err)
 		usage(err > 0);
 
-		/* tri-state 0 : done, 1 : error, -1 : proceed */
+	/* tri-state 0 : done, 1 : error, -1 : proceed */
 	return (err ? 1 : (help || ver ? 0 : -1));
 }
 
@@ -610,8 +610,8 @@ static void print_advise(ntfs_volume *vol, s64 supp_lcn)
 
 	if (supp_lcn > vol->nr_clusters) {
 		err_printf("Very rare fragmentation type detected. "
-			   "Sorry, it's not supported yet.\n"
-			   "Try to defragment your NTFS, perhaps it helps.\n");
+				"Sorry, it's not supported yet.\n"
+				"Try to defragment your NTFS, perhaps it helps.\n");
 		exit(1);
 	}
 
@@ -635,11 +635,11 @@ static void print_advise(ntfs_volume *vol, s64 supp_lcn)
 		if (freed_mb && (old_mb - new_mb))
 			printf("%lld MB", (long long)(old_mb - new_mb));
 		else
-		        printf("%lld bytes", (long long)freed_b);
+			printf("%lld bytes", (long long)freed_b);
 		printf(").\n");
 
 		printf("Please make a test run using both the -n and -s "
-			"options before real resizing!\n");
+				"options before real resizing!\n");
 	}
 }
 
@@ -663,8 +663,8 @@ static int rl_items(runlist *rl)
 static void dump_run(runlist_element *r)
 {
 	ntfs_log_verbose(" %8lld  %8lld (0x%08llx)  %lld\n", (long long)r->vcn,
-			 (long long)r->lcn, (long long)r->lcn,
-			 (long long)r->length);
+			(long long)r->lcn, (long long)r->lcn,
+			(long long)r->length);
 }
 
 static void dump_runlist(runlist *rl)
@@ -712,7 +712,7 @@ static void collect_resize_constraints(ntfs_resize_t *resize, runlist *rl)
 	if (inode == FILE_Bitmap) {
 		llcn = &resize->last_lcn;
 		if (atype == AT_DATA && NInoAttrList(resize->ni))
-		    err_exit("Highly fragmented $Bitmap isn't supported yet.");
+			err_exit("Highly fragmented $Bitmap isn't supported yet.");
 
 		supported = 1;
 
@@ -781,7 +781,7 @@ static void collect_relocation_info(ntfs_resize_t *resize, runlist *rl)
 
 		if ((!opt.info && !opt.infombonly) && (inode == FILE_MFTMirr)) {
 			err_printf("$MFTMirr can't be split up yet. Please try "
-				   "a different size.\n");
+					"a different size.\n");
 			print_advise(resize->vol, lcn + lcn_length - 1);
 			exit(1);
 		}
@@ -841,9 +841,9 @@ static void build_lcn_usage_bitmap(ntfs_volume *vol, ntfsck_t *fsck)
 		/* FIXME: ntfs_mapping_pairs_decompress should return error */
 		if (lcn < 0 || lcn_length <= 0)
 			err_exit("Corrupt runlist in inode %lld attr %x LCN "
-				 "%llx length %llx\n", (long long)inode,
-				 (unsigned int)le32_to_cpu(a->type),
-				 (long long)lcn, (long long)lcn_length);
+					"%llx length %llx\n", (long long)inode,
+					(unsigned int)le32_to_cpu(a->type),
+					(long long)lcn, (long long)lcn_length);
 
 		for (j = 0; j < lcn_length; j++) {
 			u64 k = (u64)lcn + j;
@@ -855,9 +855,9 @@ static void build_lcn_usage_bitmap(ntfs_volume *vol, ntfsck_t *fsck)
 
 				if (++fsck->show_outsider <= 10 || opt.verbose)
 					printf("Outside of the volume reference"
-					       " for inode %lld at %lld:%lld\n",
-					       (long long)inode, (long long)k,
-					       (long long)outsiders);
+							" for inode %lld at %lld:%lld\n",
+							(long long)inode, (long long)k,
+							(long long)outsiders);
 
 				break;
 			}
@@ -865,8 +865,8 @@ static void build_lcn_usage_bitmap(ntfs_volume *vol, ntfsck_t *fsck)
 			if (ntfs_bit_get_and_set(lcn_bitmap->bm, k, 1)) {
 				if (++fsck->multi_ref <= 10 || opt.verbose)
 					printf("Cluster %lld is referenced "
-					       "multiple times!\n",
-					       (long long)k);
+							"multiple times!\n",
+							(long long)k);
 				continue;
 			}
 		}
@@ -920,7 +920,7 @@ static void compare_bitmaps(ntfs_volume *vol, struct bitmap *a)
 	int backup_boot = 0;
 	u8 bm[NTFS_BUF_SIZE];
 
-        if (!opt.infombonly)
+	if (!opt.infombonly)
 		printf("Accounting clusters ...\n");
 
 	pos = 0;
@@ -932,8 +932,8 @@ static void compare_bitmaps(ntfs_volume *vol, struct bitmap *a)
 		if (count == 0) {
 			if (a->size > pos)
 				err_exit("$Bitmap size is smaller than expected"
-					 " (%lld != %lld)\n",
-					 (long long)a->size, (long long)pos);
+						" (%lld != %lld)\n",
+						(long long)a->size, (long long)pos);
 			break;
 		}
 
@@ -958,7 +958,7 @@ static void compare_bitmaps(ntfs_volume *vol, struct bitmap *a)
 					/* FIXME: call also boot sector check */
 					backup_boot = 1;
 					printf("Found backup boot sector in "
-					       "the middle of the volume.\n");
+							"the middle of the volume.\n");
 					continue;
 				}
 
@@ -976,7 +976,7 @@ static void compare_bitmaps(ntfs_volume *vol, struct bitmap *a)
 done:
 	if (mismatch) {
 		printf("Filesystem check failed! Totally %d cluster "
-		       "accounting mismatches.\n", mismatch);
+				"accounting mismatches.\n", mismatch);
 		err_printf("%s", corrupt_volume_msg);
 		exit(1);
 	}
@@ -986,7 +986,7 @@ static int inode_close(ntfs_inode *ni)
 {
 	if (ntfs_inode_close(ni)) {
 		perr_printf("ntfs_inode_close for inode %llu",
-			    (unsigned long long)ni->mft_no);
+				(unsigned long long)ni->mft_no);
 		return -1;
 	}
 	return 0;
@@ -1006,19 +1006,19 @@ static int build_allocation_bitmap(ntfs_volume *vol, ntfsck_t *fsck)
 	int pb_flags = 0;	/* progress bar flags */
 
 	/* WARNING: don't modify the text, external tools grep for it */
-        if (!opt.infombonly)
+	if (!opt.infombonly)
 		printf("Checking filesystem consistency ...\n");
 
 	if (fsck->flags & NTFSCK_PROGBAR)
 		pb_flags |= NTFS_PROGBAR;
 
 	nr_mft_records = vol->mft_na->initialized_size >>
-			vol->mft_record_size_bits;
+		vol->mft_record_size_bits;
 
 	progress_init(&progress, inode, nr_mft_records - 1, 100, pb_flags);
 
 	for (; inode < nr_mft_records; inode++) {
-        	if (!opt.infombonly)
+		if (!opt.infombonly)
 			progress_update(&progress, inode);
 
 		if ((ni = ntfs_inode_open(vol, (MFT_REF)inode)) == NULL) {
@@ -1055,7 +1055,7 @@ static void build_resize_constraints(ntfs_resize_t *resize)
 		return;
 
 	if (!(rl = ntfs_mapping_pairs_decompress(resize->vol,
-						 resize->ctx->attr, NULL)))
+					resize->ctx->attr, NULL)))
 		perr_exit("ntfs_decompress_mapping_pairs");
 
 	for (i = 0; rl[i].length; i++) {
@@ -1089,11 +1089,11 @@ static void set_resize_constraints(ntfs_resize_t *resize)
 	s64 nr_mft_records, inode;
 	ntfs_inode *ni;
 
-        if (!opt.infombonly)
+	if (!opt.infombonly)
 		printf("Collecting resizing constraints ...\n");
 
 	nr_mft_records = resize->vol->mft_na->initialized_size >>
-			resize->vol->mft_record_size_bits;
+		resize->vol->mft_record_size_bits;
 
 	for (inode = 0; inode < nr_mft_records; inode++) {
 
@@ -1138,7 +1138,7 @@ static void rl_fixup(runlist **rl)
 
 			if (tmp[1].length)
 				err_exit("Unmapped runlist in the middle! "
-					 "Please report!\n");
+						"Please report!\n");
 			tmp->lcn = LCN_ENOENT;
 			tmp->length = 0;
 		}
@@ -1153,7 +1153,7 @@ static void rl_fixup(runlist **rl)
  */
 
 static int replace_runlist(ntfs_attr *na, const runlist_element *reprl,
-				VCN lowest_vcn)
+		VCN lowest_vcn)
 {
 	const runlist_element *prep;
 	const runlist_element *pold;
@@ -1165,7 +1165,7 @@ static int replace_runlist(ntfs_attr *na, const runlist_element *reprl,
 	int r;
 
 	r = -1; /* default return */
-		/* allocate a new runlist able to hold both */
+	/* allocate a new runlist able to hold both */
 	oldcnt = 0;
 	while (na->rl[oldcnt].length)
 		oldcnt++;
@@ -1179,15 +1179,15 @@ static int replace_runlist(ntfs_attr *na, const runlist_element *reprl,
 		pnew = newrl;
 		pold = na->rl;
 		while (pold->length
-		    && ((pold->vcn + pold->length)
-				 <= (reprl[0].vcn + lowest_vcn))) {
+				&& ((pold->vcn + pold->length)
+					<= (reprl[0].vcn + lowest_vcn))) {
 			*pnew = *pold;
 			pnew++;
 			pold++;
 		}
 		/* split a possible old run partially overlapped */
 		if (pold->length
-		    && (pold->vcn < (reprl[0].vcn + lowest_vcn))) {
+				&& (pold->vcn < (reprl[0].vcn + lowest_vcn))) {
 			pnew->vcn = pold->vcn;
 			pnew->lcn = pold->lcn;
 			pnew->length = reprl[0].vcn + lowest_vcn - pold->vcn;
@@ -1206,12 +1206,12 @@ static int replace_runlist(ntfs_attr *na, const runlist_element *reprl,
 		}
 		/* locate the first fully replaced old run */
 		while (pold->length
-		    && ((pold->vcn + pold->length) <= nextvcn)) {
+				&& ((pold->vcn + pold->length) <= nextvcn)) {
 			pold++;
 		}
 		/* split a possible old run partially overlapped */
 		if (pold->length
-		    && (pold->vcn < nextvcn)) {
+				&& (pold->vcn < nextvcn)) {
 			pnew->vcn = nextvcn;
 			pnew->lcn = pold->lcn + nextvcn - pold->vcn;
 			pnew->length = pold->length - nextvcn + pold->vcn;
@@ -1267,11 +1267,11 @@ static void expand_attribute_runlist(ntfs_volume *vol, struct DELAYED *delayed)
 	MFT_REF mref;
 	runlist_element *rl;
 
-		/* open the inode */
+	/* open the inode */
 	mref = delayed->mref;
 #ifndef BAN_NEW_TEXT
 	ntfs_log_verbose("Processing a delayed update for inode %lld\n",
-					(long long)mref);
+			(long long)mref);
 #endif
 	type = delayed->type;
 	rl = delayed->rl;
@@ -1294,25 +1294,25 @@ static void expand_attribute_runlist(ntfs_volume *vol, struct DELAYED *delayed)
 			 */
 			if (!ntfs_attr_map_whole_runlist(na)) {
 				if (replace_runlist(na,rl,delayed->lowest_vcn)
-				    || ntfs_attr_update_mapping_pairs(na,0))
+						|| ntfs_attr_update_mapping_pairs(na,0))
 					perr_exit("Could not update runlist "
-						"for attribute 0x%lx in inode %lld",
-						(long)le32_to_cpu(type),(long long)mref);
+							"for attribute 0x%lx in inode %lld",
+							(long)le32_to_cpu(type),(long long)mref);
 			} else
 				perr_exit("Could not map attribute 0x%lx in inode %lld",
-					(long)le32_to_cpu(type),(long long)mref);
+						(long)le32_to_cpu(type),(long long)mref);
 			if (mref != FILE_MFT)
 				ntfs_attr_close(na);
 		} else
 			perr_exit("Could not open attribute 0x%lx in inode %lld",
-				(long)le32_to_cpu(type),(long long)mref);
+					(long)le32_to_cpu(type),(long long)mref);
 		ntfs_inode_mark_dirty(ni);
 		if ((mref != FILE_MFT) && ntfs_inode_close(ni))
 			perr_exit("Failed to close inode %lld through the library",
-				(long long)mref);
+					(long long)mref);
 	} else
 		perr_exit("Could not open inode %lld through the library",
-			(long long)mref);
+				(long long)mref);
 }
 
 /*
@@ -1342,7 +1342,7 @@ static int reload_mft(ntfs_resize_t *resize)
 	int xi;
 
 	r = 0;
-		/* get the base inode */
+	/* get the base inode */
 	ni = resize->vol->mft_ni;
 	if (!ntfs_file_record_read(resize->vol, FILE_MFT, &ni->mrec, NULL)) {
 		for (xi=0; !r && xi<resize->vol->mft_ni->nr_extents; xi++) {
@@ -1354,7 +1354,7 @@ static int reload_mft(ntfs_resize_t *resize)
 		if (!r) {
 			/* reopen the MFT bitmap, and swap vol->mftbmp_na */
 			na = ntfs_attr_open(resize->vol->mft_ni,
-						AT_BITMAP, NULL, 0);
+					AT_BITMAP, NULL, 0);
 			if (na && !ntfs_attr_map_whole_runlist(na)) {
 				ntfs_attr_close(resize->vol->mftbmp_na);
 				resize->vol->mftbmp_na = na;
@@ -1368,7 +1368,7 @@ static int reload_mft(ntfs_resize_t *resize)
 		if (!r) {
 			/* reopen the MFT data, and swap vol->mft_na */
 			na = ntfs_attr_open(resize->vol->mft_ni,
-						AT_DATA, NULL, 0);
+					AT_DATA, NULL, 0);
 			if (na && !ntfs_attr_map_whole_runlist(na)) {
 				ntfs_attr_close(resize->vol->mft_na);
 				resize->vol->mft_na = na;
@@ -1409,11 +1409,11 @@ static int record_mft_in_bitmap(ntfs_resize_t *resize)
 	int xi;
 
 	r = 0;
-		/* get the base inode */
+	/* get the base inode */
 	ni = resize->vol->mft_ni;
 	for (xi=0; !r && xi<resize->vol->mft_ni->nr_extents; xi++) {
 		r = ntfs_bitmap_set_run(resize->vol->mftbmp_na,
-					ni->extent_nis[xi]->mft_no, 1);
+				ni->extent_nis[xi]->mft_no, 1);
 	}
 	return (r);
 }
@@ -1435,31 +1435,31 @@ static void delayed_updates(ntfs_resize_t *resize)
 	if (resize->delayed_runlists && reload_mft(resize))
 		err_exit("Failed to reload the MFT for delayed updates\n");
 
-		/*
-		 * Important : updates to MFT must come first, so that
-		 * the new location of MFT is used for adding needed extents.
-		 * Now, there are runlists in the MFT bitmap and MFT data.
-		 * Extents to MFT bitmap have to be stored in the new MFT
-		 * data, and extents to MFT data have to be recorded in
-		 * the MFT bitmap.
-		 * So we update MFT data first, and we record the MFT
-		 * extents again in the MFT bitmap if they were recorded
-		 * in the old location.
-		 *
-		 * However, if we are operating in "no action" mode, the
-		 * MFT records to update are not written to their new location
-		 * and the MFT data runlist has to be updated last in order
-		 * to have the entries read from their old location.
-		 * In this situation the MFT bitmap is never written to
-		 * disk, so the same extents are reallocated repeatedly,
-		 * which is not what would be done in a real resizing.
-		 */
+	/*
+	 * Important : updates to MFT must come first, so that
+	 * the new location of MFT is used for adding needed extents.
+	 * Now, there are runlists in the MFT bitmap and MFT data.
+	 * Extents to MFT bitmap have to be stored in the new MFT
+	 * data, and extents to MFT data have to be recorded in
+	 * the MFT bitmap.
+	 * So we update MFT data first, and we record the MFT
+	 * extents again in the MFT bitmap if they were recorded
+	 * in the old location.
+	 *
+	 * However, if we are operating in "no action" mode, the
+	 * MFT records to update are not written to their new location
+	 * and the MFT data runlist has to be updated last in order
+	 * to have the entries read from their old location.
+	 * In this situation the MFT bitmap is never written to
+	 * disk, so the same extents are reallocated repeatedly,
+	 * which is not what would be done in a real resizing.
+	 */
 
 	if (opt.ro_flag
-	    && resize->delayed_runlists
-	    && (resize->delayed_runlists->mref == FILE_MFT)
-	    && (resize->delayed_runlists->type == AT_DATA)) {
-			/* Update the MFT data runlist later */
+			&& resize->delayed_runlists
+			&& (resize->delayed_runlists->mref == FILE_MFT)
+			&& (resize->delayed_runlists->type == AT_DATA)) {
+		/* Update the MFT data runlist later */
 		delayed_mft_data = resize->delayed_runlists;
 		resize->delayed_runlists = resize->delayed_runlists->next;
 	}
@@ -1492,7 +1492,7 @@ static void delayed_updates(ntfs_resize_t *resize)
 	nr_extents = resize->vol->mft_ni->nr_extents;
 	if (nr_extents > 2) {
 		printf("WARNING: The MFT is now severely fragmented"
-			" (%d extents)\n", nr_extents);
+				" (%d extents)\n", nr_extents);
 	}
 }
 
@@ -1512,7 +1512,7 @@ static void replace_later(ntfs_resize_t *resize, runlist *rl, runlist *head_rl)
 	int name_len;
 	ntfschar *attr_name;
 
-		/* save the attribute parameters, to be able to find it later */
+	/* save the attribute parameters, to be able to find it later */
 	a = resize->ctx->attr;
 	name_len = a->name_length;
 	attr_name = (ntfschar*)NULL;
@@ -1538,15 +1538,15 @@ static void replace_later(ntfs_resize_t *resize, runlist *rl, runlist *head_rl)
 		delayed->head_rl = head_rl;
 		/* Queue ahead of list if this is MFT or head is not MFT */
 		if ((delayed->mref == FILE_MFT)
-		    || !resize->delayed_runlists
-		    || (resize->delayed_runlists->mref != FILE_MFT)) {
+				|| !resize->delayed_runlists
+				|| (resize->delayed_runlists->mref != FILE_MFT)) {
 			delayed->next = resize->delayed_runlists;
 			resize->delayed_runlists = delayed;
 		} else {
 			/* Queue after all MFTs is this is not MFT */
 			previous = resize->delayed_runlists;
 			while (previous->next
-			    && (previous->next->mref == FILE_MFT))
+					&& (previous->next->mref == FILE_MFT))
 				previous = previous->next;
 			delayed->next = previous->next;
 			previous->next = delayed;
@@ -1591,7 +1591,7 @@ static int replace_attribute_runlist(ntfs_resize_t *resize, runlist *rl)
 
 		if (name_offs >= mp_offs)
 			err_exit("Attribute name is after mapping pairs! "
-				 "Please report!\n");
+					"Please report!\n");
 	}
 
 	/* CHECKME: don't trust mapping_pairs is always the last item in the
@@ -1609,22 +1609,22 @@ static int replace_attribute_runlist(ntfs_resize_t *resize, runlist *rl)
 		ntfs_log_verbose("Old mp size      : %d\n", l);
 		ntfs_log_verbose("New mp size      : %d\n", mp_size);
 		ntfs_log_verbose("Bytes in use     : %u\n", (unsigned int)
-				 le32_to_cpu(ctx->mrec->bytes_in_use));
+				le32_to_cpu(ctx->mrec->bytes_in_use));
 
 		next_attr = (char *)a + le32_to_cpu(a->length);
 		l = mp_size - l;
 
 		ntfs_log_verbose("Bytes in use new : %u\n", l + (unsigned int)
-				 le32_to_cpu(ctx->mrec->bytes_in_use));
+				le32_to_cpu(ctx->mrec->bytes_in_use));
 		ntfs_log_verbose("Bytes allocated  : %u\n", (unsigned int)
-				 le32_to_cpu(ctx->mrec->bytes_allocated));
+				le32_to_cpu(ctx->mrec->bytes_allocated));
 
 		remains_size = le32_to_cpu(ctx->mrec->bytes_in_use);
 		remains_size -= (next_attr - (char *)ctx->mrec);
 
 		ntfs_log_verbose("increase         : %d\n", l);
 		ntfs_log_verbose("shift            : %lld\n",
-				 (long long)remains_size);
+				(long long)remains_size);
 		if (le32_to_cpu(ctx->mrec->bytes_in_use) + l >
 				le32_to_cpu(ctx->mrec->bytes_allocated)) {
 #ifndef BAN_NEW_TEXT
@@ -1682,9 +1682,9 @@ static void set_max_free_zone(s64 length, s64 end, runlist_element *rle)
 }
 
 static int find_free_cluster(struct bitmap *bm,
-			     runlist_element *rle,
-			     s64 nr_vol_clusters,
-			     int hint)
+		runlist_element *rle,
+		s64 nr_vol_clusters,
+		int hint)
 {
 	/* FIXME: get rid of this 'static' variable */
 	static s64 pos = 0;
@@ -1728,7 +1728,7 @@ static int find_free_cluster(struct bitmap *bm,
 	if (rle->length < items && rle->length < max_free_cluster_range) {
 		max_free_cluster_range = rle->length;
 		ntfs_log_verbose("Max free range: %7lld     \n",
-				 (long long)max_free_cluster_range);
+				(long long)max_free_cluster_range);
 	}
 	pos = rle->lcn + items;
 	if (pos == nr_vol_clusters)
@@ -1739,9 +1739,9 @@ static int find_free_cluster(struct bitmap *bm,
 }
 
 static runlist *alloc_cluster(struct bitmap *bm,
-			      s64 items,
-			      s64 nr_vol_clusters,
-			      int hint)
+		s64 items,
+		s64 nr_vol_clusters,
+		int hint)
 {
 	runlist_element rle = {0, };
 	runlist *rl = NULL;
@@ -1993,25 +1993,25 @@ static void relocate_run(ntfs_resize_t *resize, runlist **rl, int run)
 
 	hint = (resize->mref == FILE_MFTMirr) ? 1 : 0;
 	if ((resize->mref == FILE_MFT)
-	    && (resize->ctx->attr->type == AT_DATA)
-	    && !run
-	    && resize->new_mft_start) {
+			&& (resize->ctx->attr->type == AT_DATA)
+			&& !run
+			&& resize->new_mft_start) {
 		relocate_rl = resize->new_mft_start;
 	} else
 		if (!(relocate_rl = alloc_cluster(&resize->lcn_bitmap,
-					lcn_length, new_vol_size, hint)))
+						lcn_length, new_vol_size, hint)))
 			perr_exit("Cluster allocation failed for %llu:%lld",
-				  (unsigned long long)resize->mref,
-				  (long long)lcn_length);
+					(unsigned long long)resize->mref,
+					(long long)lcn_length);
 
 	/* FIXME: check $MFTMirr DATA isn't multi-run (or support it) */
 	ntfs_log_verbose("Relocate record %7llu:0x%x:%08lld:0x%08llx:0x%08llx "
-			 "--> 0x%08llx\n", (unsigned long long)resize->mref,
-			 (unsigned int)le32_to_cpu(resize->ctx->attr->type),
-			 (long long)lcn_length,
-			 (unsigned long long)(*rl + run)->vcn,
-			 (unsigned long long)lcn,
-			 (unsigned long long)relocate_rl->lcn);
+			"--> 0x%08llx\n", (unsigned long long)resize->mref,
+			(unsigned int)le32_to_cpu(resize->ctx->attr->type),
+			(long long)lcn_length,
+			(unsigned long long)(*rl + run)->vcn,
+			(unsigned long long)lcn,
+			(unsigned long long)relocate_rl->lcn);
 
 	relocate_clusters(resize, relocate_rl, lcn);
 	rl_insert_at_run(rl, run, relocate_rl);
@@ -2019,11 +2019,11 @@ static void relocate_run(ntfs_resize_t *resize, runlist **rl, int run)
 	/* We don't release old clusters in the bitmap, that area isn't
 	   used by the allocator and will be truncated later on */
 
-		/* Do not free the relocated MFT start */
+	/* Do not free the relocated MFT start */
 	if ((resize->mref != FILE_MFT)
-	    || (resize->ctx->attr->type != AT_DATA)
-	    || run
-	    || !resize->new_mft_start)
+			|| (resize->ctx->attr->type != AT_DATA)
+			|| run
+			|| !resize->new_mft_start)
 		free(relocate_rl);
 
 	resize->dirty_inode = DIRTY_ATTRIB;
@@ -2053,10 +2053,10 @@ static void relocate_attribute(ntfs_resize_t *resize)
 		/* FIXME: ntfs_mapping_pairs_decompress should return error */
 		if (lcn < 0 || lcn_length <= 0)
 			err_exit("Corrupt runlist in MTF %llu attr %x LCN "
-				 "%llx length %llx\n",
-				 (unsigned long long)resize->mref,
-				 (unsigned int)le32_to_cpu(a->type),
-				 (long long)lcn, (long long)lcn_length);
+					"%llx length %llx\n",
+					(unsigned long long)resize->mref,
+					(unsigned int)le32_to_cpu(a->type),
+					(long long)lcn, (long long)lcn_length);
 
 		relocate_run(resize, &rl, i);
 	}
@@ -2084,7 +2084,7 @@ static int is_mftdata(ntfs_resize_t *resize)
 		return 1;
 
 	if (MREF_LE(resize->mrec->base_mft_record) == 0 &&
-	    MSEQNO_LE(resize->mrec->base_mft_record) != 0)
+			MSEQNO_LE(resize->mrec->base_mft_record) != 0)
 		return 1;
 
 	return 0;
@@ -2152,12 +2152,12 @@ static void relocate_attributes(ntfs_resize_t *resize, int do_mftdata)
 			continue;
 
 		if (resize->mref == FILE_Bitmap &&
-		    resize->ctx->attr->type == AT_DATA)
+				resize->ctx->attr->type == AT_DATA)
 			continue;
 
 		/* Do not relocate bad clusters */
 		if ((base_mref == FILE_BadClus)
-		    && (resize->ctx->attr->type == AT_DATA))
+				&& (resize->ctx->attr->type == AT_DATA))
 			continue;
 
 		relocate_attribute(resize);
@@ -2188,23 +2188,23 @@ static void relocate_inode(ntfs_resize_t *resize, MFT_REF mref, int do_mftdata)
 
 //		if (vol->dev->d_ops->sync(vol->dev) == -1)
 //			perr_exit("Failed to sync device");
-		/* relocate MFT during second step, even if not dirty */
+	/* relocate MFT during second step, even if not dirty */
 	if ((mref == FILE_MFT) && do_mftdata && resize->new_mft_start) {
 		s64 pos;
 
-			/* write the MFT own record at its new location */
+		/* write the MFT own record at its new location */
 		pos = (resize->new_mft_start->lcn
-					<< vol->cluster_size_bits)
+				<< vol->cluster_size_bits)
 			+ (FILE_MFT << vol->mft_record_size_bits);
 		if (!opt.ro_flag
-		    && (ntfs_mst_pwrite(vol->dev, pos, 1,
-				vol->mft_record_size, resize->mrec) != 1))
+				&& (ntfs_mst_pwrite(vol->dev, pos, 1,
+						vol->mft_record_size, resize->mrec) != 1))
 			perr_exit("Couldn't update MFT own record");
 	} else {
 		if ((resize->dirty_inode == DIRTY_INODE)
-		   && write_mft_record(vol, mref, resize->mrec)) {
+				&& write_mft_record(vol, mref, resize->mrec)) {
 			perr_exit("Couldn't update record %llu",
-						(unsigned long long)mref);
+					(unsigned long long)mref);
 		}
 	}
 }
@@ -2226,16 +2226,16 @@ static void relocate_inodes(ntfs_resize_t *resize)
 		perr_exit("ntfs_malloc failed");
 
 	nr_mft_records = resize->vol->mft_na->initialized_size >>
-			resize->vol->mft_record_size_bits;
+		resize->vol->mft_record_size_bits;
 
-		/*
-		 * If we need to relocate the first run of the MFT DATA,
-		 * do it now, to have a better chance of getting at least
-		 * 16 records in the first chunk. This is mandatory to be
-		 * later able to read an MFT extent in record 15.
-		 * Should this fail, we can stop with no damage, the volume
-		 * is still in its initial state.
-		 */
+	/*
+	 * If we need to relocate the first run of the MFT DATA,
+	 * do it now, to have a better chance of getting at least
+	 * 16 records in the first chunk. This is mandatory to be
+	 * later able to read an MFT extent in record 15.
+	 * Should this fail, we can stop with no damage, the volume
+	 * is still in its initial state.
+	 */
 	if (!resize->vol->mft_na->rl)
 		err_exit("Internal error : no runlist for $MFT\n");
 
@@ -2251,13 +2251,13 @@ static void relocate_inodes(ntfs_resize_t *resize)
 		 */
 		length = resize->vol->mft_na->rl->length;
 		if (ntfs_file_record_read(resize->vol, FILE_MFT,
-				&resize->mrec, NULL)
-		    || !(resize->ctx = attr_get_search_ctx(NULL,
-				resize->mrec))) {
+					&resize->mrec, NULL)
+				|| !(resize->ctx = attr_get_search_ctx(NULL,
+						resize->mrec))) {
 			err_exit("Could not read the base record of MFT\n");
 		}
 		while (!ntfs_attrs_walk(resize->ctx)
-		   && (resize->ctx->attr->type != AT_DATA)) { }
+				&& (resize->ctx->attr->type != AT_DATA)) { }
 		if (resize->ctx->attr->type == AT_DATA) {
 			sle64 high_le;
 
@@ -2271,9 +2271,9 @@ static void relocate_inodes(ntfs_resize_t *resize)
 		resize->new_mft_start = alloc_cluster(&resize->lcn_bitmap,
 				length, resize->new_volume_size, 0);
 		if (!resize->new_mft_start
-		    || (((resize->new_mft_start->length
-			<< resize->vol->cluster_size_bits)
-			    >> resize->vol->mft_record_size_bits) < 16)) {
+				|| (((resize->new_mft_start->length
+							<< resize->vol->cluster_size_bits)
+						>> resize->vol->mft_record_size_bits) < 16)) {
 			err_exit("Could not allocate 16 records in"
 					" the first MFT chunk\n");
 		}
@@ -2294,7 +2294,7 @@ static void relocate_inodes(ntfs_resize_t *resize)
 
 		if (highest_vcn == resize->mft_highest_vcn)
 			err_exit("Sanity check failed! Highest_vcn = %lld. "
-				 "Please report!\n", (long long)highest_vcn);
+					"Please report!\n", (long long)highest_vcn);
 	}
 done:
 	free(resize->mrec);
@@ -2407,7 +2407,7 @@ static void truncate_badclust_bad_attr(ntfs_resize_t *resize)
 		err_printf("Could not adjust the bad sector list\n");
 		exit(1);
 	}
-		/* Clear the sparse flags, even if there are bad clusters */
+	/* Clear the sparse flags, even if there are bad clusters */
 	na->ni->flags &= ~FILE_ATTR_SPARSE_FILE;
 	na->data_flags &= ~ATTR_IS_SPARSE;
 	ctx = resize->ctx;
@@ -2430,8 +2430,8 @@ static void truncate_badclust_bad_attr(ntfs_resize_t *resize)
  * per cluster of the shrunken volume.  Also it must be a of 8 bytes in size.
  */
 static void realloc_bitmap_data_attr(ntfs_resize_t *resize,
-				     runlist **rl,
-				     s64 nr_bm_clusters)
+		runlist **rl,
+		s64 nr_bm_clusters)
 {
 	s64 i;
 	ntfs_volume *vol = resize->vol;
@@ -2492,11 +2492,11 @@ static void truncate_bitmap_data_attr(ntfs_resize_t *resize)
 		realloc_lcn_bitmap(resize, bm_bsize);
 		realloc_bitmap_data_attr(resize, &rl, nr_bm_clusters);
 	}
-		/*
-		 * Delayed relocations may require cluster allocations
-		 * through the library, to hold added attribute lists,
-		 * be sure they will be within the new limits.
-		 */
+	/*
+	 * Delayed relocations may require cluster allocations
+	 * through the library, to hold added attribute lists,
+	 * be sure they will be within the new limits.
+	 */
 	lcnbmp_na = resize->vol->lcnbmp_na;
 	lcnbmp_na->data_size = bm_bsize;
 	lcnbmp_na->initialized_size = bm_bsize;
@@ -2524,7 +2524,7 @@ static void truncate_bitmap_data_attr(ntfs_resize_t *resize)
 	}
 
 	if (truncated) {
-			/* switch to the new bitmap runlist */
+		/* switch to the new bitmap runlist */
 		free(lcnbmp_na->rl);
 		lcnbmp_na->rl = rl;
 	}
@@ -2537,9 +2537,9 @@ static void truncate_bitmap_data_attr(ntfs_resize_t *resize)
  * (inode number).
  */
 static void lookup_data_attr(ntfs_volume *vol,
-			     MFT_REF mref,
-			     const char *aname,
-			     ntfs_attr_search_ctx **ctx)
+		MFT_REF mref,
+		const char *aname,
+		ntfs_attr_search_ctx **ctx)
 {
 	ntfs_inode *ni;
 	ntfschar *ustr;
@@ -2557,7 +2557,7 @@ static void lookup_data_attr(ntfs_volume *vol,
 	}
 
 	if (ntfs_attr_lookup(AT_DATA, ustr, len, CASE_SENSITIVE,
-			 0, NULL, 0, *ctx))
+				0, NULL, 0, *ctx))
 		perr_exit("ntfs_lookup_attr");
 
 	ntfs_ucsfree(ustr);
@@ -2599,22 +2599,22 @@ static int check_bad_sectors(ntfs_volume *vol)
 
 		badclusters += rl[i].length;
 		ntfs_log_verbose("Bad cluster: %#8llx - %#llx    (%lld)\n",
-				 (long long)rl[i].lcn,
-				 (long long)rl[i].lcn + rl[i].length - 1,
-				 (long long)rl[i].length);
+				(long long)rl[i].lcn,
+				(long long)rl[i].lcn + rl[i].length - 1,
+				(long long)rl[i].length);
 	}
 
 	if (badclusters) {
 		printf("%sThis software has detected that the disk has at least"
-		       " %lld bad sector%s.\n",
-		       !opt.badsectors ? NERR_PREFIX : "WARNING: ",
-		       (long long)badclusters, badclusters - 1 ? "s" : "");
+				" %lld bad sector%s.\n",
+				!opt.badsectors ? NERR_PREFIX : "WARNING: ",
+				(long long)badclusters, badclusters - 1 ? "s" : "");
 		if (!opt.badsectors) {
 			printf("%s", bad_sectors_warning_msg);
 			exit(1);
 		} else
 			printf("WARNING: Bad sectors can cause reliability "
-			       "problems and massive data loss!!!\n");
+					"problems and massive data loss!!!\n");
 	}
 
 	ntfs_attr_close(na);
@@ -2662,20 +2662,20 @@ static void truncate_bitmap_file(ntfs_resize_t *resize)
 	if (resize->new_mft_start) {
 		s64 pos;
 
-			/* write the MFT record at its new location */
+		/* write the MFT record at its new location */
 		pos = (resize->new_mft_start->lcn << vol->cluster_size_bits)
 			+ (FILE_Bitmap << vol->mft_record_size_bits);
 		if (!opt.ro_flag
-		    && (ntfs_mst_pwrite(vol->dev, pos, 1,
-				vol->mft_record_size, resize->ctx->mrec) != 1))
+				&& (ntfs_mst_pwrite(vol->dev, pos, 1,
+						vol->mft_record_size, resize->ctx->mrec) != 1))
 			perr_exit("Couldn't update $Bitmap at new location");
 	} else {
 		if (write_mft_record(vol, resize->ctx->ntfs_ino->mft_no,
-			     resize->ctx->mrec))
+					resize->ctx->mrec))
 			perr_exit("Couldn't update $Bitmap");
 	}
 
-		/* If successful, update cache and sync $Bitmap */
+	/* If successful, update cache and sync $Bitmap */
 	memcpy(vol->lcnbmp_ni->mrec,resize->ctx->mrec,vol->mft_record_size);
 	ntfs_inode_mark_dirty(vol->lcnbmp_ni);
 	NInoFileNameSetDirty(vol->lcnbmp_ni);
@@ -2742,29 +2742,29 @@ static void update_bootsector(ntfs_resize_t *r)
 		r->progress.flags |= NTFS_PROGBAR_SUPPRESS;
 		/* Be sure the MFTMirr holds the updated MFT runlist */
 		switch (r->mirr_from) {
-		case MIRR_MFT :
-			/* The late updates of MFT have not been synced */
-			ntfs_inode_sync(vol->mft_ni);
-			copy_clusters(r, r->mftmir_rl.lcn,
-				vol->mft_na->rl->lcn, r->mftmir_rl.length);
-			break;
-		case MIRR_NEWMFT :
-			copy_clusters(r, r->mftmir_rl.lcn,
-				 r->new_mft_start->lcn, r->mftmir_rl.length);
-			break;
-		default :
-			copy_clusters(r, r->mftmir_rl.lcn, r->mftmir_old,
-				      r->mftmir_rl.length);
-			break;
+			case MIRR_MFT :
+				/* The late updates of MFT have not been synced */
+				ntfs_inode_sync(vol->mft_ni);
+				copy_clusters(r, r->mftmir_rl.lcn,
+						vol->mft_na->rl->lcn, r->mftmir_rl.length);
+				break;
+			case MIRR_NEWMFT :
+				copy_clusters(r, r->mftmir_rl.lcn,
+						r->new_mft_start->lcn, r->mftmir_rl.length);
+				break;
+			default :
+				copy_clusters(r, r->mftmir_rl.lcn, r->mftmir_old,
+						r->mftmir_rl.length);
+				break;
 		}
 		if (r->mftmir_old)
 			bs->mftmirr_lcn = cpu_to_sle64(r->mftmir_rl.lcn);
 		r->progress.flags &= ~NTFS_PROGBAR_SUPPRESS;
 	}
-		/* Set the start of the relocated MFT */
+	/* Set the start of the relocated MFT */
 	if (r->new_mft_start) {
 		bs->mft_lcn = cpu_to_sle64(r->new_mft_start->lcn);
-			/* no more need for the new MFT start */
+		/* no more need for the new MFT start */
 		free(r->new_mft_start);
 		r->new_mft_start = (runlist_element*)NULL;
 	}
@@ -2775,18 +2775,18 @@ static void update_bootsector(ntfs_resize_t *r)
 	if (!opt.ro_flag)
 		if (vol->dev->d_ops->write(vol->dev, bs, bs_size) == -1)
 			perr_exit("write() error");
-		/*
-		 * Set the backup boot sector, if the target size is
-		 * either not defined or is defined with no multiplier
-		 * suffix and is a multiple of the sector size.
-		 * With these conditions we can be confident enough that
-		 * the partition size is already defined or it will be
-		 * later defined with the same exact value.
-		 */
+	/*
+	 * Set the backup boot sector, if the target size is
+	 * either not defined or is defined with no multiplier
+	 * suffix and is a multiple of the sector size.
+	 * With these conditions we can be confident enough that
+	 * the partition size is already defined or it will be
+	 * later defined with the same exact value.
+	 */
 	if (!opt.ro_flag && opt.reliable_size
-	    && !(opt.bytes % vol->sector_size)) {
+			&& !(opt.bytes % vol->sector_size)) {
 		if (vol->dev->d_ops->seek(vol->dev, opt.bytes
-				- vol->sector_size, SEEK_SET) == (off_t)-1)
+					- vol->sector_size, SEEK_SET) == (off_t)-1)
 			perr_exit("lseek");
 		if (vol->dev->d_ops->write(vol->dev, bs, bs_size) == -1)
 			perr_exit("write() error");
@@ -2827,10 +2827,10 @@ static void print_disk_usage(ntfs_volume *vol, s64 nr_used_clusters)
 	used = nr_used_clusters * vol->cluster_size;
 
 	/* WARNING: don't modify the text, external tools grep for it */
-        if (!opt.infombonly) {
+	if (!opt.infombonly) {
 		printf("Space in use       : %lld MB (%.1f%%)\n",
-	        	(long long)rounded_up_division(used, NTFS_MBYTE),
-	        	100.0 * ((float)used / total));
+				(long long)rounded_up_division(used, NTFS_MBYTE),
+				100.0 * ((float)used / total));
 	}
 }
 
@@ -2858,23 +2858,23 @@ static ntfs_volume *check_volume(void)
 
 		perr_printf("Opening '%s' as NTFS failed", opt.volume);
 		switch (err) {
-		case EINVAL :
-			printf(invalid_ntfs_msg, opt.volume);
-			break;
-		case EIO :
-			printf("%s", corrupt_volume_msg);
-			break;
-		case EPERM :
-			printf("%s", hibernated_volume_msg);
-			break;
-		case EOPNOTSUPP :
-			printf("%s", unclean_journal_msg);
-			break;
-		case EBUSY :
-			printf("%s", opened_volume_msg);
-			break;
-		default :
-			break;
+			case EINVAL :
+				printf(invalid_ntfs_msg, opt.volume);
+				break;
+			case EIO :
+				printf("%s", corrupt_volume_msg);
+				break;
+			case EPERM :
+				printf("%s", hibernated_volume_msg);
+				break;
+			case EOPNOTSUPP :
+				printf("%s", unclean_journal_msg);
+				break;
+			case EBUSY :
+				printf("%s", opened_volume_msg);
+				break;
+			default :
+				break;
 		}
 		exit(1);
 	}
@@ -2897,27 +2897,27 @@ static ntfs_volume *mount_volume(void)
 	if (ntfs_check_if_mounted(opt.volume, &mntflag)) {
 		perr_printf("Failed to check '%s' mount state", opt.volume);
 		printf("Probably /etc/mtab is missing. It's too risky to "
-		       "continue. You might try\nan another Linux distro.\n");
+				"continue. You might try\nan another Linux distro.\n");
 		exit(1);
 	}
 	if (mntflag & NTFS_MF_MOUNTED) {
 		if (!(mntflag & NTFS_MF_READONLY))
 			err_exit("Device '%s' is mounted read-write. "
-				 "You must 'umount' it first.\n", opt.volume);
+					"You must 'umount' it first.\n", opt.volume);
 		if (!opt.ro_flag)
 			err_exit("Device '%s' is mounted. "
-				 "You must 'umount' it first.\n", opt.volume);
+					"You must 'umount' it first.\n", opt.volume);
 	}
 	vol = check_volume();
 
 	if (vol->flags & VOLUME_IS_DIRTY)
 		if (opt.force-- <= 0)
 			err_exit("Volume is scheduled for check.\nRun chkdsk /f"
-				 " and please try again, or see option -f.\n");
+					" and please try again, or see option -f.\n");
 
 	if (NTFS_MAX_CLUSTER_SIZE < vol->cluster_size)
 		err_exit("Cluster size %u is too large!\n",
-			(unsigned int)vol->cluster_size);
+				(unsigned int)vol->cluster_size);
 
 	if (ntfs_volume_get_free_space(vol))
 		err_exit("Failed to update the free space\n");
@@ -2932,9 +2932,9 @@ static ntfs_volume *mount_volume(void)
 
 	if (!opt.infombonly) {
 		printf("Cluster size       : %u bytes\n",
-			(unsigned int)vol->cluster_size);
+				(unsigned int)vol->cluster_size);
 		print_vol_size("Current volume size",
-			vol_size(vol, vol->nr_clusters));
+				vol_size(vol, vol->nr_clusters));
 	}
 
 	return vol;
@@ -2988,7 +2988,7 @@ static void check_resize_constraints(ntfs_resize_t *resize)
 
 	if (resize->inuse == resize->vol->nr_clusters)
 		err_exit("Volume is full. To shrink it, "
-			 "delete unused files.\n");
+				"delete unused files.\n");
 
 	if (opt.info || opt.infombonly)
 		return;
@@ -2996,14 +2996,14 @@ static void check_resize_constraints(ntfs_resize_t *resize)
 	/* FIXME: reserve some extra space so Windows can boot ... */
 	if (new_size < resize->inuse)
 		err_exit("New size can't be less than the space already"
-			 " occupied by data.\nYou either need to delete unused"
-			 " files or see the -i option.\n");
+				" occupied by data.\nYou either need to delete unused"
+				" files or see the -i option.\n");
 
 	if (new_size <= resize->last_unsupp)
 		err_exit("The fragmentation type, you have, isn't "
-			 "supported yet. Rerun ntfsresize\nwith "
-			 "the -i option to estimate the smallest "
-			 "shrunken volume size supported.\n");
+				"supported yet. Rerun ntfsresize\nwith "
+				"the -i option to estimate the smallest "
+				"shrunken volume size supported.\n");
 
 	print_num_of_relocations(resize);
 }
@@ -3023,10 +3023,10 @@ static void check_cluster_allocation(ntfs_volume *vol, ntfsck_t *fsck)
 		err_printf("Filesystem check failed!\n");
 		if (fsck->outsider)
 			err_printf("%d clusters are referenced outside "
-				   "of the volume.\n", fsck->outsider);
+					"of the volume.\n", fsck->outsider);
 		if (fsck->multi_ref)
 			err_printf("%d clusters are referenced multiple"
-				   " times.\n", fsck->multi_ref);
+					" times.\n", fsck->multi_ref);
 		printf("%s", corrupt_volume_msg);
 		exit(1);
 	}
@@ -3085,30 +3085,30 @@ typedef struct EXPAND {
  */
 
 static ATTR_RECORD *find_attr(MFT_RECORD *mrec, ATTR_TYPES type,
-					ntfschar *name, int namelen)
+		ntfschar *name, int namelen)
 {
 	ATTR_RECORD *a;
 	u32 offset;
 	ntfschar *attrname;
 
-			/* fetch the requested attribute */
+	/* fetch the requested attribute */
 	offset = le16_to_cpu(mrec->attrs_offset);
 	a = (ATTR_RECORD*)((char*)mrec + offset);
 	attrname = (ntfschar*)((char*)a + le16_to_cpu(a->name_offset));
 	while ((a->type != AT_END)
-	    && ((a->type != type)
-		|| (a->name_length != namelen)
-		|| (namelen && memcmp(attrname,name,2*namelen)))
-	    && (offset < le32_to_cpu(mrec->bytes_in_use))) {
+			&& ((a->type != type)
+				|| (a->name_length != namelen)
+				|| (namelen && memcmp(attrname,name,2*namelen)))
+			&& (offset < le32_to_cpu(mrec->bytes_in_use))) {
 		offset += le32_to_cpu(a->length);
 		a = (ATTR_RECORD*)((char*)mrec + offset);
 		if (namelen)
 			attrname = (ntfschar*)((char*)a
-				+ le16_to_cpu(a->name_offset));
+					+ le16_to_cpu(a->name_offset));
 	}
 	if ((a->type != type)
-	    || (a->name_length != namelen)
-	    || (namelen && memcmp(attrname,name,2*namelen)))
+			|| (a->name_length != namelen)
+			|| (namelen && memcmp(attrname,name,2*namelen)))
 		a = (ATTR_RECORD*)NULL;
 	return (a);
 }
@@ -3120,7 +3120,7 @@ static ATTR_RECORD *find_attr(MFT_RECORD *mrec, ATTR_TYPES type,
  */
 
 static ATTR_RECORD *get_unnamed_attr(expand_t *expand, ATTR_TYPES type,
-							s64 inum)
+		s64 inum)
 {
 	ntfs_volume *vol;
 	ATTR_RECORD *a;
@@ -3141,7 +3141,7 @@ static ATTR_RECORD *get_unnamed_attr(expand_t *expand, ATTR_TYPES type,
 		a = find_attr(expand->mrec, type, NULL, 0);
 		found = a && (a->type == type) && !a->name_length;
 	}
-		/* not finding the attribute list is not an error */
+	/* not finding the attribute list is not an error */
 	if (!found && (type != AT_ATTRIBUTE_LIST)) {
 		err_printf("Could not find attribute 0x%lx in inode %lld\n",
 				(long)le32_to_cpu(type), (long long)inum);
@@ -3157,7 +3157,7 @@ static ATTR_RECORD *get_unnamed_attr(expand_t *expand, ATTR_TYPES type,
  */
 
 static ATTR_RECORD *read_and_get_attr(expand_t *expand, ATTR_TYPES type,
-				s64 inum, ntfschar *name, int namelen)
+		s64 inum, ntfschar *name, int namelen)
 {
 	ntfs_volume *vol;
 	ATTR_RECORD *a;
@@ -3194,13 +3194,13 @@ static s64 get_data_size(expand_t *expand, s64 inum)
 	s64 size;
 
 	size = 0;
-			/* get the size of unnamed $DATA */
+	/* get the size of unnamed $DATA */
 	a = get_unnamed_attr(expand, AT_DATA, inum);
 	if (a && a->non_resident)
 		size = sle64_to_cpu(a->allocated_size);
 	if (!size) {
 		err_printf("Bad record %lld, could not get its size\n",
-					(long long)inum);
+				(long long)inum);
 	}
 	return (size);
 }
@@ -3222,25 +3222,25 @@ static u8 *get_mft_bitmap(expand_t *expand)
 
 	expand->mft_bitmap = (u8*)NULL;
 	vol = expand->vol;
-			/* get the runlist of unnamed bitmap */
+	/* get the runlist of unnamed bitmap */
 	a = get_unnamed_attr(expand, AT_BITMAP, FILE_MFT);
 	ok = TRUE;
 	bitmap_size = sle64_to_cpu(a->allocated_size);
 	if (a
-	    && a->non_resident
-	    && ((bitmap_size << (vol->mft_record_size_bits + 3))
-			>= expand->mft_size)) {
-// rl in extent not implemented
+			&& a->non_resident
+			&& ((bitmap_size << (vol->mft_record_size_bits + 3))
+				>= expand->mft_size)) {
+		// rl in extent not implemented
 		rl = ntfs_mapping_pairs_decompress(expand->vol, a,
-						(runlist_element*)NULL);
+				(runlist_element*)NULL);
 		expand->mft_bitmap = (u8*)ntfs_calloc(bitmap_size);
 		if (rl && expand->mft_bitmap) {
 			for (prl=rl; prl->length && ok; prl++) {
 				lseek_to_cluster(vol,
-					prl->lcn + expand->cluster_increment);
+						prl->lcn + expand->cluster_increment);
 				ok = !read_all(vol->dev, expand->mft_bitmap
-					+ (prl->vcn << vol->cluster_size_bits),
-					prl->length << vol->cluster_size_bits);
+						+ (prl->vcn << vol->cluster_size_bits),
+						prl->length << vol->cluster_size_bits);
 			}
 			if (!ok) {
 				err_printf("Could not read the MFT bitmap\n");
@@ -3278,11 +3278,11 @@ static int check_expand_bad_sectors(expand_t *expand, ATTR_RECORD *a)
 		res = -1;
 	} else {
 
-	/*
-	 * FIXME: The below would be partial for non-base records in the
-	 * not yet supported multi-record case. Alternatively use audited
-	 * ntfs_attr_truncate after an umount & mount.
-	 */
+		/*
+		 * FIXME: The below would be partial for non-base records in the
+		 * not yet supported multi-record case. Alternatively use audited
+		 * ntfs_attr_truncate after an umount & mount.
+		 */
 		rl = ntfs_mapping_pairs_decompress(expand->vol, a, NULL);
 		if (!rl) {
 			perr_printf("Decompressing $BadClust:"
@@ -3290,9 +3290,9 @@ static int check_expand_bad_sectors(expand_t *expand, ATTR_RECORD *a)
 			res = -1;
 		} else {
 			for (i = 0; rl[i].length; i++) {
-		/* CHECKME: LCN_RL_NOT_MAPPED check isn't needed */
+				/* CHECKME: LCN_RL_NOT_MAPPED check isn't needed */
 				if (rl[i].lcn == LCN_HOLE
-				    || rl[i].lcn == LCN_RL_NOT_MAPPED)
+						|| rl[i].lcn == LCN_RL_NOT_MAPPED)
 					continue;
 
 				badclusters += rl[i].length;
@@ -3300,27 +3300,27 @@ static int check_expand_bad_sectors(expand_t *expand, ATTR_RECORD *a)
 						"    (%lld)\n",
 						(long long)rl[i].lcn,
 						(long long)rl[i].lcn
-							+ rl[i].length - 1,
+						+ rl[i].length - 1,
 						(long long)rl[i].length);
 			}
 
 			if (badclusters) {
 				err_printf("%sThis software has detected that"
-					" the disk has at least"
-					" %lld bad sector%s.\n",
-					!opt.badsectors ? NERR_PREFIX
-							: "WARNING: ",
-					(long long)badclusters,
-					badclusters - 1 ? "s" : "");
+						" the disk has at least"
+						" %lld bad sector%s.\n",
+						!opt.badsectors ? NERR_PREFIX
+						: "WARNING: ",
+						(long long)badclusters,
+						badclusters - 1 ? "s" : "");
 				if (!opt.badsectors) {
 					err_printf("%s", bad_sectors_warning_msg);
 					res = -1;
 				} else
 					err_printf("WARNING: Bad sectors can cause"
-						" reliability problems"
-						" and massive data loss!!!\n");
+							" reliability problems"
+							" and massive data loss!!!\n");
 			}
-		free(rl);
+			free(rl);
 		}
 	}
 	return (res);
@@ -3333,8 +3333,8 @@ static int check_expand_bad_sectors(expand_t *expand, ATTR_RECORD *a)
 static int check_expand_constraints(expand_t *expand)
 {
 	static ntfschar bad[] = {
-			const_cpu_to_le16('$'), const_cpu_to_le16('B'),
-			const_cpu_to_le16('a'), const_cpu_to_le16('d')
+		const_cpu_to_le16('$'), const_cpu_to_le16('B'),
+		const_cpu_to_le16('a'), const_cpu_to_le16('d')
 	} ;
 	ATTR_RECORD *a;
 	runlist_element *rl;
@@ -3345,12 +3345,12 @@ static int check_expand_constraints(expand_t *expand)
 	if (opt.verbose)
 		ntfs_log_verbose("Checking for expansion constraints...\n");
 	res = 0;
-		/* extents for $MFT are not supported */
+	/* extents for $MFT are not supported */
 	if (get_unnamed_attr(expand, AT_ATTRIBUTE_LIST, FILE_MFT)) {
 		err_printf("The $MFT is too much fragmented\n");
 		res = -1;
 	}
-		/* fragmented $MFTMirr is not supported */
+	/* fragmented $MFTMirr is not supported */
 	a = get_unnamed_attr(expand, AT_DATA, FILE_MFTMirr);
 	if (a) {
 		rl = ntfs_mapping_pairs_decompress(expand->vol, a, NULL);
@@ -3360,7 +3360,7 @@ static int check_expand_constraints(expand_t *expand)
 		}
 		free(rl);
 	}
-		/* fragmented $Boot is not supported */
+	/* fragmented $Boot is not supported */
 	a = get_unnamed_attr(expand, AT_DATA, FILE_Boot);
 	if (a) {
 		rl = ntfs_mapping_pairs_decompress(expand->vol, a, NULL);
@@ -3370,15 +3370,15 @@ static int check_expand_constraints(expand_t *expand)
 		}
 		free(rl);
 	}
-		/* Volume should not be marked dirty */
+	/* Volume should not be marked dirty */
 	a = get_unnamed_attr(expand, AT_VOLUME_INFORMATION, FILE_Volume);
 	if (a) {
 		volinfo = (VOLUME_INFORMATION*)
-				(le16_to_cpu(a->value_offset) + (char*)a);
+			(le16_to_cpu(a->value_offset) + (char*)a);
 		flags = volinfo->flags;
 		if ((flags & VOLUME_IS_DIRTY) && (opt.force-- <= 0)) {
 			err_printf("Volume is scheduled for check.\nRun chkdsk /f"
-			 " and please try again, or see option -f.\n");
+					" and please try again, or see option -f.\n");
 			res = -1;
 		}
 	} else {
@@ -3386,11 +3386,11 @@ static int check_expand_constraints(expand_t *expand)
 		res = -1;
 	}
 
-		/* There should not be too many bad clusters */
+	/* There should not be too many bad clusters */
 	a = read_and_get_attr(expand, AT_DATA, FILE_BadClus, bad, 4);
 	if (!a || !a->non_resident) {
 		err_printf("Resident attribute in $BadClust! Please report to "
-			 	"%s\n", NTFS_DEV_LIST);
+				"%s\n", NTFS_DEV_LIST);
 		res = -1;
 	} else
 		if (check_expand_bad_sectors(expand,a))
@@ -3423,15 +3423,15 @@ static BOOL can_expand(expand_t *expand, ntfs_volume *vol)
 
 	ok = TRUE;
 	old_sector_count = vol->nr_clusters
-			<< (vol->cluster_size_bits - vol->sector_size_bits);
-		/* do not include the space lost near the end */
+		<< (vol->cluster_size_bits - vol->sector_size_bits);
+	/* do not include the space lost near the end */
 	expand->cluster_increment = (expand->new_sectors
-			 >> (vol->cluster_size_bits - vol->sector_size_bits))
-				- vol->nr_clusters;
+			>> (vol->cluster_size_bits - vol->sector_size_bits))
+		- vol->nr_clusters;
 	expand->byte_increment = expand->cluster_increment
-					<< vol->cluster_size_bits;
+		<< vol->cluster_size_bits;
 	expand->sector_increment = expand->byte_increment
-					>> vol->sector_size_bits;
+		>> vol->sector_size_bits;
 	printf("Sectors allocated to volume :  old %lld current %lld difference %lld\n",
 			(long long)old_sector_count,
 			(long long)(old_sector_count + expand->sector_increment),
@@ -3439,26 +3439,26 @@ static BOOL can_expand(expand_t *expand, ntfs_volume *vol)
 	printf("Clusters allocated to volume : old %lld current %lld difference %lld\n",
 			(long long)vol->nr_clusters,
 			(long long)(vol->nr_clusters
-					+ expand->cluster_increment),
+				+ expand->cluster_increment),
 			(long long)expand->cluster_increment);
-		/* the new size must be bigger */
+	/* the new size must be bigger */
 	if ((expand->sector_increment < 0)
-	    || (!expand->sector_increment && !opt.info)) {
+			|| (!expand->sector_increment && !opt.info)) {
 		err_printf("Cannot expand volume : the partition has not been expanded\n");
 		ok = FALSE;
 	}
-			/* the old bootsector must match the backup */
+	/* the old bootsector must match the backup */
 	got = ntfs_pread(expand->vol->dev, expand->byte_increment,
-				vol->sector_size, expand->mrec);
+			vol->sector_size, expand->mrec);
 	if ((got != vol->sector_size)
-	    || memcmp(expand->bootsector,expand->mrec,vol->sector_size)) {
+			|| memcmp(expand->bootsector,expand->mrec,vol->sector_size)) {
 		err_printf("The backup bootsector does not match the old bootsector\n");
 		ok = FALSE;
 	}
 	if (ok) {
-			/* read the first MFT record, to get the MFT size */
+		/* read the first MFT record, to get the MFT size */
 		expand->mft_size = get_data_size(expand, FILE_MFT);
-			/* read the 6th MFT record, to get the $Boot size */
+		/* read the 6th MFT record, to get the $Boot size */
 		expand->boot_size = get_data_size(expand, FILE_Boot);
 		if (!expand->mft_size || !expand->boot_size) {
 			ok = FALSE;
@@ -3472,39 +3472,39 @@ static BOOL can_expand(expand_t *expand, ntfs_volume *vol)
 			 */
 			if (opt.info) {
 				clusters = (((expand->original_sectors + 1)
-						<< vol->sector_size_bits)
+							<< vol->sector_size_bits)
 						+ expand->mft_size
 						+ expand->boot_size)
-						    >> vol->cluster_size_bits;
+					>> vol->cluster_size_bits;
 				bitmap_bits = ((clusters + 1)
-						    << vol->cluster_size_bits)
-						/ (vol->cluster_size + 1);
+						<< vol->cluster_size_bits)
+					/ (vol->cluster_size + 1);
 			} else {
 				bitmap_bits = (expand->new_sectors + 1)
-			    		>> (vol->cluster_size_bits
-						- vol->sector_size_bits);
+					>> (vol->cluster_size_bits
+							- vol->sector_size_bits);
 			}
 			/* byte size must be a multiple of 8 */
 			expand->bitmap_size = ((bitmap_bits + 63) >> 3) & -8;
 			expand->bitmap_allocated = ((expand->bitmap_size - 1)
-				| (vol->cluster_size - 1)) + 1;
+					| (vol->cluster_size - 1)) + 1;
 			expand->mft_lcn = (expand->boot_size
 					+ expand->bitmap_allocated)
-						>> vol->cluster_size_bits;
+				>> vol->cluster_size_bits;
 			/*
 			 * Check whether $Boot, $Bitmap and $MFT can fit
 			 * into the expanded space.
 			 */
 			sectors_needed = (expand->boot_size + expand->mft_size
-					 + expand->bitmap_allocated)
-						>> vol->sector_size_bits;
+					+ expand->bitmap_allocated)
+				>> vol->sector_size_bits;
 			if (!opt.info
-			    && (sectors_needed >= expand->sector_increment)) {
+					&& (sectors_needed >= expand->sector_increment)) {
 				err_printf("The expanded space cannot hold the new metadata\n");
 				err_printf("   expanded space %lld sectors\n",
-					(long long)expand->sector_increment);
+						(long long)expand->sector_increment);
 				err_printf("   needed space %lld sectors\n",
-					(long long)sectors_needed);
+						(long long)sectors_needed);
 				ok = FALSE;
 			}
 		}
@@ -3515,32 +3515,32 @@ static BOOL can_expand(expand_t *expand, ntfs_volume *vol)
 		if (expand->byte_increment & (vol->cluster_size - 1)) {
 			err_printf("Cannot expand volume without copying the data :\n");
 			err_printf("There are %d sectors in a cluster,\n",
-				(int)(vol->cluster_size/vol->sector_size));
+					(int)(vol->cluster_size/vol->sector_size));
 			err_printf("  and the sector difference is not a multiple of %d\n",
-				(int)(vol->cluster_size/vol->sector_size));
+					(int)(vol->cluster_size/vol->sector_size));
 			advice = expand->byte_increment & ~vol->cluster_size;
 			ok = FALSE;
 		}
 		if (!ok)
 			err_printf("You should increase the beginning of partition by %d sectors\n",
-				(int)((expand->byte_increment - advice)
-					>> vol->sector_size_bits));
+					(int)((expand->byte_increment - advice)
+						>> vol->sector_size_bits));
 	}
 	if (ok)
 		ok = !check_expand_constraints(expand);
 	if (ok && opt.info) {
 		minimum_size = (expand->original_sectors
-						<< vol->sector_size_bits)
-					+ expand->boot_size
-					+ expand->mft_size
-					+ expand->bitmap_allocated;
+				<< vol->sector_size_bits)
+			+ expand->boot_size
+			+ expand->mft_size
+			+ expand->bitmap_allocated;
 
 		printf("You must expand the partition to at least %lld bytes,\n",
-			(long long)(minimum_size + vol->sector_size));
+				(long long)(minimum_size + vol->sector_size));
 		printf("and you may add a multiple of %ld bytes to this size.\n",
-			(long)vol->cluster_size);
+				(long)vol->cluster_size);
 		printf("The minimum NTFS volume size is %lld bytes\n",
-			(long long)minimum_size);
+				(long long)minimum_size);
 		ok = FALSE;
 	}
 	return (ok);
@@ -3556,9 +3556,9 @@ static int set_bitmap(expand_t *expand, runlist_element *rl)
 	res = -1;
 	reallocated = FALSE;
 	if ((rl->lcn >= 0)
-	    && (rl->length > 0)
-	    && ((rl->lcn + rl->length)
-		    <= (expand->vol->nr_clusters + expand->cluster_increment))) {
+			&& (rl->length > 0)
+			&& ((rl->lcn + rl->length)
+				<= (expand->vol->nr_clusters + expand->cluster_increment))) {
 		lcn = rl->lcn;
 		lcn_end = lcn + rl->length;
 		while ((lcn & 7) && (lcn < lcn_end)) {
@@ -3581,13 +3581,13 @@ static int set_bitmap(expand_t *expand, runlist_element *rl)
 		}
 		if (reallocated)
 			err_printf("Reallocated cluster found in run"
-				" lcn 0x%llx length %lld\n",
-				(long long)rl->lcn,(long long)rl->length);
+					" lcn 0x%llx length %lld\n",
+					(long long)rl->lcn,(long long)rl->length);
 		else
 			res = 0;
 	} else {
 		err_printf("Bad run : lcn 0x%llx length %lld\n",
-			(long long)rl->lcn,(long long)rl->length);
+				(long long)rl->lcn,(long long)rl->length);
 	}
 	return (res);
 }
@@ -3647,12 +3647,12 @@ static int write_bitmap(expand_t *expand)
 	}
 	if (opt.verbose)
 		ntfs_log_verbose("Writing the new bitmap...\n");
-		/* write the full allocation (to avoid having to read) */
+	/* write the full allocation (to avoid having to read) */
 	if (opt.ro_flag)
 		bw = expand->bitmap_allocated;
 	else
 		bw = ntfs_pwrite(vol->dev, expand->boot_size,
-					expand->bitmap_allocated, expand->bitmap);
+				expand->bitmap_allocated, expand->bitmap);
 	if (bw == (s64)expand->bitmap_allocated)
 		res = 0;
 	else {
@@ -3691,12 +3691,12 @@ static int copy_mftmirr(expand_t *expand)
 	vol = expand->vol;
 	res = 0;
 	for (inum=FILE_MFT; !res && (inum<=FILE_Volume); inum++) {
-			/* read the new $MFT */
+		/* read the new $MFT */
 		pos = (expand->mft_lcn << vol->cluster_size_bits)
 			+ (inum << vol->mft_record_size_bits);
 		if (ntfs_mst_pread(vol->dev, pos, 1, vol->mft_record_size,
-				expand->mrec) == 1) {
-				/* overwrite the old $MFTMirr */
+					expand->mrec) == 1) {
+			/* overwrite the old $MFTMirr */
 			pos = (vol->mftmirr_lcn << vol->cluster_size_bits)
 				+ (inum << vol->mft_record_size_bits)
 				+ expand->byte_increment;
@@ -3707,8 +3707,8 @@ static int copy_mftmirr(expand_t *expand)
 				usn = -2;
 			*pusn = cpu_to_le16(usn);
 			if (!opt.ro_flag
-			    && (ntfs_mst_pwrite(vol->dev, pos, 1,
-				    vol->mft_record_size, expand->mrec) != 1)) {
+					&& (ntfs_mst_pwrite(vol->dev, pos, 1,
+							vol->mft_record_size, expand->mrec) != 1)) {
 				err_printf("Failed to overwrite the old $MFTMirr\n");
 				res = -1;
 			}
@@ -3747,15 +3747,15 @@ static int copy_boot(expand_t *expand)
 	res = 0;
 	buf = (char*)ntfs_malloc(vol->cluster_size);
 	if (buf) {
-			/* set the new volume parameters in the bootsector */
+		/* set the new volume parameters in the bootsector */
 		bs = (NTFS_BOOT_SECTOR*)expand->bootsector;
 		bs->number_of_sectors = cpu_to_sle64(expand->new_sectors);
 		bs->mft_lcn = cpu_to_sle64(expand->mft_lcn);
 		mftmirr_lcn = vol->mftmirr_lcn + expand->cluster_increment;
 		bs->mftmirr_lcn = cpu_to_sle64(mftmirr_lcn);
-			/* the hidden sectors are needed to boot into windows */
+		/* the hidden sectors are needed to boot into windows */
 		memcpy(&hidden_sectors_le,&bs->bpb.hidden_sectors,4);
-				/* alignment messed up on the Sparc */
+		/* alignment messed up on the Sparc */
 		if (hidden_sectors_le) {
 			hidden_sectors = le32_to_cpu(hidden_sectors_le);
 			if (hidden_sectors >= expand->sector_increment)
@@ -3774,7 +3774,7 @@ static int copy_boot(expand_t *expand)
 					memcpy(buf, expand->bootsector, vol->sector_size);
 				lseek_to_cluster(vol, written);
 				if (!opt.ro_flag
-				    && write_all(vol->dev, buf, vol->cluster_size)) {
+						&& write_all(vol->dev, buf, vol->cluster_size)) {
 					err_printf("Failed to write the new $Boot\n");
 					res = -1;
 				} else
@@ -3800,7 +3800,7 @@ static int copy_boot(expand_t *expand)
  */
 
 static void delayed_expand(ntfs_volume *vol, struct DELAYED *delayed,
-			struct progress_bar *progress)
+		struct progress_bar *progress)
 {
 	unsigned long count;
 	struct DELAYED *current;
@@ -3810,11 +3810,11 @@ static void delayed_expand(ntfs_volume *vol, struct DELAYED *delayed,
 		if (opt.verbose)
 			ntfs_log_verbose("Delayed updating of overflowing runlists...\n");
 		count = 0;
-			/* count by steps because of inappropriate resolution */
+		/* count by steps because of inappropriate resolution */
 		for (current=delayed; current; current=current->next)
 			count += step;
 		progress_init(progress, 0, count, 100,
-					(opt.show_progress ? NTFS_PROGBAR : 0));
+				(opt.show_progress ? NTFS_PROGBAR : 0));
 		current = delayed;
 		count = 0;
 		while (current) {
@@ -3867,7 +3867,7 @@ static int expand_index_sizes(expand_t *expand)
  */
 
 static int update_runlist(expand_t *expand, s64 inum,
-				ATTR_RECORD *a, runlist_element *rl)
+		ATTR_RECORD *a, runlist_element *rl)
 {
 	ntfs_resize_t resize = {0, };
 	ntfs_attr_search_ctx ctx;
@@ -3884,7 +3884,7 @@ static int update_runlist(expand_t *expand, s64 inum,
 	head_rl = rl;
 	rl_fixup(&rl);
 	if ((mp_size = ntfs_get_size_for_mapping_pairs(vol, rl,
-				0, INT_MAX)) == -1)
+					0, INT_MAX)) == -1)
 		perr_exit("ntfs_get_size_for_mapping_pairs");
 
 	if (a->name_length) {
@@ -3893,7 +3893,7 @@ static int update_runlist(expand_t *expand, s64 inum,
 
 		if (name_offs >= mp_offs)
 			err_exit("Attribute name is after mapping pairs! "
-				 "Please report!\n");
+					"Please report!\n");
 	}
 
 	/* CHECKME: don't trust mapping_pairs is always the last item in the
@@ -3911,26 +3911,26 @@ static int update_runlist(expand_t *expand, s64 inum,
 		ntfs_log_verbose("Old mp size      : %d\n", l);
 		ntfs_log_verbose("New mp size      : %d\n", mp_size);
 		ntfs_log_verbose("Bytes in use     : %u\n", (unsigned int)
-				 le32_to_cpu(mrec->bytes_in_use));
+				le32_to_cpu(mrec->bytes_in_use));
 
 		next_attr = (char *)a + le32_to_cpu(a->length);
 		l = mp_size - l;
 
 		ntfs_log_verbose("Bytes in use new : %u\n", l + (unsigned int)
-				 le32_to_cpu(mrec->bytes_in_use));
+				le32_to_cpu(mrec->bytes_in_use));
 		ntfs_log_verbose("Bytes allocated  : %u\n", (unsigned int)
-				 le32_to_cpu(mrec->bytes_allocated));
+				le32_to_cpu(mrec->bytes_allocated));
 
 		remains_size = le32_to_cpu(mrec->bytes_in_use);
 		remains_size -= (next_attr - (char *)mrec);
 
 		ntfs_log_verbose("increase         : %d\n", l);
 		ntfs_log_verbose("shift            : %lld\n",
-				 (long long)remains_size);
+				(long long)remains_size);
 		if (le32_to_cpu(mrec->bytes_in_use) + l >
 				le32_to_cpu(mrec->bytes_allocated)) {
 			ntfs_log_verbose("Queuing expansion for later processing\n");
-				/* hack for reusing unmodified old code ! */
+			/* hack for reusing unmodified old code ! */
 			resize.ctx = &ctx;
 			ctx.attr = a;
 			ctx.mrec = mrec;
@@ -4008,14 +4008,14 @@ static int rebase_runlists(expand_t *expand, s64 inum)
 			&& (offset < le32_to_cpu(mrec->bytes_in_use))) {
 		if (a->non_resident) {
 			rl = ntfs_mapping_pairs_decompress(expand->vol, a,
-						(runlist_element*)NULL);
+					(runlist_element*)NULL);
 			if (rl) {
 				for (prl=rl; prl->length; prl++)
 					if (prl->lcn >= 0) {
 						prl->lcn += expand->cluster_increment;
 						if (set_bitmap(expand,prl))
 							res = -1;
-						}
+					}
 				if (update_runlist(expand,inum,a,rl)) {
 					ntfs_log_verbose("Runlist updating has to be delayed\n");
 				} else
@@ -4061,30 +4061,30 @@ static runlist_element *rebase_runlists_meta(expand_t *expand, s64 inum)
 	vol = expand->vol;
 	mrec = expand->mrec;
 	switch (inum) {
-	case FILE_Boot :
-		lcn = 0;
-		lth = expand->boot_size >> vol->cluster_size_bits;
-		data_size = expand->boot_size;
-		break;
-	case FILE_Bitmap :
-		lcn = expand->boot_size >> vol->cluster_size_bits;
-		lth = expand->bitmap_allocated >> vol->cluster_size_bits;
-		data_size = expand->bitmap_size;
-		break;
-	case FILE_MFT :
-		lcn = (expand->boot_size + expand->bitmap_allocated)
+		case FILE_Boot :
+			lcn = 0;
+			lth = expand->boot_size >> vol->cluster_size_bits;
+			data_size = expand->boot_size;
+			break;
+		case FILE_Bitmap :
+			lcn = expand->boot_size >> vol->cluster_size_bits;
+			lth = expand->bitmap_allocated >> vol->cluster_size_bits;
+			data_size = expand->bitmap_size;
+			break;
+		case FILE_MFT :
+			lcn = (expand->boot_size + expand->bitmap_allocated)
 				>> vol->cluster_size_bits;
-		lth = expand->mft_size >> vol->cluster_size_bits;
-		data_size = expand->mft_size;
-		break;
-	case FILE_BadClus :
-		lcn = 0; /* not used */
-		lth = vol->nr_clusters + expand->cluster_increment;
-		data_size = lth << vol->cluster_size_bits;
-		break;
-	default :
-		lcn = lth = data_size = 0;
-		res = -1;
+			lth = expand->mft_size >> vol->cluster_size_bits;
+			data_size = expand->mft_size;
+			break;
+		case FILE_BadClus :
+			lcn = 0; /* not used */
+			lth = vol->nr_clusters + expand->cluster_increment;
+			data_size = lth << vol->cluster_size_bits;
+			break;
+		default :
+			lcn = lth = data_size = 0;
+			res = -1;
 	}
 	allocated_size = lth << vol->cluster_size_bits;
 	offset = le16_to_cpu(mrec->attrs_offset);
@@ -4094,20 +4094,20 @@ static runlist_element *rebase_runlists_meta(expand_t *expand, s64 inum)
 		if (a->non_resident) {
 			keeprl = FALSE;
 			rl = ntfs_mapping_pairs_decompress(vol, a,
-						(runlist_element*)NULL);
+					(runlist_element*)NULL);
 			if (rl) {
 				/* rebase the old runlist */
 				for (prl=rl; prl->length; prl++)
 					if (prl->lcn >= 0) {
 						prl->lcn += expand->cluster_increment;
 						if ((a->type != AT_DATA)
-						    && set_bitmap(expand,prl))
+								&& set_bitmap(expand,prl))
 							res = -1;
 					}
 				/* relocated unnamed data (not $BadClus) */
 				if ((a->type == AT_DATA)
-				    && !a->name_length
-				    && (inum != FILE_BadClus)) {
+						&& !a->name_length
+						&& (inum != FILE_BadClus)) {
 					old_rl = rl;
 					rl = new_rl;
 					keeprl = TRUE;
@@ -4127,8 +4127,8 @@ static runlist_element *rebase_runlists_meta(expand_t *expand, s64 inum)
 				}
 				/* expand the named data for $BadClus */
 				if ((a->type == AT_DATA)
-				    && a->name_length
-				    && (inum == FILE_BadClus)) {
+						&& a->name_length
+						&& (inum == FILE_BadClus)) {
 					old_rl = rl;
 					keeprl = TRUE;
 					prl = rl;
@@ -4188,21 +4188,21 @@ static int rebase_inode(expand_t *expand, const runlist_element *prl,
 		pos = (prl->lcn << vol->cluster_size_bits)
 			+ ((inum - jnum) << vol->mft_record_size_bits);
 		if ((ntfs_mst_pread(vol->dev, pos, 1,
-					vol->mft_record_size, mrec) == 1)
-		    && (mrec->flags & MFT_RECORD_IN_USE)) {
+						vol->mft_record_size, mrec) == 1)
+				&& (mrec->flags & MFT_RECORD_IN_USE)) {
 			switch (inum) {
-			case FILE_Bitmap :
-			case FILE_Boot :
-			case FILE_BadClus :
-				rl = rebase_runlists_meta(expand, inum);
-				if (rl)
-					free(rl);
-				else
-					res = -1;
-				break;
-			default :
-			   	res = rebase_runlists(expand, inum);
-				break;
+				case FILE_Bitmap :
+				case FILE_Boot :
+				case FILE_BadClus :
+					rl = rebase_runlists_meta(expand, inum);
+					if (rl)
+						free(rl);
+					else
+						res = -1;
+					break;
+				default :
+					res = rebase_runlists(expand, inum);
+					break;
 			}
 		} else {
 			err_printf("Could not read the $MFT entry %lld\n",
@@ -4210,10 +4210,10 @@ static int rebase_inode(expand_t *expand, const runlist_element *prl,
 			res = -1;
 		}
 	} else {
-			/*
-			 * Replace unused records (possibly uninitialized)
-			 * by minimal valid records, not marked in use
-			 */
+		/*
+		 * Replace unused records (possibly uninitialized)
+		 * by minimal valid records, not marked in use
+		 */
 		res = minimal_record(expand,mrec);
 	}
 	if (!res) {
@@ -4221,11 +4221,11 @@ static int rebase_inode(expand_t *expand, const runlist_element *prl,
 			+ (inum << vol->mft_record_size_bits);
 		if (opt.verbose)
 			ntfs_log_verbose("Rebasing inode %lld cluster 0x%llx\n",
-				(long long)inum,
-				(long long)(pos >> vol->cluster_size_bits));
+					(long long)inum,
+					(long long)(pos >> vol->cluster_size_bits));
 		if (!opt.ro_flag
-		    && (ntfs_mst_pwrite(vol->dev, pos, 1,
-				vol->mft_record_size, mrec) != 1)) {
+				&& (ntfs_mst_pwrite(vol->dev, pos, 1,
+						vol->mft_record_size, mrec) != 1)) {
 			err_printf("Could not write the $MFT entry %lld\n",
 					(long long)inum);
 			res = -1;
@@ -4260,42 +4260,42 @@ static int rebase_all_inodes(expand_t *expand)
 	mrec = expand->mrec;
 	inum = 0;
 	pos = (vol->mft_lcn + expand->cluster_increment)
-				<< vol->cluster_size_bits;
+		<< vol->cluster_size_bits;
 	got = ntfs_mst_pread(vol->dev, pos, 1,
 			vol->mft_record_size, mrec);
 	if ((got == 1) && (mrec->flags & MFT_RECORD_IN_USE)) {
 		pos = expand->mft_lcn << vol->cluster_size_bits;
 		if (opt.verbose)
 			ntfs_log_verbose("Rebasing inode %lld cluster 0x%llx\n",
-				(long long)inum,
-				(long long)(pos >> vol->cluster_size_bits));
+					(long long)inum,
+					(long long)(pos >> vol->cluster_size_bits));
 		mft_rl = rebase_runlists_meta(expand, FILE_MFT);
 		if (!mft_rl
-		    || (!opt.ro_flag
-			&& (ntfs_mst_pwrite(vol->dev, pos, 1,
-				vol->mft_record_size, mrec) != 1)))
+				|| (!opt.ro_flag
+					&& (ntfs_mst_pwrite(vol->dev, pos, 1,
+							vol->mft_record_size, mrec) != 1)))
 			res = -1;
 		else {
 			for (prl=mft_rl; prl->length; prl++) { }
 			inodecnt = (prl->vcn << vol->cluster_size_bits)
 				>> vol->mft_record_size_bits;
 			progress_init(expand->progress, 0, inodecnt, 100,
-				(opt.show_progress ? NTFS_PROGBAR : 0));
+					(opt.show_progress ? NTFS_PROGBAR : 0));
 			prl = mft_rl;
 			jnum = 0;
 			do {
 				inum++;
 				while (prl->length
-				    && ((inum << vol->mft_record_size_bits)
-					>= ((prl->vcn + prl->length)
-						<< vol->cluster_size_bits))) {
+						&& ((inum << vol->mft_record_size_bits)
+							>= ((prl->vcn + prl->length)
+								<< vol->cluster_size_bits))) {
 					prl++;
 					jnum = inum;
 				}
 				progress_update(expand->progress, inum);
 				if (prl->length) {
 					res = rebase_inode(expand,
-						prl,inum,jnum);
+							prl,inum,jnum);
 				}
 			} while (!res && prl->length);
 			free(mft_rl);
@@ -4315,7 +4315,7 @@ static int rebase_all_inodes(expand_t *expand)
  */
 
 static ntfs_volume *get_volume_data(expand_t *expand, struct ntfs_device *dev,
-			s32 sector_size)
+		s32 sector_size)
 {
 	s64 br;
 	ntfs_volume *vol;
@@ -4330,7 +4330,7 @@ static ntfs_volume *get_volume_data(expand_t *expand, struct ntfs_device *dev,
 		expand->vol = vol;
 		vol->dev = dev;
 		br = ntfs_pread(dev, expand->new_sectors*sector_size,
-				 sector_size, expand->bootsector);
+				sector_size, expand->bootsector);
 		if (br != sector_size) {
 			if (br != -1)
 				errno = EINVAL;
@@ -4340,24 +4340,24 @@ static ntfs_volume *get_volume_data(expand_t *expand, struct ntfs_device *dev,
 				err_printf("Error reading the backup bootsector");
 		} else {
 			bs = (NTFS_BOOT_SECTOR*)expand->bootsector;
-		/* alignment problem on Sparc, even doing memcpy() */
+			/* alignment problem on Sparc, even doing memcpy() */
 			sector_size_le = cpu_to_le16(sector_size);
 			if (!memcmp(&sector_size_le,
 						&bs->bpb.bytes_per_sector,2)
-			    && ntfs_boot_sector_is_ntfs(bs)
-			    && !ntfs_boot_sector_parse(vol, bs)) {
+					&& ntfs_boot_sector_is_ntfs(bs)
+					&& !ntfs_boot_sector_parse(vol, bs)) {
 				expand->original_sectors
-				    = sle64_to_cpu(bs->number_of_sectors);
+					= sle64_to_cpu(bs->number_of_sectors);
 				expand->mrec = (MFT_RECORD*)
 					ntfs_malloc(vol->mft_record_size);
 				if (expand->mrec
-				    && can_expand(expand,vol)) {
+						&& can_expand(expand,vol)) {
 					ntfs_log_verbose("Resizing is possible\n");
 					ok = TRUE;
 				}
 			} else
 				err_printf("Could not get the old volume parameters "
-					"from the backup bootsector\n");
+						"from the backup bootsector\n");
 		}
 	}
 
@@ -4381,24 +4381,24 @@ static int really_expand(expand_t *expand)
 
 	expand->bitmap = (u8*)ntfs_calloc(expand->bitmap_allocated);
 	if (expand->bitmap
-	    && get_mft_bitmap(expand)) {
+			&& get_mft_bitmap(expand)) {
 		printf("\n*** WARNING ***\n\n");
 		printf("Expanding a volume is an experimental new feature\n");
 		if (!opt.ro_flag)
 			printf("A first check with option -n is recommended\n");
 		printf("\nShould something go wrong during the actual"
-			 " resizing (power outage, etc.),\n");
+				" resizing (power outage, etc.),\n");
 		printf("just restart the procedure, but DO NOT TRY to repair"
-			" with chkdsk or similar,\n");
+				" with chkdsk or similar,\n");
 		printf("until the resizing is over,"
-			" you would LOSE YOUR DATA !\n");
+				" you would LOSE YOUR DATA !\n");
 		printf("\nYou have been warned !\n\n");
 		if (!opt.ro_flag && (opt.force-- <= 0))
 			proceed_question();
 		if (!rebase_all_inodes(expand)
-		    && !write_bitmap(expand)
-		    && !copy_mftmirr(expand)
-		    && !copy_boot(expand)) {
+				&& !write_bitmap(expand)
+				&& !copy_mftmirr(expand)
+				&& !copy_boot(expand)) {
 			free(expand->vol);
 			expand->vol = (ntfs_volume*)NULL;
 			free(expand->mft_bitmap);
@@ -4413,11 +4413,11 @@ static int really_expand(expand_t *expand)
 					expand->vol = vol;
 					ntfs_log_verbose("Delayed runlist updatings\n");
 					delayed_expand(vol, expand->delayed_runlists,
-						expand->progress);
+							expand->progress);
 					expand->delayed_runlists
 						= (struct DELAYED*)NULL;
 					expand_index_sizes(expand);
-		/* rewriting the backup bootsector, no return ticket now ! */
+					/* rewriting the backup bootsector, no return ticket now ! */
 					res = write_bootsector(expand);
 					if (dev->d_ops->sync(dev) == -1) {
 						printf("Could not sync\n");
@@ -4433,7 +4433,7 @@ static int really_expand(expand_t *expand)
 						expand->delayed_runlists,
 						expand->progress);
 				expand->delayed_runlists
-						= (struct DELAYED*)NULL;
+					= (struct DELAYED*)NULL;
 				printf("\nAll checks have been completed successfully\n");
 				printf("Cannot check further in no-action mode\n");
 			}
@@ -4468,21 +4468,21 @@ static int expand_to_beginning(void)
 	dev = ntfs_device_alloc(opt.volume, 0, &ntfs_device_default_io_ops,
 			NULL);
 	if (dev) {
-	        if (!(*dev->d_ops->open)(dev,
-				(opt.ro_flag ? O_RDONLY : O_RDWR))) {
+		if (!(*dev->d_ops->open)(dev,
+					(opt.ro_flag ? O_RDONLY : O_RDWR))) {
 			sector_size = ntfs_device_sector_size_get(dev);
 			if (sector_size <= 0) {
 				sector_size = 512;
 				new_sectors = ntfs_device_size_get(dev,
-								sector_size);
+						sector_size);
 				if (!new_sectors) {
 					sector_size = 4096;
 					new_sectors = ntfs_device_size_get(dev,
-								sector_size);
+							sector_size);
 				}
 			} else
 				new_sectors = ntfs_device_size_get(dev,
-								sector_size);
+						sector_size);
 			if (new_sectors) {
 				new_sectors--; /* last sector not counted */
 				expand.new_sectors = new_sectors;
@@ -4523,10 +4523,10 @@ int main(int argc, char **argv)
 
 	utils_set_locale();
 
-		/*
-		 * If we're just checking the device, we'll do it first,
-		 * and exit out, no matter what we find.
-		 */
+	/*
+	 * If we're just checking the device, we'll do it first,
+	 * and exit out, no matter what we find.
+	 */
 	if (opt.check) {
 		vol = check_volume();
 #if CLEAN_EXIT
@@ -4555,15 +4555,15 @@ int main(int argc, char **argv)
 	device_size *= vol->sector_size;
 	if (device_size <= 0)
 		err_exit("Couldn't get device size (%lld)!\n",
-			(long long)device_size);
+				(long long)device_size);
 
 	if (!opt.infombonly)
 		print_vol_size("Current device size", device_size);
 
 	if (device_size < vol->nr_clusters * vol->cluster_size)
 		err_exit("Current NTFS volume size is bigger than the device "
-			 "size!\nCorrupt partition table or incorrect device "
-			 "partitioning?\n");
+				"size!\nCorrupt partition table or incorrect device "
+				"partitioning?\n");
 
 	if (!opt.bytes && !opt.info && !opt.infombonly) {
 		opt.bytes = device_size;
@@ -4581,13 +4581,13 @@ int main(int argc, char **argv)
 		print_vol_size("New volume size    ", vol_size(vol, new_size));
 		if (device_size < opt.bytes)
 			err_exit("New size can't be bigger than the device size"
-				 ".\nIf you want to enlarge NTFS then first "
-				 "enlarge the device size by e.g. fdisk.\n");
+					".\nIf you want to enlarge NTFS then first "
+					"enlarge the device size by e.g. fdisk.\n");
 	}
 
 	if (!opt.info && !opt.infombonly && (new_size == vol->nr_clusters ||
-			  (opt.bytes == device_size &&
-			   new_size == vol->nr_clusters - 1))) {
+				(opt.bytes == device_size &&
+				 new_size == vol->nr_clusters - 1))) {
 		printf("Nothing to do: NTFS volume size is already OK.\n");
 		exit(0);
 	}

--- a/src/sd.c
+++ b/src/sd.c
@@ -62,17 +62,17 @@ void init_system_file_sd(int sys_file_no, u8 **sd_val, int *sd_val_len)
 	aa_ace->flags = 0;
 	aa_ace->size = const_cpu_to_le16(0x14);
 	switch (sys_file_no) {
-	case FILE_AttrDef:
-	case FILE_Boot:
-		aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_READ |
-			FILE_READ_ATTRIBUTES | FILE_READ_EA | FILE_READ_DATA;
-		break;
-	default:
-		aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_WRITE |
-			FILE_WRITE_ATTRIBUTES | FILE_READ_ATTRIBUTES |
-			FILE_WRITE_EA | FILE_READ_EA | FILE_APPEND_DATA |
-			FILE_WRITE_DATA | FILE_READ_DATA;
-		break;
+		case FILE_AttrDef:
+		case FILE_Boot:
+			aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_READ |
+				FILE_READ_ATTRIBUTES | FILE_READ_EA | FILE_READ_DATA;
+			break;
+		default:
+			aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_WRITE |
+				FILE_WRITE_ATTRIBUTES | FILE_READ_ATTRIBUTES |
+				FILE_WRITE_EA | FILE_READ_EA | FILE_APPEND_DATA |
+				FILE_WRITE_DATA | FILE_READ_DATA;
+			break;
 	}
 	aa_ace->sid.revision = 1;
 	aa_ace->sid.sub_authority_count = 1;
@@ -84,7 +84,7 @@ void init_system_file_sd(int sys_file_no, u8 **sd_val, int *sd_val_len)
 	/* SECURITY_NT_SID_AUTHORITY (S-1-5) */
 	aa_ace->sid.identifier_authority.value[5] = 5;
 	aa_ace->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
+		const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
 	/*
 	 * Now at offset 0x30 within security descriptor, just after the first
 	 * ACE of the DACL. All system files, except the root directory, have
@@ -98,19 +98,19 @@ void init_system_file_sd(int sys_file_no, u8 **sd_val, int *sd_val_len)
 	aa_ace->size = const_cpu_to_le16(0x18);
 	/* Only $AttrDef and $Boot behave differently to everything else. */
 	switch (sys_file_no) {
-	case FILE_AttrDef:
-	case FILE_Boot:
-		aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_READ |
+		case FILE_AttrDef:
+		case FILE_Boot:
+			aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_READ |
 				FILE_READ_ATTRIBUTES | FILE_READ_EA |
 				FILE_READ_DATA;
-		break;
-	default:
-		aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_READ |
+			break;
+		default:
+			aa_ace->mask = SYNCHRONIZE | STANDARD_RIGHTS_READ |
 				FILE_WRITE_ATTRIBUTES |
 				FILE_READ_ATTRIBUTES | FILE_WRITE_EA |
 				FILE_READ_EA | FILE_APPEND_DATA |
 				FILE_WRITE_DATA | FILE_READ_DATA;
-		break;
+			break;
 	}
 	aa_ace->sid.revision = 1;
 	aa_ace->sid.sub_authority_count = 2;
@@ -123,9 +123,9 @@ void init_system_file_sd(int sys_file_no, u8 **sd_val, int *sd_val_len)
 	aa_ace->sid.identifier_authority.value[5] = 5;
 	sub_authorities = aa_ace->sid.sub_authority;
 	*sub_authorities++ =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	*sub_authorities =
-			const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
+		const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
 	/*
 	 * Now at offset 0x48 into the security descriptor, as specified in the
 	 * security descriptor, we now have the owner SID.
@@ -204,10 +204,10 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->flags = 0;
 	ace->size = const_cpu_to_le16(0x18);
 	ace->mask = STANDARD_RIGHTS_ALL | FILE_WRITE_ATTRIBUTES |
-			 FILE_LIST_DIRECTORY | FILE_WRITE_DATA |
-			 FILE_ADD_SUBDIRECTORY | FILE_READ_EA | FILE_WRITE_EA |
-			 FILE_TRAVERSE | FILE_DELETE_CHILD |
-			 FILE_READ_ATTRIBUTES;
+		FILE_LIST_DIRECTORY | FILE_WRITE_DATA |
+		FILE_ADD_SUBDIRECTORY | FILE_READ_EA | FILE_WRITE_EA |
+		FILE_TRAVERSE | FILE_DELETE_CHILD |
+		FILE_READ_ATTRIBUTES;
 	ace->sid.revision = SID_REVISION;
 	ace->sid.sub_authority_count = 0x02;
 	/* SECURITY_NT_SID_AUTHORITY (S-1-5) */
@@ -219,14 +219,14 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[5] = 5;
 	sub_authorities = ace->sid.sub_authority;
 	*sub_authorities++ =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	*sub_authorities = const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
 
 	//ace2
 	ace = (ACCESS_ALLOWED_ACE*)((u8*)ace + le16_to_cpu(ace->size));
 	ace->type = ACCESS_ALLOWED_ACE_TYPE;
 	ace->flags = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE |
-			INHERIT_ONLY_ACE;
+		INHERIT_ONLY_ACE;
 	ace->size = const_cpu_to_le16(0x18);
 	ace->mask = GENERIC_ALL;
 	ace->sid.revision = SID_REVISION;
@@ -240,7 +240,7 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[5] = 5;
 	sub_authorities = ace->sid.sub_authority;
 	*sub_authorities++ =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	*sub_authorities = const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
 
 	//ace3
@@ -249,10 +249,10 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->flags = 0;
 	ace->size = const_cpu_to_le16(0x14);
 	ace->mask = STANDARD_RIGHTS_ALL | FILE_WRITE_ATTRIBUTES |
-			 FILE_LIST_DIRECTORY | FILE_WRITE_DATA |
-			 FILE_ADD_SUBDIRECTORY | FILE_READ_EA | FILE_WRITE_EA |
-			 FILE_TRAVERSE | FILE_DELETE_CHILD |
-			 FILE_READ_ATTRIBUTES;
+		FILE_LIST_DIRECTORY | FILE_WRITE_DATA |
+		FILE_ADD_SUBDIRECTORY | FILE_READ_EA | FILE_WRITE_EA |
+		FILE_TRAVERSE | FILE_DELETE_CHILD |
+		FILE_READ_ATTRIBUTES;
 	ace->sid.revision = SID_REVISION;
 	ace->sid.sub_authority_count = 0x01;
 	/* SECURITY_NT_SID_AUTHORITY (S-1-5) */
@@ -263,13 +263,13 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[4] = 0;
 	ace->sid.identifier_authority.value[5] = 5;
 	ace->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
+		const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
 
 	//ace4
 	ace = (ACCESS_ALLOWED_ACE*)((u8*)ace + le16_to_cpu(ace->size));
 	ace->type = ACCESS_ALLOWED_ACE_TYPE;
 	ace->flags = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE |
-			INHERIT_ONLY_ACE;
+		INHERIT_ONLY_ACE;
 	ace->size = const_cpu_to_le16(0x14);
 	ace->mask = GENERIC_ALL;
 	ace->sid.revision = SID_REVISION;
@@ -282,7 +282,7 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[4] = 0;
 	ace->sid.identifier_authority.value[5] = 5;
 	ace->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
+		const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
 
 	//ace5
 	ace = (ACCESS_ALLOWED_ACE*)((char*)ace + le16_to_cpu(ace->size));
@@ -290,10 +290,10 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->flags = 0;
 	ace->size = const_cpu_to_le16(0x14);
 	ace->mask = SYNCHRONIZE | READ_CONTROL | DELETE |
-			FILE_WRITE_ATTRIBUTES | FILE_READ_ATTRIBUTES |
-			FILE_TRAVERSE | FILE_WRITE_EA | FILE_READ_EA |
-			FILE_ADD_SUBDIRECTORY | FILE_ADD_FILE |
-			FILE_LIST_DIRECTORY;
+		FILE_WRITE_ATTRIBUTES | FILE_READ_ATTRIBUTES |
+		FILE_TRAVERSE | FILE_WRITE_EA | FILE_READ_EA |
+		FILE_ADD_SUBDIRECTORY | FILE_ADD_FILE |
+		FILE_LIST_DIRECTORY;
 	ace->sid.revision = SID_REVISION;
 	ace->sid.sub_authority_count = 0x01;
 	/* SECURITY_NT_SID_AUTHORITY (S-1-5) */
@@ -304,13 +304,13 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[4] = 0;
 	ace->sid.identifier_authority.value[5] = 5;
 	ace->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_AUTHENTICATED_USER_RID);
+		const_cpu_to_le32(SECURITY_AUTHENTICATED_USER_RID);
 
 	//ace6
 	ace = (ACCESS_ALLOWED_ACE*)((u8*)ace + le16_to_cpu(ace->size));
 	ace->type = ACCESS_ALLOWED_ACE_TYPE;
 	ace->flags = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE |
-			INHERIT_ONLY_ACE;
+		INHERIT_ONLY_ACE;
 	ace->size = const_cpu_to_le16(0x14);
 	ace->mask = GENERIC_READ | GENERIC_WRITE | GENERIC_EXECUTE | DELETE;
 	ace->sid.revision = SID_REVISION;
@@ -323,7 +323,7 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[4] = 0;
 	ace->sid.identifier_authority.value[5] = 5;
 	ace->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_AUTHENTICATED_USER_RID);
+		const_cpu_to_le32(SECURITY_AUTHENTICATED_USER_RID);
 
 	//ace7
 	ace = (ACCESS_ALLOWED_ACE*)((u8*)ace + le16_to_cpu(ace->size));
@@ -331,7 +331,7 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->flags = 0;
 	ace->size = const_cpu_to_le16(0x18);
 	ace->mask = SYNCHRONIZE | READ_CONTROL | FILE_READ_ATTRIBUTES |
-			FILE_TRAVERSE | FILE_READ_EA | FILE_LIST_DIRECTORY;
+		FILE_TRAVERSE | FILE_READ_EA | FILE_LIST_DIRECTORY;
 	ace->sid.revision = SID_REVISION;
 	ace->sid.sub_authority_count = 0x02;
 	/* SECURITY_NT_SID_AUTHORITY (S-1-5) */
@@ -343,14 +343,14 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[5] = 5;
 	sub_authorities = ace->sid.sub_authority;
 	*sub_authorities++ =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	*sub_authorities = const_cpu_to_le32(DOMAIN_ALIAS_RID_USERS);
 
 	//ace8
 	ace = (ACCESS_ALLOWED_ACE*)((u8*)ace + le16_to_cpu(ace->size));
 	ace->type = ACCESS_ALLOWED_ACE_TYPE;
 	ace->flags = OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE |
-			INHERIT_ONLY_ACE;
+		INHERIT_ONLY_ACE;
 	ace->size = const_cpu_to_le16(0x18);
 	ace->mask = GENERIC_READ | GENERIC_EXECUTE;
 	ace->sid.revision = SID_REVISION;
@@ -364,7 +364,7 @@ void init_root_sd(u8 **sd_val, int *sd_val_len)
 	ace->sid.identifier_authority.value[5] = 5;
 	sub_authorities = ace->sid.sub_authority;
 	*sub_authorities++ =
-			const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
+		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	*sub_authorities = const_cpu_to_le32(DOMAIN_ALIAS_RID_USERS);
 
 	//owner sid
@@ -410,9 +410,9 @@ void init_secure_sds(char *sd_val)
 	ACCESS_ALLOWED_ACE *ace;
 	SID *sid;
 
-/*
- * security descriptor #1
- */
+	/*
+	 * security descriptor #1
+	 */
 	//header
 	sds = (SECURITY_DESCRIPTOR_HEADER*)((char*)sd_val);
 	sds->hash = const_cpu_to_le32(0xF80312F0);
@@ -454,7 +454,7 @@ void init_secure_sds(char *sd_val)
 	ace->sid.identifier_authority.value[4] = 0;
 	ace->sid.identifier_authority.value[5] = 5;
 	ace->sid.sub_authority[0] =
-			const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
+		const_cpu_to_le32(SECURITY_LOCAL_SYSTEM_RID);
 	//ace2
 	ace = (ACCESS_ALLOWED_ACE*)((char*)ace + le16_to_cpu(ace->size));
 	ace->type = 0x00;
@@ -505,9 +505,9 @@ void init_secure_sds(char *sd_val)
 		const_cpu_to_le32(SECURITY_BUILTIN_DOMAIN_RID);
 	sid->sub_authority[1] =
 		const_cpu_to_le32(DOMAIN_ALIAS_RID_ADMINS);
-/*
- * security descriptor #2
- */
+	/*
+	 * security descriptor #2
+	 */
 	//header
 	sds = (SECURITY_DESCRIPTOR_HEADER*)((char*)sd_val + 0x80);
 	sds->hash = const_cpu_to_le32(0xB32451);
@@ -517,7 +517,7 @@ void init_secure_sds(char *sd_val)
 
 	//security descriptor relative
 	sd = (SECURITY_DESCRIPTOR_RELATIVE*)((char*)sds +
-		 sizeof(SECURITY_DESCRIPTOR_HEADER));
+			sizeof(SECURITY_DESCRIPTOR_HEADER));
 	sd->revision = 0x01;
 	sd->alignment = 0x00;
 	sd->control = SE_SELF_RELATIVE | SE_DACL_PRESENT;

--- a/src/utils.c
+++ b/src/utils.c
@@ -77,11 +77,11 @@
 
 const char *ntfs_bugs = "Developers' email address: " NTFS_DEV_LIST "\n";
 const char *ntfs_gpl = "This program is free software, released under the GNU "
-	"General Public License\nand you are welcome to redistribute it under "
-	"certain conditions.  It comes with\nABSOLUTELY NO WARRANTY; for "
-	"details read the GNU General Public License to be\nfound in the file "
-	"\"COPYING\" distributed with this program, or online at:\n"
-	"http://www.gnu.org/copyleft/gpl.html\n";
+"General Public License\nand you are welcome to redistribute it under "
+"certain conditions.  It comes with\nABSOLUTELY NO WARRANTY; for "
+"details read the GNU General Public License to be\nfound in the file "
+"\"COPYING\" distributed with this program, or online at:\n"
+"http://www.gnu.org/copyleft/gpl.html\n";
 
 static const char *invalid_ntfs_msg =
 "The device '%s' doesn't have a valid NTFS.\n"
@@ -171,7 +171,7 @@ int ntfs_mbstoucs_libntfscompat(const char *ins,
 				 * because it emulates libntfs's mbstoucs more
 				 * closely. */
 				ntfschar *re_outs = realloc(*outs,
-					sizeof(ntfschar)*(tmpstr_len + 1));
+						sizeof(ntfschar)*(tmpstr_len + 1));
 				if(!re_outs)
 					tmpstr_len = -1;
 				else
@@ -181,7 +181,7 @@ int ntfs_mbstoucs_libntfscompat(const char *ins,
 			if(tmpstr_len >= 0) {
 				/* The extra character is the \0 terminator. */
 				memcpy(*outs, tmpstr,
-					sizeof(ntfschar)*(tmpstr_len + 1));
+						sizeof(ntfschar)*(tmpstr_len + 1));
 			}
 
 			free(tmpstr);
@@ -506,14 +506,14 @@ int utils_inode_get_name(ntfs_inode *inode, char *buffer, int bufsize)
 			}
 
 			if (ntfs_ucstombs(attr->file_name, attr->file_name_length,
-			    &names[i], 0) < 0) {
+						&names[i], 0) < 0) {
 				char *temp;
 				ntfs_log_error("Couldn't translate filename to current locale.\n");
 				temp = ntfs_malloc(30);
 				if (!temp)
 					return 0;
 				snprintf(temp, 30, "<MFT%llu>", (unsigned
-						long long)inode->mft_no);
+							long long)inode->mft_no);
 				names[i] = temp;
 			}
 
@@ -669,7 +669,7 @@ int utils_cluster_in_use(ntfs_volume *vol, long long lcn)
 
 	/* Does lcn lie in the section of $Bitmap we already have cached? */
 	if ((lcn < bmplcn)
-	    || (lcn >= (long long)(bmplcn + (sizeof(buffer) << 3)))) {
+			|| (lcn >= (long long)(bmplcn + (sizeof(buffer) << 3)))) {
 		ntfs_log_debug("Bit lies outside cache.\n");
 		attr = ntfs_attr_open(vol->lcnbmp_ni, AT_DATA, AT_UNNAMED, 0);
 		if (!attr) {
@@ -737,8 +737,8 @@ int check_mftrec_in_use(ntfs_volume *vol, MFT_REF mref, int force)
 
 	/* Does mref lie in the section of $Bitmap we already have cached? */
 	if (force ||
-		((s64)MREF(mref) < bmpmref) ||
-		((s64)MREF(mref) >= (s64)(bmpmref + (sizeof(buffer) << 3)))) {
+			((s64)MREF(mref) < bmpmref) ||
+			((s64)MREF(mref) >= (s64)(bmpmref + (sizeof(buffer) << 3)))) {
 
 		ntfs_log_debug("Bit lies outside cache.\n");
 
@@ -961,7 +961,7 @@ int mft_next_record(struct mft_search_ctx *ctx)
 	}
 
 	nr_mft_records = ctx->vol->mft_na->initialized_size >>
-			ctx->vol->mft_record_size_bits;
+		ctx->vol->mft_record_size_bits;
 
 	for (ctx->mft_num++; (s64)ctx->mft_num < nr_mft_records; ctx->mft_num++) {
 		int in_use;
@@ -986,13 +986,13 @@ int mft_next_record(struct mft_search_ctx *ctx)
 				r = ntfs_file_record_read(ctx->vol, (MFT_REF) ctx->mft_num, &mrec, NULL);
 				if (r || !mrec || !mrec->base_mft_record)
 					ntfs_log_error(
-						"Error reading inode %lld.\n",
-						(long long)ctx->mft_num);
+							"Error reading inode %lld.\n",
+							(long long)ctx->mft_num);
 				else {
 					ntfs_log_debug("Inode %lld is an "
-						"extent of inode %lld.\n",
-						(long long)ctx->mft_num,
-						(long long)MREF(le64_to_cpu(mrec->base_mft_record)));
+							"extent of inode %lld.\n",
+							(long long)ctx->mft_num,
+							(long long)MREF(le64_to_cpu(mrec->base_mft_record)));
 				}
 				free (mrec);
 				continue;
@@ -1064,7 +1064,7 @@ int mft_next_record(struct mft_search_ctx *ctx)
 
 			if (ntfs_attr_pread(mft, ctx->vol->mft_record_size * ctx->mft_num, ctx->vol->mft_record_size, ctx->inode->mrec) < ctx->vol->mft_record_size) {
 				ntfs_log_perror("Couldn't read MFT Record %llu",
-					(unsigned long long) ctx->mft_num);
+						(unsigned long long) ctx->mft_num);
 				// free / close
 				ntfs_attr_close(mft);
 				return -1;
@@ -1112,38 +1112,38 @@ char *ntfs_utils_reformat(char *out, int sz, const char *fmt)
 	state = F_INIT;
 	while (*f && ((i + 3) < sz)) {
 		switch (state) {
-		case F_INIT :
-			if (*f == '%')
-				state = F_PERCENT;
-			*p++ = *f++;
-			i++;
-			break;
-		case F_PERCENT :
-			if (*f == 'l') {
-				state = F_FIRST;
-				f++;
-			} else {
-				if (((*f < '0') || (*f > '9'))
-				    && (*f != '*') && (*f != '-'))
-					state = F_INIT;
+			case F_INIT :
+				if (*f == '%')
+					state = F_PERCENT;
 				*p++ = *f++;
 				i++;
-			}
-			break;
-		case F_FIRST :
-			if (*f == 'l') {
-				*p++ = 'I';
-				*p++ = '6';
-				*p++ = '4';
-				f++;
-				i += 3;
-			} else {
-				*p++ = 'l';
-				*p++ = *f++;
-				i += 2;
-			}
-			state = F_INIT;
-			break;
+				break;
+			case F_PERCENT :
+				if (*f == 'l') {
+					state = F_FIRST;
+					f++;
+				} else {
+					if (((*f < '0') || (*f > '9'))
+							&& (*f != '*') && (*f != '-'))
+						state = F_INIT;
+					*p++ = *f++;
+					i++;
+				}
+				break;
+			case F_FIRST :
+				if (*f == 'l') {
+					*p++ = 'I';
+					*p++ = '6';
+					*p++ = '4';
+					f++;
+					i += 3;
+				} else {
+					*p++ = 'l';
+					*p++ = *f++;
+					i += 2;
+				}
+				state = F_INIT;
+				break;
 		}
 	}
 	*p++ = 0;

--- a/src/utils.h
+++ b/src/utils.h
@@ -125,17 +125,17 @@ int mft_next_record(struct mft_search_ctx *ctx);
 char *ntfs_utils_reformat(char *out, int sz, const char *fmt);
 char *ntfs_utils_unix_path(const char *in);
 #define ntfs_log_redirect(fn,fi,li,le,d,fmt, args...) \
-		do { char _b[MAX_FMT]; ntfs_log_redirect(fn,fi,li,le,d, \
-		ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
+	do { char _b[MAX_FMT]; ntfs_log_redirect(fn,fi,li,le,d, \
+			ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
 #define printf(fmt, args...) \
-		do { char _b[MAX_FMT]; \
+	do { char _b[MAX_FMT]; \
 		printf(ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
 #define fprintf(str, fmt, args...) \
-		do { char _b[MAX_FMT]; \
+	do { char _b[MAX_FMT]; \
 		fprintf(str, ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
 #define vfprintf(file, fmt, args) \
-		do { char _b[MAX_FMT]; vfprintf(file, \
-		ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
+	do { char _b[MAX_FMT]; vfprintf(file, \
+			ntfs_utils_reformat(_b,MAX_FMT,fmt), args); } while (0)
 #endif	/* HAVE_WINDOWS_H */
 
 /**


### PR DESCRIPTION
Normalize code indentation to improve code readability and maintain format style for all files in libntfs/, include/, src/ excluding src/deprecated.