### PR TITLE
ntfsprogs-plus: fix build warning variable 'n' set but not used

### DIFF
--- a/libntfs/attrib.c
+++ b/libntfs/attrib.c
@@ -1599,7 +1599,6 @@ static int split_compressed_hole(ntfs_attr *na, runlist_element **prl,
 			 */
 		if (endblock < rl[0].length) {
 			runlist_element *xrl;
-			int n;
 
 			/*
 			 * we have to split into three parts if the run
@@ -1613,10 +1612,8 @@ ntfs_log_error("No free run, case 1\n");
 				}
 				na->unused_runs -= 2;
 				xrl = rl;
-				n = 0;
 				while (xrl->length) {
 					xrl++;
-					n++;
 				}
 				do {
 					xrl[2] = *xrl;
@@ -1642,10 +1639,8 @@ ntfs_log_error("No free run, case 2\n");
 				}
 				na->unused_runs--;
 				xrl = rl;
-				n = 0;
 				while (xrl->length) {
 					xrl++;
-					n++;
 				}
 				do {
 					xrl[1] = *xrl;
@@ -1670,7 +1665,6 @@ ntfs_log_error("No free run, case 2\n");
 		} else {
 			if (rl[1].length) {
 				runlist_element *xrl;
-				int n;
 
 				/*
 				 * split into two parts and use the
@@ -1681,10 +1675,8 @@ ntfs_log_error("No free run, case 4\n");
 				}
 				na->unused_runs--;
 				xrl = rl;
-				n = 0;
 				while (xrl->length) {
 					xrl++;
-					n++;
 				}
 				do {
 					xrl[1] = *xrl;


### PR DESCRIPTION
Fixes:
../../libntfs/attrib.c:1602:29: warning: variable 'n' set but not used [-Wunused-but-set-variable=]
../../libntfs/attrib.c:1673:37: warning: variable 'n' set but not used [-Wunused-but-set-variable=]