### PR TITLE
ntfsprogs-plus: fix build warning variable 'col' set but not used

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -856,7 +856,8 @@ void progress_update(struct progress_bar *p, u64 current)
  */
 void utils_dump_mem(void *buf, int start, int length, int flags)
 {
-	int off, i, s, e, col;
+	int off, i, s, e;
+	int __attribute__((unused)) col;
 	u8 *mem = buf;
 
 	s =  start                & ~15;	// round down


### PR DESCRIPTION
Fixes:
```c
../../src/utils.c: In function 'utils_dump_mem':
../../src/utils.c:859:27: warning: variable 'col' set but not used [-Wunused-but-set-variable=]
  859 |         int off, i, s, e, col;
      |                           ^~~
``` 