### PR TITLE
libntfs/index.c: silence -Wunused-result for ntfs_index_lookup in ntfs_ih_takeout

### DIFF
--- a/libntfs/index.c
+++ b/libntfs/index.c
@@ -1883,7 +1883,8 @@ static int ntfs_ih_takeout(ntfs_index_context *icx, INDEX_HEADER *ih,
 
 	if (le16_to_cpu(ie_dup->key_length) > 0) {
 		ntfs_index_ctx_reinit(icx);
-		ntfs_index_lookup(&ie_dup->key, le16_to_cpu(ie_dup->key_length), icx);
+		__attribute__((unused)) int dummy =
+			ntfs_index_lookup(&ie_dup->key, le16_to_cpu(ie_dup->key_length), icx);
 	}
 out:
 	free(ie_roam);


### PR DESCRIPTION
The ntfs_index_lookup() call after ntfs_index_ctx_reinit() is used to reposition icx after a successful operation. A lookup failure at this point does not affect the return value since the operation has already completed.

Assign the return value to an __attribute__((unused)) dummy variable to explicitly document the intentional discard and silence the -Wunused-result warning.

Fixes:
    ../../libntfs/index.c: In function 'ntfs_ih_takeout':
    ../../libntfs/index.c:1886:17: warning: ignoring return value of 'ntfs_index_lookup' declared with attribute 'warn_unused_result' [-Wunused-result]
     1886 |                 ntfs_index_lookup(&ie_dup->key, le16_to_cpu(ie_dup->key_length), icx);
          |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~