### PR TITLE
libntfs: fix -Wzero-length-bounds warnings for zero-length array accesses

### DIFF
--- a/libntfs/ea.c
+++ b/libntfs/ea.c
@@ -262,6 +262,7 @@ int ntfs_set_ntfs_ea(ntfs_inode *ni, const char *value, size_t size, int flags)
 		nextoffs = 0;
 		while (ok && (offs < size)) {
 			p_ea = (const EA_ATTR*)&value[offs];
+			const u8 *name = (const u8 *)p_ea + offsetof(EA_ATTR, name);
 			nextoffs = offs + le32_to_cpu(p_ea->next_entry_offset);
 			/* null offset to next not allowed */
 			ok = (nextoffs > offs)
@@ -277,7 +278,7 @@ int ntfs_set_ntfs_ea(ntfs_inode *ni, const char *value, size_t size, int flags)
 							+ p_ea->name_length + 1
 							+ le16_to_cpu(p_ea->value_length))
 						>= (nextoffs - 3))
-				&& !p_ea->name[p_ea->name_length];
+				&& !name[p_ea->name_length];
 			/* name not checked, as chkdsk accepts any chars */
 			if (ok) {
 				if (p_ea->flags & NEED_EA)
@@ -460,9 +461,9 @@ int ntfs_ea_check_wsldev(ntfs_inode *ni, dev_t *rdevp)
 				offset += next;
 		} while (!found && (next > 0) && (offset < lth));
 		if (found) {
+			const u8 *name = (const u8 *)p_ea + offsetof(EA_ATTR, name);
 			/* beware of alignment */
-			memcpy(&device, &p_ea->name[p_ea->name_length + 1],
-					sizeof(device));
+			memcpy(&device, name + p_ea->name_length + 1, sizeof(device));
 			*rdevp = makedev(le32_to_cpu(device.major),
 					le32_to_cpu(device.minor));
 			res = 0;

--- a/libntfs/reparse.c
+++ b/libntfs/reparse.c
@@ -145,6 +145,7 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
 		FILE_NAME_ATTR attr;
 		ntfschar file_name[NTFS_MAX_NAME_LEN + 1];
 	} find;
+	ntfschar *fn = (ntfschar *)((u8 *)&find.attr + offsetof(FILE_NAME_ATTR, file_name));
 
 	mref = (u64)-1; /* default return (not found) */
 	icx = ntfs_index_ctx_get(dir_ni, NTFS_INDEX_I30, 4);
@@ -162,9 +163,9 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
 			 */
 			if ((cpuchar < vol->upcase_len)
 					&& (le16_to_cpu(vol->upcase[cpuchar]) < cpuchar))
-				find.attr.file_name[i] = vol->upcase[cpuchar];
+				fn[i] = vol->upcase[cpuchar];
 			else
-				find.attr.file_name[i] = uname[i];
+				fn[i] = uname[i];
 		}
 		olderrno = errno;
 		lkup = ntfs_index_lookup((char*)&find, uname_len, icx);
@@ -182,7 +183,7 @@ static u64 ntfs_fix_file_name(ntfs_inode *dir_ni, ntfschar *uname,
 		if (entry) {
 			found = &entry->key.file_name;
 			if (lkup
-					&& ntfs_names_are_equal(find.attr.file_name,
+					&& ntfs_names_are_equal(fn,
 						find.attr.file_name_length,
 						found->file_name, found->file_name_length,
 						IGNORE_CASE,


### PR DESCRIPTION
Replace direct indexing and pointer arithmetic on zero-length array members (name[0], file_name[0]) with a local u8 pointer computed via offsetof(), silencing -Wzero-length-bounds warnings in:

  - libntfs/ea.c: ntfs_set_ntfs_ea(), ntfs_ea_check_wsldev()
  - libntfs/reparse.c: ntfs_fix_file_name()

Fixes:
```
    In function 'ntfs_set_ntfs_ea',
        inlined from 'ntfs_set_ntfs_ea' at ../../libntfs/ea.c:242:5:
    ../../libntfs/ea.c:280:47: warning: array subscript 255 is outside the bounds of an interior zero-length array 'const u8[0]' {aka 'const unsigned char[]'} [-Wzero-length-bounds]
      280 |                                 && !p_ea->name[p_ea->name_length];
          |                                     ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~
    In file included from ../../libntfs/ea.c:55:
    ../../include/layout.h: In function 'ntfs_set_ntfs_ea':
    ../../include/layout.h:2532:12: note: while referencing 'name'
     2532 |         u8 name[0];             /* Name of the EA. */
          |            ^~~~
    ../../libntfs/ea.c: In function 'ntfs_ea_check_wsldev':
    ../../libntfs/ea.c:464:41: warning: array subscript 256 is outside the bounds of an interior zero-length array 'const u8[0]' {aka 'const unsigned char[]'} [-Wzero-length-bounds]
      464 |                         memcpy(&device, &p_ea->name[p_ea->name_length + 1],
          |                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    ../../include/layout.h:2532:12: note: while referencing 'name'
     2532 |         u8 name[0];             /* Name of the EA. */
          |            ^~~~

    ../../libntfs/reparse.c: In function 'ntfs_fix_file_name':
    ../../libntfs/reparse.c:165:52: warning: array subscript 254 is outside the bounds of an interior zero-length array 'ntfschar[0]' {aka 'short unsigned int[]'} [-Wzero-length-bounds]
      165 |                                 find.attr.file_name[i] = vol->upcase[cpuchar];
          |                                 ~~~~~~~~~~~~~~~~~~~^~~
    In file included from ../../libntfs/reparse.c:50:
    ../../include/layout.h:1141:18: note: while referencing 'file_name'
     1141 |         ntfschar file_name[0];                  /* (0x42) File name in Unicode. */
          |                  ^~~~~~~~~
    ../../libntfs/reparse.c:167:52: warning: array subscript 254 is outside the bounds of an interior zero-length array 'ntfschar[0]' {aka 'short unsigned int[]'} [-Wzero-length-bounds]
      167 |                                 find.attr.file_name[i] = uname[i];
          |                                 ~~~~~~~~~~~~~~~~~~~^~~
    ../../include/layout.h:1141:18: note: while referencing 'file_name'
     1141 |         ntfschar file_name[0];                  /* (0x42) File name in Unicode. */
          |                  ^~~~~~~~~
```