### PR TITLE
libntfs: fixes -Waddress-of-packed-member

### DIFF
--- a/libntfs/collate.c
+++ b/libntfs/collate.c
@@ -221,17 +221,25 @@ static int ntfs_collate_file_name(ntfs_volume *vol,
 {
 	const FILE_NAME_ATTR *file_name_attr1;
 	const FILE_NAME_ATTR *file_name_attr2;
+	ntfschar fn1[NTFS_MAX_NAME_LEN];
+	ntfschar fn2[NTFS_MAX_NAME_LEN];
 	int rc;
 
 	ntfs_log_trace("Entering.\n");
+
 	file_name_attr1 = (const FILE_NAME_ATTR*)data1;
 	file_name_attr2 = (const FILE_NAME_ATTR*)data2;
+
+	memcpy(fn1, file_name_attr1->file_name,
+	       file_name_attr1->file_name_length * sizeof(ntfschar));
+	memcpy(fn2, file_name_attr2->file_name,
+	       file_name_attr2->file_name_length * sizeof(ntfschar));
+
 	rc = ntfs_names_full_collate(
-			(ntfschar*)&file_name_attr1->file_name,
-			file_name_attr1->file_name_length,
-			(ntfschar*)&file_name_attr2->file_name,
-			file_name_attr2->file_name_length,
+			fn1, file_name_attr1->file_name_length,
+			fn2, file_name_attr2->file_name_length,
 			CASE_SENSITIVE, vol->upcase, vol->upcase_len);
+
 	ntfs_log_trace("Done, returning %i.\n", rc);
 	return rc;
 }

--- a/libntfs/dir.c
+++ b/libntfs/dir.c
@@ -245,6 +245,7 @@ INDEX_ENTRY * __ntfs_inode_lookup_by_name(ntfs_inode *dir_ni,
 	int eo, rc;
 	u32 index_block_size;
 	u8 index_vcn_size_bits;
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
 
 	ntfs_log_trace("Entering\n");
 
@@ -317,8 +318,10 @@ INDEX_ENTRY * __ntfs_inode_lookup_by_name(ntfs_inode *dir_ni,
 		 * Not a perfect match, need to do full blown collation so we
 		 * know which way in the B+tree we have to go.
 		 */
+		memcpy(fn_name, ie->key.file_name.file_name,
+		       ie->key.file_name.file_name_length * sizeof(ntfschar));
 		rc = ntfs_names_full_collate(uname, uname_len,
-				(ntfschar*)&ie->key.file_name.file_name,
+				fn_name,
 				ie->key.file_name.file_name_length,
 				case_sensitivity, vol->upcase, vol->upcase_len);
 		/*
@@ -437,8 +440,10 @@ descend_into_child_node:
 		 * Not a perfect match, need to do full blown collation so we
 		 * know which way in the B+tree we have to go.
 		 */
+		memcpy(fn_name, ie->key.file_name.file_name,
+		       ie->key.file_name.file_name_length * sizeof(ntfschar));
 		rc = ntfs_names_full_collate(uname, uname_len,
-				(ntfschar*)&ie->key.file_name.file_name,
+				fn_name,
 				ie->key.file_name.file_name_length,
 				case_sensitivity, vol->upcase, vol->upcase_len);
 		/*
@@ -996,6 +1001,7 @@ static int ntfs_filldir(ntfs_inode *dir_ni, s64 *pos, u8 ivcn_bits,
 	FILE_NAME_ATTR *fn = &ie->key.file_name;
 	unsigned dt_type;
 	BOOL metadata;
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
 	ntfschar *loname;
 	int res;
 	MFT_REF mref;
@@ -1031,7 +1037,9 @@ static int ntfs_filldir(ntfs_inode *dir_ni, s64 *pos, u8 ivcn_bits,
 			|| (NVolShowSysFiles(dir_ni->vol) && (NVolShowHidFiles(dir_ni->vol)
 					|| metadata))) {
 		if (NVolCaseSensitive(dir_ni->vol)) {
-			res = filldir(dirent, fn->file_name,
+			memcpy(fn_name, fn->file_name,
+			       fn->file_name_length * sizeof(ntfschar));
+			res = filldir(dirent, fn_name,
 					fn->file_name_length,
 					fn->file_name_type, *pos,
 					mref, dt_type);
@@ -1945,6 +1953,7 @@ int ntfs_delete(ntfs_volume *vol, const char *pathname,
 	BOOL looking_for_dos_name = FALSE, looking_for_win32_name = FALSE;
 	BOOL case_sensitive_match = TRUE;
 	int err = 0;
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
 #if CACHE_NIDATA_SIZE
 	int i;
 #endif
@@ -2022,7 +2031,9 @@ search:
 					&& NVolCaseSensitive(ni->vol)))
 			case_sensitive = CASE_SENSITIVE;
 
-		if (ntfs_names_are_equal(fn->file_name, fn->file_name_length,
+		memcpy(fn_name, fn->file_name,
+		       fn->file_name_length * sizeof(ntfschar));
+		if (ntfs_names_are_equal(fn_name, fn->file_name_length,
 					name, name_len, case_sensitive,
 					ni->vol->upcase, ni->vol->upcase_len)){
 

--- a/libntfs/index.c
+++ b/libntfs/index.c
@@ -284,9 +284,11 @@ static INDEX_ENTRY *ntfs_ie_prev(INDEX_HEADER *ih, INDEX_ENTRY *ie)
 char *ntfs_ie_filename_get(INDEX_ENTRY *ie)
 {
 	FILE_NAME_ATTR *fn;
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
 
 	fn = (FILE_NAME_ATTR *)&ie->key;
-	return ntfs_attr_name_get(fn->file_name, fn->file_name_length);
+	memcpy(fn_name, fn->file_name, fn->file_name_length * sizeof(ntfschar));
+	return ntfs_attr_name_get(fn_name, fn->file_name_length);
 }
 
 void ntfs_ie_filename_dump(INDEX_ENTRY *ie)

--- a/libntfs/inode.c
+++ b/libntfs/inode.c
@@ -1320,7 +1320,10 @@ rollback:
 	ale = (ATTR_LIST_ENTRY*)al;
 	while ((u8*)ale < al + al_len) {
 		if (MREF_LE(ale->mft_reference) != ni->mft_no) {
-			if (!ntfs_attr_lookup(ale->type, ale->name,
+			ntfschar ale_name[NTFS_MAX_NAME_LEN];
+			memcpy(ale_name, ale->name,
+			       ale->name_length * sizeof(ntfschar));
+			if (!ntfs_attr_lookup(ale->type, ale_name,
 						ale->name_length,
 						CASE_SENSITIVE,
 						sle64_to_cpu(ale->lowest_vcn),

--- a/libntfs/reparse.c
+++ b/libntfs/reparse.c
@@ -180,14 +180,22 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
 		else
 			entry = icx->entry;
 		if (entry) {
+			ntfschar fn1[NTFS_MAX_NAME_LEN];
+			ntfschar fn2[NTFS_MAX_NAME_LEN];
+
 			found = &entry->key.file_name;
-			if (lkup
-					&& ntfs_names_are_equal(find.attr.file_name,
-						find.attr.file_name_length,
-						found->file_name, found->file_name_length,
+			if (lkup) {
+				memcpy(fn1, find.attr.file_name,
+				       find.attr.file_name_length * sizeof(ntfschar));
+				memcpy(fn1, found->file_name,
+				       found->file_name_length * sizeof(ntfschar));
+				if(ntfs_names_are_equal(
+						fn1, find.attr.file_name_length,
+						fn2, found->file_name_length,
 						IGNORE_CASE,
 						vol->upcase, vol->upcase_len))
-				lkup = 0;
+					lkup = 0;
+			}
 			if (!lkup) {
 				/*
 				 * name found :

--- a/libntfs/unistr.c
+++ b/libntfs/unistr.c
@@ -429,8 +429,14 @@ void ntfs_name_locase(ntfschar *name, u32 name_len, const ntfschar *locase,
 void ntfs_file_value_upcase(FILE_NAME_ATTR *file_name_attr,
 		const ntfschar *upcase, const u32 upcase_len)
 {
-	ntfs_name_upcase((ntfschar*)&file_name_attr->file_name,
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
+
+	memcpy(fn_name, file_name_attr->file_name,
+	       file_name_attr->file_name_length * sizeof(ntfschar));
+	ntfs_name_upcase(fn_name,
 			file_name_attr->file_name_length, upcase, upcase_len);
+	memcpy(file_name_attr->file_name, fn_name,
+	       file_name_attr->file_name_length * sizeof(ntfschar));
 }
 
 /*

--- a/libntfs/volume.c
+++ b/libntfs/volume.c
@@ -266,6 +266,7 @@ static int ntfs_mft_load(ntfs_volume *vol)
 	int eo;
 	char *filename;
 	FILE_NAME_ATTR *fn;
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
 
 	/* Manually setup an ntfs_inode. */
 	vol->mft_ni = ntfs_inode_allocate(vol);
@@ -435,7 +436,9 @@ mft_has_no_attr_list:
 	/* Check if filename is "$MFT" */
 	fn = (FILE_NAME_ATTR *)((u8 *)ctx->attr +
 			le16_to_cpu(ctx->attr->value_offset));
-	filename = ntfs_attr_name_get(fn->file_name, fn->file_name_length);
+	memcpy(fn_name, fn->file_name,
+               fn->file_name_length * sizeof(ntfschar));
+	filename = ntfs_attr_name_get(fn_name, fn->file_name_length);
 	if (!filename || strcmp(filename, "$MFT")) {
 		ntfs_log_error("filename of $MFT record is not '$MFT'(%s)\n",
 				filename);
@@ -499,6 +502,7 @@ static int ntfs_mftmirr_load(ntfs_volume *vol)
 	char *filename = NULL;
 	FILE_NAME_ATTR *fn;
 	ntfs_attr_search_ctx *ctx = NULL;
+	ntfschar fn_name[NTFS_MAX_NAME_LEN];
 
 	vol->mftmirr_ni = ntfs_inode_open(vol, FILE_MFTMirr);
 	if (!vol->mftmirr_ni) {
@@ -542,7 +546,9 @@ static int ntfs_mftmirr_load(ntfs_volume *vol)
 	/* Check if filename is "$MFTMirr" */
 	fn = (FILE_NAME_ATTR *)((u8 *)ctx->attr +
 			le16_to_cpu(ctx->attr->value_offset));
-	filename = ntfs_attr_name_get(fn->file_name, fn->file_name_length);
+	memcpy(fn_name, fn->file_name,
+               fn->file_name_length * sizeof(ntfschar));
+	filename = ntfs_attr_name_get(fn_name, fn->file_name_length);
 	if (!filename || strcmp(filename, "$MFTMirr")) {
 		ntfs_log_error("filename of $MFT record is not '$MFTMirr'(%s)\n",
 				filename);


### PR DESCRIPTION
libntfs: fixes -Waddress-of-packed-member

Fixes:
`warning: taking address of packed member of 'struct <anonymous>' may result in an unaligned pointer value [-Waddress-of-packed-member]`