### PR TITLE
Revert "ntfsprogs-plus: add mkfs.ntfsplus symlink for xfstests"

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -69,8 +69,6 @@ install-exec-hook:
 	$(INSTALL) -d $(DESTDIR)/$(sbindir)
 	$(LN_S) -f $(sbindir)/mkntfs $(DESTDIR)$(sbindir)/mkfs.ntfs
 	$(LN_S) -f $(sbindir)/ntfsck $(DESTDIR)$(sbindir)/fsck.ntfs
-	$(LN_S) -f $(sbindir)/mkntfs $(DESTDIR)$(sbindir)/mkfs.ntfsplus
-	$(LN_S) -f $(sbindir)/ntfsck $(DESTDIR)$(sbindir)/fsck.ntfsplus
 
 install-data-hook:
 	$(INSTALL) -d $(DESTDIR)$(man8dir)


### PR DESCRIPTION
This reverts commit 9b00baf60ad86739044a4447d6af81141a352068.

kernel now uses ntfs, not ntfsplus