### PR TITLE
Avoid creating 'lost+found' folder when no orphan files are found

### DIFF
--- a/src/ntfsck.c
+++ b/src/ntfsck.c
@@ -4439,7 +4439,7 @@ static int ntfsck_check_orphaned_mft(ntfs_volume *vol)
 	progress_init(&prog, 0, orphan_cnt + 1, 1000, pb_flags);
 
 	/* check lost found directory */
-	if (!vol->lost_found) {
+	if (!vol->lost_found && orphan_cnt > 0) {
 		root_ni = ntfsck_open_inode(vol, FILE_root);
 		if (!root_ni) {
 			ntfs_log_error("Failed to open root inode\n");


### PR DESCRIPTION
Before this PR the folder lost+found was always being created regardless if orphan files were found, which was annoying.