### PR TITLE
fix build-depends, note debian experimental has it packaged

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ you should install them.
 
 For ubuntu or debian
 ```
-sudo apt install build-essential automake autoconf libtool pkgconf uuid-dev
-sudo apt install libgcrypt20-dev libasan8
+sudo apt install build-essential automake autoconf libtool pkgconf uuid-dev libgcrypt20-dev
+sudo apt install libasan8 # only install when on x86/arm architecture
 ```
 On Debian you can also just `apt install ntfsprogs-plus` with experimental.
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,13 @@ You should have GNU Build system (autoconf, automake, libtool)
 and some libraries to build ntfsprogs-plus. If you don't have them,
 you should install them.
 
-For ubuntu
+For ubuntu or debian
 ```
-sudo apt install build-essential automake autoconf libtool
+sudo apt install build-essential automake autoconf libtool pkgconf uuid-dev
 sudo apt install libgcrypt20-dev libasan8
 ```
+On Debian you can also just `apt install ntfsprogs-plus` with experimental.
+
 For redhat
 ```
 yum install automake autoconf libtool


### PR DESCRIPTION
would it be good to also mention, linux kernel 7.1 or later is needed, with

```
CONFIG_NTFS_FS=m
CONFIG_NTFS_RW=m
```

for the architectures alpha,hppa,m68k,sh4 there's no libasan8, could it work without on those?

https://buildd.debian.org/status/package.php?p=ntfsprogs-plus&suite=sid

