### PR TITLE
ntfsinfo: fix stringop-overread warning

### DIFF
--- a/src/ntfsinfo.c
+++ b/src/ntfsinfo.c
@@ -2166,8 +2166,7 @@ static void ntfs_dump_attr_ea(ATTR_RECORD *attr, ntfs_volume *vol)
 		printf("\tName:\t\t '%s'\n", ea->name);
 		printf("\tValue:\t\t ");
 		if (ea->name_length == 11 &&
-				!strncmp((const char*)"SETFILEBITS",
-					(const char*)ea->name, 11)) {
+				!memcmp("SETFILEBITS", ea->name, 11)) {
 			pval = (const le32*)(ea->value + ea->name_length + 1);
 			printf("0%lo\n", (unsigned long)le32_to_cpu(*pval));
 		} else {


### PR DESCRIPTION
As ea->name is a raw byte array, not a null-terminated string, use memcmp instead of strncmp.

Fixes:
```
    In function 'ntfs_dump_attr_ea',
        inlined from 'ntfs_dump_file_attributes' at ../../src/ntfsinfo.c:2431:5,
        inlined from 'main' at ../../src/ntfsinfo.c:2547:4:
    ../../src/ntfsinfo.c:2169:34: warning: 'strncmp' specified bound 11 exceeds source size 0 [-Wstringop-overread]
     2169 |                                 !strncmp((const char*)"SETFILEBITS",
          |                                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     2170 |                                         (const char*)ea->name, 11)) {
          |                                         ~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from ../../include/inode.h:32,
                     from ../../include/volume.h:51,
                     from ../../include/mft.h:27,
                     from ../../src/ntfsinfo.c:71:
    ../../include/layout.h: In function 'main':
    ../../include/layout.h:2532:12: note: source object allocated here
     2532 |         u8 name[0];             /* Name of the EA. */
          |            ^~~~
```