### PR TITLE
mkntfs: add foreign filesystem detection using libblkid

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,18 @@ if test "$enable_crypto" != "no"; then
 fi
 AM_CONDITIONAL(ENABLE_CRYPTO, $compile_crypto)
 
+# Check for libblkid (for foreign filesystem detection in mkntfs)
+PKG_CHECK_MODULES([BLKID], [blkid >= 2.20],
+    [
+        AC_DEFINE([HAVE_LIBBLKID], [1], [Define to 1 if you have libblkid])
+        AC_SUBST([BLKID_CFLAGS])
+        AC_SUBST([BLKID_LIBS])
+    ],
+    [
+        AC_MSG_WARN([libblkid not found or too old → foreign FS detection will be disabled in mkntfs])
+    ]
+)
+
 # add --with-extra-includes and --with-extra-libs switch to ./configure
 all_libraries="$all_libraries $USER_LDFLAGS"
 all_includes="$all_includes $USER_INCLUDES"

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -28,7 +28,7 @@ AM_CPPFLAGS		= -I$(top_srcdir)/include $(all_includes)
 
 mkntfs_CPPFLAGS		= $(AM_CPPFLAGS) $(MKNTFS_CPPFLAGS)
 mkntfs_SOURCES		= attrdef.c attrdef.h sd.c sd.h mkntfs.c utils.c utils.h
-mkntfs_LDADD		= $(AM_LIBS) $(MKNTFS_LIBS)
+mkntfs_LDADD		= $(AM_LIBS) $(MKNTFS_LIBS) $(BLKID_LIBS)
 mkntfs_LDFLAGS		= $(AM_LFLAGS)
 
 ntfslabel_SOURCES	= ntfslabel.c utils.c utils.h


### PR DESCRIPTION
Currently mkntfs overwrites any existing filesystem without checking, which causes xfstests generic/740 to fail when trying to mkfs.ntfs over other filesystems (btrfs, ext4, exfat, etc.).

This patch adds basic detection of existing filesystems using libblkid:
- Probes the device for known superblocks
- If a non-NTFS filesystem is detected, refuse to format unless -F (force) is specified
- Improves safety and aligns mkntfs behavior with other modern mkfs tools (mkfs.xfs, mkfs.ext4, etc.)

Detection is skipped if libblkid is not available at build time.