### PR TITLE
Update to return a pointer to a const-qualified type to fix warning

### DIFF
--- a/include/mft.h
+++ b/include/mft.h
@@ -61,7 +61,7 @@ static __inline__ int ntfs_mft_record_read(const ntfs_volume *vol,
 extern int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
 		MFT_RECORD *m);
 
-extern int ntfs_file_record_read(const ntfs_volume *vol, const MFT_REF mref,
+extern int ntfs_file_record_read(ntfs_volume *vol, const MFT_REF mref,
 		MFT_RECORD **mrec, ATTR_RECORD **attr);
 
 extern int ntfs_mft_records_write(const ntfs_volume *vol, const MFT_REF mref,

--- a/libntfs/mft.c
+++ b/libntfs/mft.c
@@ -431,7 +431,7 @@ err_out:
  * Note: We do not check if the mft record is flagged in use. The caller can
  *	 check if desired.
  */
-int ntfs_file_record_read(const ntfs_volume *vol, const MFT_REF mref,
+int ntfs_file_record_read(ntfs_volume *vol, const MFT_REF mref,
 		MFT_RECORD **mrec, ATTR_RECORD **attr)
 {
 	MFT_RECORD *m;

--- a/src/utils.c
+++ b/src/utils.c
@@ -405,7 +405,7 @@ int utils_parse_size(const char *value, s64 *size, BOOL scale)
 int utils_parse_range(const char *string, s64 *start, s64 *finish, BOOL scale)
 {
 	s64 a, b;
-	char *middle;
+	const char *middle;
 
 	if (!string || !start || !finish) {
 		errno = EINVAL;


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

fixes:
```c
../../src/utils.c: In function 'utils_parse_range': ../../src/utils.c:415:16: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  415 |         middle = strchr(string, '-');
      |                ^
```

Does not fix:
```c
../../libntfs/mft.c: In function 'ntfs_file_record_read':
../../libntfs/mft.c:464:35: warning: passing argument 1 of 'ntfs_mft_record_check' discards 'const' qualifier from pointer target t
ype [-Wdiscarded-qualifiers]
  464 |         if (ntfs_mft_record_check(vol, mref, m))
      |                                   ^~~
../../libntfs/mft.c:236:40: note: expected 'ntfs_volume *' {aka 'struct _ntfs_volume *'} but argument is of type 'const ntfs_volume
 *' {aka 'const struct _ntfs_volume *'}
  236 | int ntfs_mft_record_check(ntfs_volume *vol, const MFT_REF mref,
      |                           ~~~~~~~~~~~~~^~~
``` 

For the above remaining warning (and error as a const is being edited) the correct fix is to declare `vol` as `const` for both `ntfs_attr_inconsistent` and `ntfs_mft_record_check`. But this can’t be done in the current code path.

